### PR TITLE
feat(external-secrets): enable HA for 1Password Connect with 3 replicas

### DIFF
--- a/kubernetes/apps/external-secrets/1password-connect/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/1password-connect/app/helmrelease.yaml
@@ -72,12 +72,10 @@ spec:
     operator:
       create: false
 
-    replicaCount: 1
+    replicaCount: 3
 
     persistence:
-      enabled: true
-      storageClassName: ceph-block
-      size: 10Gi
+      enabled: false
 
     resources:
       limits:
@@ -93,3 +91,16 @@ spec:
 
     podAnnotations:
       secret.reloader.stakater.com/reload: "onepassword-connect"
+
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - connect
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

- Configure 1Password Connect for High Availability with 3 replicas
- Disable persistent storage (using emptyDir for stateless operation)
- Add pod anti-affinity to distribute replicas across different nodes

## Changes

**HelmRelease Updates**:
- Increased replicaCount from 1 to 3
- Disabled persistence (stateless HA design)
- Added pod anti-affinity with preferred scheduling to spread pods across nodes

## Benefits

- **High Availability**: 3 replicas provide redundancy against pod/node failures
- **Improved Security**: Stateless operation with no persistent disk storage
- **Better Resilience**: Pod anti-affinity ensures distribution across nodes
- **Production Ready**: Follows 1Password Connect best practices for HA deployments

## Test Plan

After merge:
- [ ] Verify 3 pods are running
- [ ] Confirm pods are distributed across different nodes
- [ ] Test ClusterSecretStore remains Ready
- [ ] Validate ExternalSecrets continue to sync during pod disruption
