### PR TITLE
feat(secrets): Migrate Cloudflare secrets from SOPS to 1Password ExternalSecrets

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cert-manager-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cert-manager-secret
+    creationPolicy: Owner
+  refreshInterval: 5m
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: cloudflare_certmanager_token
+        property: api-token

--- a/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - ./clusterissuer.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./secret.sops.yaml
+  # Migrated to 1Password via ExternalSecrets
+  # - ./secret.sops.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/network/cloudflare-dns/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-dns-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-dns-secret
+    creationPolicy: Owner
+  refreshInterval: 5m
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: cloudflare_dns_token
+        property: api-token

--- a/kubernetes/apps/network/cloudflare-dns/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./secret.sops.yaml
+  # Migrated to 1Password via ExternalSecrets
+  # - ./secret.sops.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-tunnel-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-tunnel-secret
+    creationPolicy: Owner
+  refreshInterval: 5m
+  data:
+    - secretKey: TUNNEL_TOKEN
+      remoteRef:
+        key: cloudflare_tunnel_token
+        property: TUNNEL_TOKEN

--- a/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./dnsendpoint.yaml
-  - ./secret.sops.yaml
+  # Migrated to 1Password via ExternalSecrets
+  # - ./secret.sops.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary

Migrate three Cloudflare-related secrets from SOPS encryption to 1Password ExternalSecrets integration:

- `cloudflare-dns-secret` (network/cloudflare-dns)
- `cloudflare-tunnel-secret` (network/cloudflare-tunnel)
- `cert-manager-secret` (cert-manager/cert-manager)

Part of **STORY-012**: Complete migration from SOPS to 1Password for all cluster secrets.

## Changes

### ExternalSecrets Created
- `kubernetes/apps/network/cloudflare-dns/app/externalsecret.yaml`
- `kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml`
- `kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml`

### Kustomization Updates
- Updated 3 `kustomization.yaml` files to reference ExternalSecrets
- Commented out SOPS secret references (not deleted, for rollback capability)

### 1Password Items
All three secrets stored in 1Password "Automation" vault:
- `cloudflare_dns_token` (field: api-token)
- `cloudflare_tunnel_token` (field: TUNNEL_TOKEN)
- `cloudflare_certmanager_token` (field: api-token)

## Security Review

✅ **PASSED** - Comprehensive pre-commit security scan completed:
- ✅ No plaintext secrets in any staged files
- ✅ All SOPS files remain properly encrypted
- ✅ ExternalSecret manifests only contain references (no credentials)
- ✅ No infrastructure details exposed
- ✅ .gitignore properly excludes sensitive directories
- ✅ Kubernetes manifests validated (dry-run passed)

## Testing Plan

- [ ] Verify ExternalSecrets sync successfully: `kubectl get externalsecrets -A`
- [ ] Verify secrets created: `kubectl get secret cloudflare-dns-secret -n network`
- [ ] Verify external-dns is operational (DNS records syncing)
- [ ] Verify cloudflare-tunnel is operational (tunnel established)
- [ ] Verify cert-manager is operational (certificates issuing)
- [ ] Monitor 1Password Connect logs for access patterns
- [ ] After 24h verification, delete commented SOPS files

## Rollback Plan

If issues occur, rollback by:
1. Uncomment SOPS secret references in kustomization.yaml
2. Comment out ExternalSecret references
3. Force Flux reconciliation: `flux reconcile kustomization --with-source`

SOPS files remain in repository encrypted for this purpose.

## Related Work

- **STORY-012**: SOPS to 1Password migration epic
- **WI-012-1**: Identify and extract Cloudflare secrets ✅
- **WI-012-2**: Create 1Password items ✅
- **WI-012-3**: Create ExternalSecret for cloudflare-dns ✅
- **WI-012-4**: Create ExternalSecret for cloudflare-tunnel ✅
- **WI-012-5**: Create ExternalSecret for cert-manager ✅
- **WI-012-6**: Security review and commit ✅

**Next**: WI-013 (Grafana secrets migration)