### PR TITLE
feat(flux-system): migrate webhook secret to ExternalSecret (WI-013)

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# ExternalSecret for Flux GitHub webhook token
+# Replaces: secret.sops.yaml
+# 1Password Item: flux_webhook_token (field: token)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-webhook-token-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: github-webhook-token-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        token: "{{ .token }}"
+  dataFrom:
+    - extract:
+        key: flux_webhook_token

--- a/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./secret.sops.yaml
+  - ./externalsecret.yaml
+  # - ./secret.sops.yaml  # Migrated to ExternalSecret (1Password)
   - ./httproute.yaml
   - ./receiver.yaml


### PR DESCRIPTION
## Summary

Migrate Flux GitHub webhook token from SOPS encryption to 1Password ExternalSecret pattern.

**Part of**: EPIC-002 - Migrate SOPS secrets to 1Password  
**Work Item**: WI-013 - Flux webhook token migration

## Changes

- ✅ Created ExternalSecret for `github-webhook-token-secret`
- ✅ References 1Password item: `flux_webhook_token` (field: `token`)
- ✅ Maintains exact secret name and key for Receiver compatibility
- ✅ Commented out `secret.sops.yaml` in kustomization (will remove after validation)
- ✅ Security review approved (no plaintext secrets)

## Migration Details

**Before**: SOPS-encrypted secret in `secret.sops.yaml`  
**After**: ExternalSecret referencing 1Password item

**Secret Mapping**:
- Secret name: `github-webhook-token-secret` (unchanged)
- Key: `token` (unchanged)
- 1Password item: `flux_webhook_token`
- Vault: Automation
- Refresh: 1h

## Testing Plan

1. ✅ YAML validation (kubectl dry-run): PASSED
2. ✅ Kustomize build: PASSED
3. ✅ Security scan: APPROVED
4. 🔄 Deploy and monitor ExternalSecret sync (post-merge)
5. 🔄 Verify Flux Receiver reconciliation (post-merge)
6. 🔄 Test webhook delivery from GitHub (post-merge)
7. 🔄 Monitor for 1-2 hours, then remove SOPS secret

## Security Review

**Status**: ✅ APPROVED

- No plaintext secrets in manifests
- ExternalSecret pattern matches established practices
- SOPS secret properly deprecated (not deleted yet)
- Changes safe for public repository

## Rollback Plan

If issues occur:
1. Revert kustomization.yaml to uncomment `secret.sops.yaml`
2. Comment out `externalsecret.yaml`
3. Flux will immediately revert to SOPS secret