### PR TITLE
fix(flux-system): correct ExternalSecret property reference for 1Password

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -14,10 +14,8 @@ spec:
   target:
     name: github-webhook-token-secret
     creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        token: "{{ .token }}"
-  dataFrom:
-    - extract:
+  data:
+    - secretKey: token
+      remoteRef:
         key: flux_webhook_token
+        property: token


### PR DESCRIPTION
## Problem

The ExternalSecret for Flux webhook token was failing with:
```
unable to execute template at key token: map has no entry for key "token"
```

## Root Cause

The ExternalSecret was using `dataFrom.extract` pattern with template, which doesn't work correctly with 1Password Connect provider. The template was trying to reference `.token` but the extracted data didn't have that structure.

## Solution

Changed to use `data[]` pattern with explicit `property` mapping:
- Uses `spec.data[]` instead of `spec.dataFrom`
- Explicitly maps `secretKey: token` to `property: token`
- Matches the working pattern used by all other ExternalSecrets in the cluster (cert-manager, cloudflare-dns, cloudflare-tunnel, grafana)

## Testing

After this change:
- ExternalSecret should reconcile successfully
- Secret `github-webhook-token-secret` should be created
- Token value should match 1Password item

## References

Part of EPIC-005, STORY-013, WI-013-5

## Checklist
- [x] Changed ExternalSecret to use data[] pattern
- [x] Removed template section
- [x] Property mapping matches 1Password field name
- [ ] ExternalSecret reconciles successfully (will verify after merge)
- [ ] Secret created with correct token value