### PR TITLE
fix(flux-system): use 'password' property for 1Password item field

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -1,7 +1,8 @@
 ---
 # ExternalSecret for Flux GitHub webhook token
 # Replaces: secret.sops.yaml
-# 1Password Item: flux_webhook_token (field: token)
+# 1Password Item: flux_webhook_token
+# NOTE: Using password field as 1Password API Credential/Password items store value in 'password' field by default
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -18,4 +19,4 @@ spec:
     - secretKey: token
       remoteRef:
         key: flux_webhook_token
-        property: token
+        property: password


### PR DESCRIPTION
## Problem

The ExternalSecret continued to fail after fixing the template issue:
```
expected one 1Password ItemField matching: 'token' in 'flux_webhook_token', got 0
```

## Root Cause

1Password Password and API Credential items store the main credential value in a field named `password` by default, not `token`. The ExternalSecret was trying to reference a field named `token` that doesn't exist in the 1Password item structure.

## Solution

Changed the `property` field from `token` to `password` to match the actual 1Password item field name:
```yaml
data:
  - secretKey: token  # Still maps to 'token' key in K8s Secret
    remoteRef:
      key: flux_webhook_token
      property: password  # References 'password' field in 1Password item
```

This pattern aligns with how 1Password structures Password and API Credential items.

## Testing

After this change:
- ExternalSecret should successfully extract the password field from 1Password item
- K8s Secret should be created with key `token` containing the webhook token value
- Flux webhook receiver should function normally

## References

Part of EPIC-005, STORY-013, WI-013-5
Follows-up PR #8

## Checklist
- [x] Changed property from 'token' to 'password'
- [x] Added comment explaining 1Password field naming
- [x] secretKey still maps to 'token' for K8s Secret compatibility
- [ ] ExternalSecret reconciles successfully (will verify after merge)
- [ ] Secret created with correct token value