### PR TITLE
fix(flux-system): correct 1Password field name for webhook token

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -1,8 +1,8 @@
 ---
 # ExternalSecret for Flux GitHub webhook token
 # Replaces: secret.sops.yaml
-# 1Password Item: flux_webhook_token
-# NOTE: Using password field as 1Password API Credential/Password items store value in 'password' field by default
+# 1Password Item: flux_webhook_token (API Credential type)
+# NOTE: Field name is 'flux_webhook_token' (custom field in API Credential item)
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -19,4 +19,4 @@ spec:
     - secretKey: token
       remoteRef:
         key: flux_webhook_token
-        property: password
+        property: flux_webhook_token


### PR DESCRIPTION
## Problem

ExternalSecret was looking for field `password` but the 1Password item uses field `flux_webhook_token`.

## Changes

- Update ExternalSecret property from `password` to `flux_webhook_token`
- Update comment to reflect API Credential item type
- Matches actual field name in 1Password vault

## Validation

After merge, ExternalSecret should sync successfully and Flux webhook will use the 1Password credential.

Part of STORY-013