### PR TITLE
feat(rook-ceph): migrate external cluster secret to 1Password

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-external/app/externalsecret.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-external/app/externalsecret.yaml
@@ -1,0 +1,41 @@
+---
+# ExternalSecret for Rook-Ceph External Cluster Connection
+# Replaces: external-cluster-secret.sops.yaml
+# 1Password Item: rook_ceph_external_cluster (Automation vault)
+#
+# This secret provides connection details to the external Proxmox Ceph cluster
+# Used by Rook-Ceph operator to connect to the external cluster
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namespace: rook-ceph
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: rook-ceph-external-cluster-details
+    creationPolicy: Owner
+  data:
+    - secretKey: fsid
+      remoteRef:
+        key: rook_ceph_external_cluster
+        property: fsid
+    - secretKey: mon-endpoints
+      remoteRef:
+        key: rook_ceph_external_cluster
+        property: mon-endpoints
+    - secretKey: ceph-username
+      remoteRef:
+        key: rook_ceph_external_cluster
+        property: ceph-username
+    - secretKey: ceph-secret
+      remoteRef:
+        key: rook_ceph_external_cluster
+        property: ceph-secret
+    - secretKey: ceph-conf
+      remoteRef:
+        key: rook_ceph_external_cluster
+        property: ceph-conf

--- a/kubernetes/apps/rook-ceph/rook-ceph-external/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-external/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 namespace: rook-ceph
 
 resources:
-  - ./external-cluster-secret.sops.yaml
+  - ./externalsecret.yaml
+  # - ./external-cluster-secret.sops.yaml  # Migrated to ExternalSecret (1Password)


### PR DESCRIPTION
## Summary

Migrate Rook-Ceph external cluster connection credentials from SOPS to 1Password ExternalSecret pattern.

**Part of**: EPIC-002 - Migrate SOPS secrets to 1Password  
**Work Item**: WI-016 (STORY-016) - Rook-Ceph external cluster secret migration

## Changes

- ✅ Created ExternalSecret for `rook-ceph-external-cluster-details`
- ✅ References 1Password item: `rook_ceph_external_cluster` (Automation vault)
- ✅ 5 fields migrated: `fsid`, `mon-endpoints`, `ceph-username`, `ceph-secret`, `ceph-conf`
- ✅ Commented out SOPS secret in kustomization (preserved for rollback)
- ✅ Security review approved

## Migration Details

**Before**: SOPS-encrypted secret in `external-cluster-secret.sops.yaml`  
**After**: ExternalSecret referencing 1Password item

**Secret Mapping**:
- Secret name: `rook-ceph-external-cluster-details` (unchanged)
- Namespace: `rook-ceph`
- 1Password item: `rook_ceph_external_cluster`
- Vault: Automation
- Refresh: 5m

**Fields**:
1. `fsid`: Ceph cluster FSID
2. `mon-endpoints`: 4 monitor endpoints (comma-separated)
3. `ceph-username`: Ceph client username (`client.k8s`)
4. `ceph-secret`: Ceph client authentication key
5. `ceph-conf`: Minimal ceph.conf configuration

## Testing & Validation

**Pre-Deployment**:
- ✅ ExternalSecret tested in default namespace
- ✅ All 5 fields verified from 1Password
- ✅ Field names match exactly
- ✅ ExternalSecret syncs successfully (`SecretSynced=True`)
- ✅ Security scan passed (no plaintext credentials)

**Post-Deployment** (after merge):
1. 🔄 Verify ExternalSecret sync in rook-ceph namespace
2. 🔄 Check Rook-Ceph operator logs (no errors)
3. 🔄 Test PVC provisioning (ensure storage still works)
4. 🔄 Monitor for 48h stability period
5. 🔄 Remove SOPS secret after validation

## Security Review

**Status**: ✅ APPROVED (security-guardian)

- No plaintext credentials in manifests
- ExternalSecret pattern matches established practices
- SOPS secret properly preserved (rollback safety)
- Changes safe for public repository
- Follows flux-system webhook migration precedent

## Rollback Plan

If issues occur:
1. Revert kustomization.yaml to uncomment `external-cluster-secret.sops.yaml`
2. Comment out `externalsecret.yaml`
3. Flux will immediately revert to SOPS secret

Rollback time: < 1 minute