### PR TITLE
fix(rook-ceph): add missing Flux Kustomization for rook-ceph-external

### DIFF
--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -9,4 +9,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./rook-ceph-operator/ks.yaml
+  - ./rook-ceph-external/ks.yaml
   - ./rook-ceph-cluster/ks.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rook-ceph-external
+spec:
+  dependsOn:
+    - name: rook-ceph-operator
+      namespace: flux-system
+    - name: cluster-secret-store
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/rook-ceph-external/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: rook-ceph
+  wait: true
+  timeout: 10m


### PR DESCRIPTION
## Issue

PR #12 added the ExternalSecret manifest but the Flux Kustomization resource was missing, preventing deployment.

## Root Cause

The `rook-ceph-external` directory was missing a `ks.yaml` file and was not included in the parent kustomization, so Flux was not deploying the ExternalSecret.

## Changes

- ✅ Created `kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml`
- ✅ Added reference to parent `kubernetes/apps/rook-ceph/kustomization.yaml`
- ✅ Dependencies: rook-ceph-operator, cluster-secret-store

## Impact

**Before**: ExternalSecret manifest existed but was not deployed by Flux  
**After**: Flux will deploy the ExternalSecret to create the Rook-Ceph external cluster secret from 1Password

## Testing

After merge:
1. Flux will detect the new Kustomization
2. ExternalSecret will be created in rook-ceph namespace  
3. Secret will sync from 1Password
4. Rook-Ceph operator can access external cluster credentials

## Critical Fix

This is required to complete WI-016 (Rook-Ceph external cluster secret migration). The ExternalSecret from PR #12 cannot function without this Flux Kustomization resource.