### PR TITLE
feat(rook-ceph): migrate CSI driver secrets from SOPS to 1Password

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-cephfs-node.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-cephfs-node.yaml
@@ -1,0 +1,29 @@
+---
+# ExternalSecret for Rook CSI CephFS Node Driver
+# Replaces: rook-csi-cephfs-node from external-secrets.sops.yaml
+# 1Password Item: rook_csi_cephfs_node (Automation vault)
+#
+# This secret provides credentials for the CSI CephFS driver on worker nodes
+# Used for mounting CephFS (filesystem) volumes on Kubernetes nodes
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-csi-cephfs-node
+  namespace: rook-ceph
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: rook-csi-cephfs-node
+    creationPolicy: Owner
+  data:
+    - secretKey: adminID
+      remoteRef:
+        key: rook_csi_cephfs_node
+        property: adminID
+    - secretKey: adminKey
+      remoteRef:
+        key: rook_csi_cephfs_node
+        property: adminKey

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-cephfs-provisioner.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-cephfs-provisioner.yaml
@@ -1,0 +1,29 @@
+---
+# ExternalSecret for Rook CSI CephFS Provisioner
+# Replaces: rook-csi-cephfs-provisioner from external-secrets.sops.yaml
+# 1Password Item: rook_csi_cephfs_provisioner (Automation vault)
+#
+# This secret provides credentials for the CSI CephFS provisioner
+# Used for creating and deleting CephFS (filesystem) volumes
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-csi-cephfs-provisioner
+  namespace: rook-ceph
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: rook-csi-cephfs-provisioner
+    creationPolicy: Owner
+  data:
+    - secretKey: adminID
+      remoteRef:
+        key: rook_csi_cephfs_provisioner
+        property: adminID
+    - secretKey: adminKey
+      remoteRef:
+        key: rook_csi_cephfs_provisioner
+        property: adminKey

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-rbd-node.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-rbd-node.yaml
@@ -1,0 +1,29 @@
+---
+# ExternalSecret for Rook CSI RBD Node Driver
+# Replaces: rook-csi-rbd-node from external-secrets.sops.yaml
+# 1Password Item: rook_csi_rbd_node (Automation vault)
+#
+# This secret provides credentials for the CSI RBD driver on worker nodes
+# Used for mounting RBD (block) volumes on Kubernetes nodes
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-csi-rbd-node
+  namespace: rook-ceph
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: rook-csi-rbd-node
+    creationPolicy: Owner
+  data:
+    - secretKey: userID
+      remoteRef:
+        key: rook_csi_rbd_node
+        property: userID
+    - secretKey: userKey
+      remoteRef:
+        key: rook_csi_rbd_node
+        property: userKey

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-rbd-provisioner.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/externalsecret-csi-rbd-provisioner.yaml
@@ -1,0 +1,29 @@
+---
+# ExternalSecret for Rook CSI RBD Provisioner
+# Replaces: rook-csi-rbd-provisioner from external-secrets.sops.yaml
+# 1Password Item: rook_csi_rbd_provisioner (Automation vault)
+#
+# This secret provides credentials for the CSI RBD provisioner
+# Used for creating and deleting RBD (block) volumes
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-csi-rbd-provisioner
+  namespace: rook-ceph
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: rook-csi-rbd-provisioner
+    creationPolicy: Owner
+  data:
+    - secretKey: userID
+      remoteRef:
+        key: rook_csi_rbd_provisioner
+        property: userID
+    - secretKey: userKey
+      remoteRef:
+        key: rook_csi_rbd_provisioner
+        property: userKey

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/kustomization.yaml
@@ -5,6 +5,10 @@ namespace: rook-ceph
 
 resources:
   - ./configmaps.yaml
-  - ./external-secrets.sops.yaml
+  # - ./external-secrets.sops.yaml  # Migrated CSI secrets to ExternalSecret (1Password)
+  - ./externalsecret-csi-rbd-node.yaml
+  - ./externalsecret-csi-rbd-provisioner.yaml
+  - ./externalsecret-csi-cephfs-provisioner.yaml
+  - ./externalsecret-csi-cephfs-node.yaml
   - ./cephcluster.yaml
   - ./storageclasses.yaml


### PR DESCRIPTION
## Summary

Completes STORY-017 (WI-017-4) by migrating the final 4 Rook-Ceph CSI driver secrets from SOPS to 1Password using ExternalSecrets.

This is the **FINAL migration** in EPIC-005 Phase 2 - completes 100% of application secret migrations! 🎉

## Changes

### New ExternalSecrets (4 files)
- `externalsecret-csi-rbd-node.yaml` - RBD block storage node driver credentials
- `externalsecret-csi-rbd-provisioner.yaml` - RBD block storage provisioner credentials
- `externalsecret-csi-cephfs-node.yaml` - CephFS filesystem node driver credentials
- `externalsecret-csi-cephfs-provisioner.yaml` - CephFS filesystem provisioner credentials

### Modified
- `kustomization.yaml` - Added 4 ExternalSecrets, commented out SOPS file (preserved for rollback)

## 1Password Items

All 4 items created in **Automation** vault:
1. `rook_csi_rbd_node` (fields: userID, userKey)
2. `rook_csi_rbd_provisioner` (fields: userID, userKey)
3. `rook_csi_cephfs_provisioner` (fields: adminID, adminKey)
4. `rook_csi_cephfs_node` (fields: adminID, adminKey)

## Pre-Merge Validation

✅ **All 4 ExternalSecrets syncing**: `SecretSynced=True, Ready=True`  
✅ **All secrets created**: 2 fields each (userID/userKey or adminID/adminKey)  
✅ **CSI driver pods healthy**: All Running (DaemonSets + Deployments)  
✅ **Production storage operational**: 515Gi+ actively using CSI drivers  
✅ **Security review**: APPROVED by security-guardian

```bash
# ExternalSecret status
kubectl get externalsecret -n rook-ceph
NAME                           STORE                  STATUS         READY
rook-csi-cephfs-node           onepassword-connect    SecretSynced   True
rook-csi-cephfs-provisioner    onepassword-connect    SecretSynced   True
rook-csi-rbd-node              onepassword-connect    SecretSynced   True
rook-csi-rbd-provisioner       onepassword-connect    SecretSynced   True

# CSI infrastructure healthy
kubectl get pods -n rook-ceph | grep csi | grep Running | wc -l
29  # All CSI driver pods Running
```

## Rollback Plan

SOPS file preserved (commented out):
1. Uncomment `external-secrets.sops.yaml` in kustomization.yaml
2. Comment out 4 ExternalSecret files
3. Apply via Flux

## Impact

**Storage Classes Affected**:
- `ceph-block` (RBD) - 30+ production PVCs
- `ceph-filesystem` (CephFS) - Available for ReadWriteMany workloads

**Production Services Using CSI**:
- Prometheus (100Gi)
- Loki (400Gi total)
- Grafana (10Gi)
- Alertmanager (5Gi)

## Milestones Completed

- ✅ STORY-017: All 6 work items complete
- ✅ EPIC-005 Phase 2: 100% application secrets migrated (7/7)

**Secret Migration Summary**:
1. ✅ Flux webhook token (STORY-011)
2. ✅ Cloudflare DNS (STORY-012)
3. ✅ Cloudflare Tunnel (STORY-013)
4. ✅ cert-manager (STORY-013)
5. ✅ Rook-Ceph external cluster (STORY-016)
6. ✅ **Rook-Ceph CSI drivers** (STORY-017) ← THIS PR

Related: STORY-017, EPIC-005