### PR TITLE
fix(rook-ceph): correct rook-ceph-operator dependency namespace

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     - name: rook-ceph-operator
-      namespace: flux-system
+      namespace: rook-ceph
     - name: cluster-secret-store
       namespace: flux-system
   interval: 1h


### PR DESCRIPTION
## Summary
- Fixed Flux Kustomization dependency namespace reference  
- Changed `rook-ceph-operator` dependency from `flux-system` to `rook-ceph` namespace

## Problem
The `rook-ceph-external` Kustomization was failing with:
```
dependency 'flux-system/rook-ceph-operator' not found
```

## Root Cause
The dependency referenced the wrong namespace - it was looking in `flux-system` but the `rook-ceph-operator` Kustomization actually exists in the `rook-ceph` namespace.

## Solution
Updated `kubernetes/apps/rook-ceph/rook-ceph-external/ks.yaml` line 9:
```diff
- namespace: flux-system
+ namespace: rook-ceph
```

## Testing
- ✅ Security review passed (no secrets exposed)
- Will verify Flux reconciliation after merge