### PR TITLE
feat(cilium): configure multi-VLAN LoadBalancer segmentation (STORY-020)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -1,3 +1,12 @@
+# Cilium Multi-VLAN LoadBalancer Configuration
+# Implements network segmentation for LoadBalancer services
+# STORY-020: Cilium Multi-VLAN LoadBalancer Segmentation
+
+# ====================================
+# CLUSTER VLAN 66 (eth0) - 10.20.66.0/23
+# ====================================
+# Primary cluster network for internal services
+# Services: k8s-gateway, envoy-internal, envoy-external, grafana
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
@@ -14,10 +23,84 @@ metadata:
   name: l2-policy
 spec:
   loadBalancerIPs: true
-  # NOTE: interfaces might need to be set if you have more than one active NIC on your hosts
-  # interfaces:
-  #   - ^eno[0-9]+
-  #   - ^eth[0-9]+
+  # Restrict to eth0 interface only (cluster network)
+  interfaces:
+    - ^eth0$
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+
+# ====================================
+# DMZ VLAN 81 (eth2) - 10.20.81.0/24
+# ====================================
+# DMZ network for externally-facing services
+# Future services: Plex, game servers, public-facing apps
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: dmz-pool
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - start: "10.20.81.100"
+      stop: "10.20.81.150"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: dmz-l2-policy
+spec:
+  loadBalancerIPs: true
+  # Restrict to eth2 interface only (DMZ network)
+  interfaces:
+    - ^eth2$
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+
+# ====================================
+# IoT VLAN 62 (eth1) - 10.20.62.0/24
+# ====================================
+# IoT network for home automation services
+# Future services: Home Assistant, MQTT, Zigbee2MQTT
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: iot-pool
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - start: "10.20.62.100"
+      stop: "10.20.62.150"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: iot-l2-policy
+spec:
+  loadBalancerIPs: true
+  # Restrict to eth1 interface only (IoT network)
+  interfaces:
+    - ^eth1$
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+
+# ====================================
+# SERVICE LABELING GUIDE
+# ====================================
+# To deploy a service on a specific VLAN, use one of these methods:
+#
+# Method 1: Specify exact IP from the desired pool
+# metadata:
+#   annotations:
+#     io.cilium/lb-ipam-ips: "10.20.81.100"  # DMZ VLAN
+#
+# Method 2: Let Cilium auto-assign from pool (based on CIDR match)
+# The service will be assigned an IP from the pool that matches
+# the requested IP range
+#
+# Default behavior: Services without specific annotations will
+# use the default "pool" (cluster VLAN 66)


### PR DESCRIPTION
## Summary

Configure Cilium Multi-VLAN LoadBalancer segmentation (STORY-020) - adds interface restrictions to L2 announcement policies to ensure proper network isolation across three VLANs.

### Network Segmentation Implemented

**Three separate LoadBalancer pools with interface-specific announcements:**

1. **Cluster VLAN 66 (eth0)**: 10.20.66.0/23
   - Existing services: k8s-gateway, envoy-internal, envoy-external, grafana
   - Interface restriction: `^eth0$` only

2. **DMZ VLAN 81 (eth2)**: 10.20.81.100-150  
   - Future services: Plex, game servers, public-facing apps
   - Interface restriction: `^eth2$` only

3. **IoT VLAN 62 (eth1)**: 10.20.62.100-150
   - Future services: Home Assistant, MQTT, Zigbee2MQTT
   - Interface restriction: `^eth1$` only

### Changes Made

**File Modified:**
- `kubernetes/apps/kube-system/cilium/app/networks.yaml`

**Configuration Updates:**
- Added `interfaces: [^eth0$]` to `l2-policy` (cluster network)
- Verified `interfaces: [^eth2$]` on `dmz-l2-policy` (DMZ network)
- Verified `interfaces: [^eth1$]` on `iot-l2-policy` (IoT network)
- Added comprehensive documentation and service labeling guide

### Implementation Approach

**Safe File-Only Changes:**
- ✅ Modified YAML file only (no kubectl apply during development)
- ✅ Preserved existing resource names (pool, l2-policy)
- ✅ No resource deletion/recreation
- ✅ No service disruption
- ✅ Let Flux reconcile changes after merge

**Previous Attempt Lessons:**
- Initial attempt deleted/recreated resources causing cluster disruption
- Updated homelab-infra-architect agent with safety guidelines
- This PR uses safe approach: file-only changes, Flux handles reconciliation

### Security Review

Pre-push security scan completed (MANDATORY per PR_RULES.md):
- **Security Score**: 10/10 (APPROVED by security-guardian agent)
- Zero secrets or credentials in committed files
- All IP addresses are RFC1918 private ranges
- No .claude/ files committed
- Clean single-file commit

### Test Plan

- [x] YAML syntax validated
- [x] Security scan passed (10/10)
- [x] Single file modified (networks.yaml)
- [x] No secrets or local-only files committed
- [ ] Flux reconciliation after merge (~10 minutes)
- [ ] Verify L2 policies have interface restrictions in cluster
- [ ] Verify existing LoadBalancer services maintain their IPs
- [ ] Test DMZ/IoT service deployment with proper pool assignment

### Impact

**Post-Merge Behavior:**
- Existing cluster services continue on VLAN 66 (eth0) - no disruption
- New DMZ services can be deployed to VLAN 81 (eth2) via pool annotation
- New IoT services can be deployed to VLAN 62 (eth1) via pool annotation
- Network isolation prevents IP conflicts across VLANs

### Related Work

- Completes STORY-020 from EPIC-010 (Cilium Multi-VLAN LoadBalancer Configuration)
- Builds on PR #18 (multi-NIC rollout to all 12 workers)
- Enables future deployment of DMZ and IoT workloads with proper network segmentation