### PR TITLE
fix(multus): correct CNI config path for Talos Linux

### DIFF
--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -48,10 +48,10 @@ spec:
           memory: 100Mi
 
     # CNI paths configuration
-    # CRITICAL: Talos Linux uses /var/lib/cni/conf instead of /etc/cni/net.d
+    # Talos Linux uses standard CNI paths
     cni:
-      netPath: /var/lib/cni/conf  # Talos-specific CNI config path
-      binPath: /opt/cni/bin        # Standard CNI binary path
+      netPath: /etc/cni/net.d  # Standard CNI config path
+      binPath: /opt/cni/bin    # Standard CNI binary path
 
     # SECURITY NOTE: bjw-s chart uses capability-based security instead of privileged mode
     # The chart automatically sets:


### PR DESCRIPTION
## Problem

Multus pods are crashing with: `cannot find valid master CNI config in "/host/etc/cni/net.d"`

## Root Cause

PR #20 configured Multus to use `/var/lib/cni/conf` as the CNI config path, but Talos Linux actually uses the **standard** CNI paths:
- CNI configs: `/etc/cni/net.d/` (where Cilium writes `05-cilium.conflist`)  
- CNI binaries: `/opt/cni/bin/`

## Fix

Update `helmrelease.yaml`:
- Change `cni.netPath` from `/var/lib/cni/conf` to `/etc/cni/net.d`
- Update comment to reflect Talos uses standard paths

## Verification

Confirmed on Talos node:
```bash
talosctl -n 10.20.67.4 ls /etc/cni/net.d/
# Shows: 05-cilium.conflist
```

## Impact

After merge, Flux will reconcile and Multus DaemonSet will deploy successfully on all nodes.

Related: #20