### PR TITLE
feat(network): add NetworkAttachmentDefinitions for IoT and DMZ VLANs (STORY-022)

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./k8s-gateway/ks.yaml
+  - ./network-attachments/ks.yaml

--- a/kubernetes/apps/network/network-attachments/app/dmz-vlan81.yaml
+++ b/kubernetes/apps/network/network-attachments/app/dmz-vlan81.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: dmz-vlan81
+  namespace: network
+  labels:
+    app.kubernetes.io/name: network-attachment
+    app.kubernetes.io/component: dmz-vlan
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "macvlan",
+      "master": "eth2",
+      "mode": "bridge",
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.20.81.0/24",
+        "rangeStart": "10.20.81.100",
+        "rangeEnd": "10.20.81.200",
+        "gateway": "10.20.81.1",
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ]
+      }
+    }

--- a/kubernetes/apps/network/network-attachments/app/iot-vlan62.yaml
+++ b/kubernetes/apps/network/network-attachments/app/iot-vlan62.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: iot-vlan62
+  namespace: network
+  labels:
+    app.kubernetes.io/name: network-attachment
+    app.kubernetes.io/component: iot-vlan
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "macvlan",
+      "master": "eth1",
+      "mode": "bridge",
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.20.62.0/23",
+        "rangeStart": "10.20.62.100",
+        "rangeEnd": "10.20.62.200",
+        "gateway": "10.20.62.1",
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ]
+      }
+    }

--- a/kubernetes/apps/network/network-attachments/app/kustomization.yaml
+++ b/kubernetes/apps/network/network-attachments/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: network
+
+resources:
+  - ./namespace.yaml
+  - ./iot-vlan62.yaml
+  - ./dmz-vlan81.yaml

--- a/kubernetes/apps/network/network-attachments/app/namespace.yaml
+++ b/kubernetes/apps/network/network-attachments/app/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: network
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/network/network-attachments/ks.yaml
+++ b/kubernetes/apps/network/network-attachments/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: network-attachments
+  namespace: flux-system
+spec:
+  targetNamespace: network
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: network-attachments
+  interval: 10m
+  path: ./kubernetes/apps/network/network-attachments/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  dependsOn:
+    - name: multus
+      namespace: flux-system


### PR DESCRIPTION
## Summary

Create NetworkAttachmentDefinitions for IoT VLAN 62 and DMZ VLAN 81 to enable multi-network pod attachment via Multus CNI.

## Changes Made

**NetworkAttachmentDefinitions Created**:
- **IoT VLAN 62**: MacVLAN bridge on eth1, subnet 10.20.62.0/23, IP pool .100-.200
- **DMZ VLAN 81**: MacVLAN bridge on eth2, subnet 10.20.81.0/24, IP pool .100-.200

**Directory Structure**:
```
kubernetes/apps/network/network-attachments/
├── app/
│   ├── kustomization.yaml
│   ├── namespace.yaml
│   ├── iot-vlan62.yaml
│   └── dmz-vlan81.yaml
└── ks.yaml (Flux Kustomization with Multus dependency)
```

**Files Created**: 5 new files
**Files Modified**: 1 (kubernetes/apps/network/kustomization.yaml)

## Configuration Details

### IoT VLAN 62
- Interface: eth1
- Mode: MacVLAN bridge
- Subnet: 10.20.62.0/23
- Gateway: 10.20.62.1
- Pod IP pool: 10.20.62.100 - 10.20.62.200

### DMZ VLAN 81
- Interface: eth2
- Mode: MacVLAN bridge
- Subnet: 10.20.81.0/24
- Gateway: 10.20.81.1
- Pod IP pool: 10.20.81.100 - 10.20.81.200

## Security Review

Pre-push security scan completed (MANDATORY per PR_RULES.md):
- **Security Score**: 9/10 (APPROVED by security-guardian agent)
- Zero secrets or credentials in committed files
- RFC1918 private addressing only
- Proper namespace isolation with PSA labels
- MacVLAN provides L2 network segmentation
- No .claude/ files committed

**Findings**: Only informational/low severity items acceptable for homelab GitOps

## Safe File-Only Approach

✅ Followed proven file-only approach:
- No kubectl apply during development
- No cluster modifications
- Flux will reconcile after merge
- Zero service disruption expected

## Test Plan

- [x] YAML syntax validated
- [x] Security scan passed (9/10)
- [x] Files created in proper structure
- [x] No secrets committed
- [ ] Flux reconciliation after merge (~5 minutes)
- [ ] NADs created in network namespace
- [ ] Ready for pod multi-network attachment testing

## Usage Example

After merge, pods can attach to secondary networks via annotation:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: home-assistant
  annotations:
    k8s.v1.cni.cncf.io/networks: network/iot-vlan62
spec:
  containers:
  - name: home-assistant
    image: homeassistant/home-assistant:latest
```

## Related Work

- Part of EPIC-008: Multi-VLAN Network Isolation
- Follows STORY-021: Multus CNI Deployment (PR #20, #21)
- Enables production workloads with proper network isolation
- Foundation for Home Assistant (IoT) and Plex/ARK (DMZ) deployments

## Post-Merge Validation

After merge, verify:
```bash
# Check NADs created
kubectl get network-attachment-definitions -n network

# Describe NADs
kubectl describe nad iot-vlan62 -n network
kubectl describe nad dmz-vlan81 -n network

# Check Flux reconciliation
flux get kustomizations -n flux-system network-attachments
```