### PR TITLE
fix(network): correct multus dependency namespace for network-attachments

### DIFF
--- a/kubernetes/apps/network/network-attachments/ks.yaml
+++ b/kubernetes/apps/network/network-attachments/ks.yaml
@@ -19,4 +19,4 @@ spec:
   wait: true
   dependsOn:
     - name: multus
-      namespace: flux-system
+      namespace: kube-system


### PR DESCRIPTION
## Problem

After PR #22 merge, network-attachments kustomization is failing with:
```
dependency 'flux-system/multus' not found: kustomizations.kustomize.toolkit.fluxcd.io "multus" not found
```

## Root Cause

The multus kustomization is deployed to **kube-system** namespace (via parent kustomization.yaml namespace directive), not flux-system.

Verification:
```bash
kubectl get kustomization multus -n kube-system
# NAME     AGE   READY   STATUS
# multus   28m   True    Applied revision: refs/heads/main...

kubectl get kustomization multus -n flux-system
# Error from server (NotFound): not found
```

## Fix

Change dependency namespace reference from `flux-system` to `kube-system`:

```diff
   dependsOn:
     - name: multus
-      namespace: flux-system
+      namespace: kube-system
```

## Why This Happened

The multus/ks.yaml file specifies `namespace: flux-system` in metadata, but the parent kustomization at `kubernetes/apps/kube-system/kustomization.yaml` has `namespace: kube-system` which overrides it.

## Impact

After merge, network-attachments will be able to find its multus dependency and successfully deploy the NetworkAttachmentDefinitions for IoT and DMZ VLANs.

Related: #22