### PR TITLE
fix(home-assistant): remove invalid nodeSelector for worker nodes

### DIFF
--- a/kubernetes/apps/iot/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/home-assistant/app/helmrelease.yaml
@@ -65,8 +65,6 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: network/iot-vlan62
         security.homelab/zigbee-device: "SMLIGHT SLZB-06P10 (network-attached via IoT VLAN)"
-      nodeSelector:
-        kubernetes.io/role: worker
       securityContext:
         runAsNonRoot: true
         runAsUser: 568


### PR DESCRIPTION
## Summary
Fixes pod scheduling failure for Home Assistant by removing invalid nodeSelector.

## Problem
After merging PR #24, Home Assistant pod fails to schedule with error:
```
12 node(s) didn't match Pod's node affinity/selector
```

## Root Cause
The nodeSelector `kubernetes.io/role: worker` doesn't exist on worker nodes in this Talos cluster.

Worker nodes have ROLES set to `<none>` and don't have the `kubernetes.io/role` label.

## Solution
Remove the nodeSelector entirely. Control plane nodes already have the `node-role.kubernetes.io/control-plane` taint which prevents workload pods from scheduling there.

## Changes
- **Removed**: `nodeSelector: {kubernetes.io/role: worker}` from helmrelease.yaml
- Pod will now schedule on any available worker node
- Control plane taints ensure pods don't land on control plane nodes

## Testing
- After merge, pod should transition from Pending to Running
- Verify pod scheduled on worker node: `kubectl get pods -n iot -o wide`

## Impact
- **Severity**: HIGH - blocking Home Assistant deployment
- **Risk**: LOW - removing incorrect selector, control plane taints remain