### PR TITLE
fix(cilium): add serviceSelector to L2 announcement policies

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -29,6 +29,11 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+  # Only announce services without network label (default pool)
+  serviceSelector:
+    matchExpressions:
+      - key: network
+        operator: DoesNotExist
 
 # ====================================
 # DMZ VLAN 81 (eth2) - 10.20.81.0/24
@@ -61,6 +66,10 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+  # Only announce DMZ services
+  serviceSelector:
+    matchLabels:
+      network: dmz
 
 # ====================================
 # IoT VLAN 62 (eth1) - 10.20.62.0/24
@@ -93,6 +102,10 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+  # Only announce IoT services
+  serviceSelector:
+    matchLabels:
+      network: iot
 
 # ====================================
 # SERVICE LABELING GUIDE


### PR DESCRIPTION
## Problem

Home Assistant LoadBalancer IP (10.20.62.100) not accessible from external network despite working perfectly from within the cluster.

**Root Cause**: L2 announcement policies lacked `serviceSelector` configuration. All three policies (cluster, IoT, DMZ) were announcing ALL LoadBalancer IPs on different interfaces simultaneously, causing announcement conflicts that prevented proper L2 advertisement on the physical network.

## Changes

**File Modified**: `kubernetes/apps/kube-system/cilium/app/networks.yaml`

**L2 Announcement Policies Updated**:

1. **iot-l2-policy** (eth1 - IoT VLAN 62):
   ```yaml
   serviceSelector:
     matchLabels:
       network: iot
   ```
   Only announces services with `network: iot` label on eth1

2. **dmz-l2-policy** (eth2 - DMZ VLAN 81):
   ```yaml
   serviceSelector:
     matchLabels:
       network: dmz
   ```
   Only announces services with `network: dmz` label on eth2

3. **l2-policy** (eth0 - Cluster VLAN 66):
   ```yaml
   serviceSelector:
     matchExpressions:
       - key: network
         operator: DoesNotExist
   ```
   Only announces services WITHOUT network label (default pool) on eth0

## Impact

**Before (Broken)**:
- All LoadBalancer IPs announced on eth0, eth1, AND eth2 simultaneously
- ARP conflicts and routing ambiguity on physical network
- LoadBalancer IPs not reachable from external devices

**After (Fixed)**:
- IoT services (network: iot) announced ONLY on eth1 → reachable from IoT VLAN 62
- DMZ services (network: dmz) announced ONLY on eth2 → reachable from DMZ VLAN 81
- Cluster services (no label) announced ONLY on eth0 → reachable from cluster VLAN 66
- Clean L2 advertisement per VLAN, no conflicts

## Security Benefits

- **Network Segmentation Enforced**: Services only accessible on designated VLAN
- **Prevents Cross-VLAN Access**: L2 layer enforcement prevents unintended service exposure
- **Defense in Depth**: Adds L2 enforcement to existing L3 NetworkPolicy controls
- **Reduces Attack Surface**: Services not discoverable from unintended network segments

## Testing Plan

After merge:
1. Verify L2 policies applied correctly
2. Test Home Assistant access from IoT VLAN: `curl http://10.20.62.100:8123`
3. Verify ARP entries for 10.20.62.100 on IoT VLAN network devices
4. Confirm cluster services NOT announced on IoT VLAN
5. Monitor Cilium logs for L2 announcement events

## Validation from Cluster

Already confirmed working from within cluster:
- Pod status: Ready (1/1) with 0 restarts ✓
- LoadBalancer IP assigned: 10.20.62.100 ✓
- Service label: network: iot ✓
- Cluster-internal access: HTTP 302 redirect to /onboarding.html ✓

Missing piece was proper L2 announcement on physical network.

## Security Review

Security-guardian agent review: **APPROVED**

- No security vulnerabilities introduced
- Significantly improves network segmentation enforcement
- Implements security best practices for multi-VLAN architecture
- Defense in depth strategy

## Related

- Epic: EPIC-008 Phase 4A
- Story: STORY-023 (Deploy Home Assistant with IoT VLAN)
- Previous: PR #29 (NetworkAttachmentDefinition routing fix)
- Previous: PR #28 (Cilium pool serviceSelector fix)

This completes the multi-VLAN LoadBalancer infrastructure. After this fix, services with appropriate labels will be properly announced and accessible on their designated VLANs.