### PR TITLE
fix(cilium): restrict IoT/DMZ L2 announcements to worker nodes only

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -63,9 +63,11 @@ spec:
   # Restrict to eth2 interface only (DMZ network)
   interfaces:
     - ^eth2$
+  # Only select worker nodes (exclude control plane nodes without eth1/eth2)
   nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
   # Only announce DMZ services
   serviceSelector:
     matchLabels:
@@ -99,9 +101,11 @@ spec:
   # Restrict to eth1 interface only (IoT network)
   interfaces:
     - ^eth1$
+  # Only select worker nodes (exclude control plane nodes without eth1/eth2)
   nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
   # Only announce IoT services
   serviceSelector:
     matchLabels:


### PR DESCRIPTION
## Problem

Home Assistant LoadBalancer IP (10.20.62.100) not accessible from IoT VLAN despite all previous fixes (routing fix in PR #29, serviceSelector fix in PR #30).

**Root Cause**: L2 announcement leader for `home-assistant` service is k8s-ctrl-3 (control plane node), which does NOT have the eth1 interface required for IoT VLAN announcements.

**Evidence**:
```bash
# L2 announcement lease holder
kubectl get lease -n kube-system cilium-l2announce-iot-home-assistant
# Holder: k8s-ctrl-3 (control plane node)

# Control plane nodes only have eth0
talosctl -n 10.20.67.3 get links
# Result: Only eth0 interface exists

# Worker nodes have all three interfaces
talosctl -n 10.20.67.13 get links
# Result: eth0, eth1 (IoT), eth2 (DMZ) all present
```

## Changes

**File Modified**: `kubernetes/apps/kube-system/cilium/app/networks.yaml`

**L2 Announcement Policies Updated**:

1. **iot-l2-policy**: Exclude control plane nodes
   ```yaml
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
   ```

2. **dmz-l2-policy**: Exclude control plane nodes
   ```yaml
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
   ```

3. **l2-policy** (cluster/eth0): No change (all nodes have eth0)

## Impact

**Before (Broken)**:
- iot-l2-policy nodeSelector: `kubernetes.io/os: linux` → matches ALL nodes
- Leader election could select control plane node without eth1
- Control plane node cannot announce on non-existent interface
- LoadBalancer IP never announced via ARP on physical network

**After (Fixed)**:
- iot-l2-policy nodeSelector: Excludes control plane nodes
- Leader election only selects worker nodes (which have eth1/eth2)
- Worker node announces LoadBalancer IP on eth1 via ARP
- LoadBalancer IP accessible from IoT VLAN devices

## Network Architecture

**Node Interface Topology**:
```
Control Plane Nodes (k8s-ctrl-{1,2,3}):
├─ eth0 ✓ (VLAN 66 - Cluster network)
├─ eth1 ✗ (does not exist)
└─ eth2 ✗ (does not exist)

Worker Nodes (k8s-work-{1..16}):
├─ eth0 ✓ (VLAN 66 - Cluster network)
├─ eth1 ✓ (VLAN 62 - IoT network)
└─ eth2 ✓ (VLAN 81 - DMZ network)
```

**L2 Announcement Leader Selection**:
- eth0 (Cluster): Any node (all have eth0) ✓
- eth1 (IoT): Worker nodes only (control plane lacks eth1) ✓
- eth2 (DMZ): Worker nodes only (control plane lacks eth2) ✓

## Testing Plan

After merge:
1. Verify IoT L2 announcement leader is a worker node
2. Verify LoadBalancer IP assigned to worker node's eth1 interface
3. Test Home Assistant access from IoT VLAN: `curl http://10.20.62.100:8123`
4. Verify ARP entry for 10.20.62.100 on IoT VLAN devices
5. Confirm Home Assistant web UI loads

## Expected Results

From IoT VLAN device (10.20.62.0/23):
```bash
# Should succeed
ping 10.20.62.100
curl http://10.20.62.100:8123  # Returns HTTP 302 redirect to /onboarding.html

# ARP table should show LoadBalancer IP
arp -a | grep 10.20.62.100
# Should show worker node's eth1 MAC address
```

From workstation (10.20.65.119) with cross-VLAN routing enabled:
```bash
# Should also succeed via routing
curl http://10.20.62.100:8123
```

## Security Review

Security-guardian agent review: **APPROVED**

- No security vulnerabilities introduced
- Improves system reliability by preventing misconfigurations
- Maintains network segmentation enforcement
- Follows principle of least privilege
- No credentials or secrets exposed

## Related

- Epic: EPIC-008 Phase 4A - Multi-VLAN LoadBalancer Infrastructure
- Story: STORY-023 - Deploy Home Assistant with IoT VLAN isolation
- Previous: PR #29 (NetworkAttachmentDefinition routing fix)
- Previous: PR #30 (L2 announcement serviceSelector fix)

This is the FINAL piece required for multi-VLAN LoadBalancer functionality. After this fix, services will be properly announced on their designated VLANs and accessible from external networks.