### PR TITLE
fix(home-assistant): allow external internet access for integrations

### DIFF
--- a/kubernetes/apps/iot/home-assistant/app/networkpolicy.yaml
+++ b/kubernetes/apps/iot/home-assistant/app/networkpolicy.yaml
@@ -30,10 +30,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: rook-ceph
-    # Allow external access for integrations and updates
-    - to:
-        - namespaceSelector: {}
-      ports:
+    # Allow external internet access for integrations and updates
+    # No 'to' selector = allow to any destination
+    - ports:
         - protocol: TCP
           port: 443
         - protocol: TCP


### PR DESCRIPTION
## Problem

Home Assistant integrations failing to load with errors:
- **ZHA (Zigbee)**: Config flow returns 500 Internal Server Error
- **Met.no (Weather)**: TimeoutError accessing https://aa015h6buqvih86i1.api.met.no
- **Radio Browser**: Unable to load stations

**Root Cause**: NetworkPolicy egress rule has `namespaceSelector: {}` which only allows connections to other Kubernetes namespaces, blocking all external internet access.

## Changes

**File Modified**: `kubernetes/apps/iot/home-assistant/app/networkpolicy.yaml`

**Egress Rule Fix**:
```yaml
# Before (blocks external internet):
- to:
    - namespaceSelector: {}
  ports:
    - protocol: TCP
      port: 443
    - protocol: TCP
      port: 80

# After (allows external internet):
- ports:
    - protocol: TCP
      port: 443
    - protocol: TCP
      port: 80
```

Removed `to: namespaceSelector: {}` restriction to allow egress to ANY destination on ports 80/443.

## Impact

**Fixes**:
- ✅ External API access for integrations (Met.no weather, Radio Browser, etc.)
- ✅ HACS (Home Assistant Community Store) downloads
- ✅ Component updates and security patches
- ✅ External smart home service integrations (potential future use)

**Security Controls Maintained**:
- ✅ Port restrictions: Only 80 (HTTP) and 443 (HTTPS), not all ports
- ✅ DNS egress: Restricted to kube-system namespace only
- ✅ Ingress: Limited to port 8123
- ✅ VLAN isolation: IoT VLAN access via secondary interface
- ✅ Application security: Authentication, TLS encryption

## Testing

Tested connectivity from Home Assistant pod:
```bash
# DNS resolution works
kubectl exec -n iot home-assistant-* -- nslookup google.com
# ✅ Resolves successfully

# HTTPS blocked (before fix)
kubectl exec -n iot home-assistant-* -- wget --timeout=5 https://www.google.com
# ❌ wget: download timed out

# After applying fix, external HTTPS should work
```

After merge, verify:
1. Met.no weather integration updates successfully
2. Radio Browser loads stations
3. ZHA config flow loads without errors
4. No timeout errors in Home Assistant logs

## Security Review

Security-guardian agent review: **APPROVED**

- No new attack vectors introduced
- Port restrictions maintained (only 80/443)
- DNS controls preserved
- Follows Kubernetes best practices for applications requiring internet access
- Home Assistant legitimately requires external API access for intended functionality

## Related

- Epic: EPIC-008 Phase 4A
- Story: STORY-023 - Deploy Home Assistant with IoT VLAN isolation
- Depends on: PR #31 (L2 announcement worker node fix)

This fixes the final connectivity issue preventing Home Assistant integrations from functioning.