### PR TITLE
fix(iot): allow management VLAN ingress to Home Assistant (STORY-023)

### DIFF
--- a/kubernetes/apps/iot/home-assistant/app/networkpolicy.yaml
+++ b/kubernetes/apps/iot/home-assistant/app/networkpolicy.yaml
@@ -12,11 +12,13 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress only from IoT VLAN (10.20.62.0/23)
-    # Defense in depth: LoadBalancer IP is on IoT VLAN, but enforce at pod level
+    # Allow ingress from IoT VLAN (10.20.62.0/23) and management VLAN (10.20.65.0/24)
+    # Defense in depth: LoadBalancer IP is on IoT VLAN, but allow management access
     - from:
         - ipBlock:
             cidr: 10.20.62.0/23
+        - ipBlock:
+            cidr: 10.20.65.0/24
       ports:
         - protocol: TCP
           port: 8123


### PR DESCRIPTION
## Issue

After PR #33 merged (NetworkPolicy hardening), Home Assistant UI became inaccessible from management workstation.

**Root Cause**: NetworkPolicy restricted ingress to IoT VLAN only (10.20.62.0/23), blocking access from management VLAN (10.20.65.0/24) where workstation (10.20.65.119) resides.

## Solution

Add management VLAN (10.20.65.0/24) as second ipBlock to ingress rules.

## Changes

### Ingress Rule Updated
```yaml
ingress:
  - from:
      - ipBlock:
          cidr: 10.20.62.0/23    # IoT VLAN (IoT devices)
      - ipBlock:
          cidr: 10.20.65.0/24    # Management VLAN (workstations)
    ports:
      - protocol: TCP
        port: 8123
```

## Security Analysis

**Maintains Defense in Depth**:
- ✅ Still blocks cluster VLAN 66 (10.20.66.0/23)
- ✅ Still blocks DMZ VLAN 81 (10.20.81.0/24)
- ✅ Still blocks other VLANs
- ✅ SSRF prevention unchanged (egress)
- ✅ DNS restriction unchanged (CoreDNS only)

**Access Control**:
- Allows: IoT devices (10.20.62.0/23) + Management workstations (10.20.65.0/24)
- Blocks: Everything else (510 + 254 = 764 allowed IPs out of 16M+ private IPs)

**Security Score**: Remains 9/10 (minimal risk)

## Validation

After merge:
1. UI should be accessible from 10.20.65.119 at http://10.20.62.100:8123/
2. IoT devices can still access Home Assistant
3. Other VLANs remain blocked

## Epic and Story

**Epic**: EPIC-008 Phase 4A  
**Story**: STORY-023 - Deploy Home Assistant with IoT VLAN Isolation

This is a hotfix to restore management access while maintaining security posture.