### PR TITLE
feat(network): Deploy unifi-dns for automatic DNS record management (STORY-025)

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ./envoy-gateway/ks.yaml
   - ./k8s-gateway/ks.yaml
   - ./network-attachments/ks.yaml
+  - ./unifi-dns/ks.yaml

--- a/kubernetes/apps/network/unifi-dns/app/externalsecret.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: unifi-dns-secret
+  namespace: network
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: unifi-dns-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        UNIFI_USER: "{{ .username }}"
+        UNIFI_PASS: "{{ .credential }}"
+        UNIFI_HOST: "{{ .url }}"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: UniFi UDM API - k8s-unifi-dns
+        property: username
+    - secretKey: credential
+      remoteRef:
+        key: UniFi UDM API - k8s-unifi-dns
+        property: credential
+    - secretKey: url
+      remoteRef:
+        key: UniFi UDM API - k8s-unifi-dns
+        property: url

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: unifi-dns
+  namespace: network
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-dns
+      version: 1.15.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: network
+      interval: 30m
+  values:
+    fullnameOverride: unifi-dns
+
+    # Log level
+    logLevel: info
+    logFormat: json
+
+    # Provider configuration
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/kashalls/external-dns-unifi-webhook
+          tag: v0.7.0
+        env:
+          - name: UNIFI_USER
+            valueFrom:
+              secretKeyRef:
+                name: unifi-dns-secret
+                key: UNIFI_USER
+          - name: UNIFI_PASS
+            valueFrom:
+              secretKeyRef:
+                name: unifi-dns-secret
+                key: UNIFI_PASS
+          - name: UNIFI_HOST
+            valueFrom:
+              secretKeyRef:
+                name: unifi-dns-secret
+                key: UNIFI_HOST
+          - name: UNIFI_SKIP_TLS_VERIFY
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-webhook
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+    # External-DNS configuration
+    interval: 5m
+
+    # Domain filter
+    domainFilters:
+      - homelab0.org
+
+    # Sources to watch
+    sources:
+      - gateway-httproute
+      - service
+
+    # Policy
+    policy: sync
+
+    # Registry
+    registry: txt
+    txtOwnerId: k8s-unifi-dns
+    txtPrefix: k8s.
+
+    # ServiceAccount
+    serviceAccount:
+      create: true
+      name: unifi-dns
+
+    # Resources
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi

--- a/kubernetes/apps/network/unifi-dns/app/helmrepository.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: network
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/kubernetes/apps/network/unifi-dns/app/kustomization.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/network/unifi-dns/ks.yaml
+++ b/kubernetes/apps/network/unifi-dns/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: unifi-dns
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/network/unifi-dns/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: unifi-dns
+      namespace: network


### PR DESCRIPTION
## Summary

Deploys **unifi-dns** (external-dns with UniFi webhook) to automatically create DNS records in UniFi UDM for internal services accessed via HTTPRoutes.

This completes **STORY-024** (UDM API Credentials) and **STORY-025** (Deploy unifi-dns) as part of **EPIC-011** (Internal DNS Automation).

## Changes

### New Resources Created:
- `kubernetes/apps/network/unifi-dns/app/externalsecret.yaml` - Maps 1Password credentials to Kubernetes Secret
- `kubernetes/apps/network/unifi-dns/app/helmrepository.yaml` - kubernetes-sigs/external-dns Helm repo
- `kubernetes/apps/network/unifi-dns/app/helmrelease.yaml` - external-dns 1.15.0 with UniFi webhook v0.7.0
- `kubernetes/apps/network/unifi-dns/app/kustomization.yaml` - Resource aggregation
- `kubernetes/apps/network/unifi-dns/ks.yaml` - Flux Kustomization

### Modified Resources:
- `kubernetes/apps/network/kustomization.yaml` - Added unifi-dns to network apps

## Configuration

**External-DNS Settings:**
- Provider: webhook (UniFi)
- Domain filter: `homelab0.org` only
- Sources: `gateway-httproute`, `service`
- Policy: `sync` (removes orphaned records)
- Interval: 5m
- TXT owner ID: `k8s-unifi-dns`
- TXT prefix: `k8s.`

**UniFi Integration:**
- UDM Host: 10.20.66.1 (cluster VLAN)
- Authentication: Username/password (automation account)
- TLS verification: **Enabled** (UNIFI_SKIP_TLS_VERIFY=false)
- Credentials: 1Password ExternalSecret

**Container Images:**
- external-dns: **1.15.0** (kubernetes-sigs/external-dns)
- unifi-webhook: **v0.7.0** (ghcr.io/kashalls/external-dns-unifi-webhook)

## Security Review

**Status**: ✅ **APPROVED** (security-guardian)  
**Score**: **9/10**

### Security Controls:
- ✅ All credentials in 1Password (no plaintext secrets)
- ✅ TLS verification enabled for UDM communication
- ✅ Container images pinned (not :latest)
- ✅ Resource limits defined
- ✅ Domain filtering prevents DNS hijacking
- ✅ TXT record ownership prevents conflicts
- ✅ GitOps deployment (no direct kubectl apply)

### Vulnerabilities: **NONE**

## Test Plan

After merge, validate:

- [ ] **WI-025-3**: Flux deploys unifi-dns successfully
  ```bash
  kubectl get helmrelease -n network unifi-dns
  kubectl get pods -n network -l app.kubernetes.io/name=external-dns
  ```

- [ ] **WI-025-4**: Webhook connects to UniFi UDM
  ```bash
  kubectl logs -n network -l app.kubernetes.io/name=external-dns -c external-dns-unifi-webhook
  ```

- [ ] **WI-025-5**: DNS record created for homeassistant.homelab0.org
  - Check UniFi Network → Settings → Networks → DNS → Custom DNS
  - Verify A record: `homeassistant.homelab0.org` → `10.20.67.22` (envoy-internal)
  - Verify TXT record: `k8s.homeassistant.homelab0.org` with ownership metadata

- [ ] **WI-025-6**: DNS record lifecycle works
  - Create: Deploy test HTTPRoute → DNS record created
  - Update: Change HTTPRoute target → DNS record updated
  - Delete: Remove HTTPRoute → DNS record removed

## Expected Outcome

After this PR merges:
1. **unifi-dns pod running** in network namespace
2. **DNS record auto-created** for `homeassistant.homelab0.org` pointing to envoy-internal Gateway (10.20.67.22)
3. **HTTPS access working** from management network: `https://homeassistant.homelab0.org` with valid TLS cert
4. **Future HTTPRoutes** automatically get DNS records without manual UDM configuration

## Related Issues

- Epic: **EPIC-011** (Internal DNS Automation) - IN PROGRESS
- Story: **STORY-024** (Setup UDM API Credentials) - ✅ COMPLETE
- Story: **STORY-025** (Deploy unifi-dns Application) - 🚧 IN PROGRESS
- Blocked by: None
- Blocks: **STORY-026** (Fix k8s-gateway Configuration)

## References

- [external-dns Documentation](https://kubernetes-sigs.github.io/external-dns/)
- [kashalls/external-dns-unifi-webhook](https://github.com/kashalls/external-dns-unifi-webhook)
- [Security Review Report](.claude/.ai-docs/stories/STORY-025-deploy-unifi-dns.md)

---