### PR TITLE
fix(network): enable TLS skip verification for UniFi UDM self-signed certificate

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -45,8 +45,12 @@ spec:
               secretKeyRef:
                 name: unifi-dns-secret
                 key: UNIFI_HOST
+          # SECURITY: TLS verification disabled for UDM self-signed cert
+          # UDM cert only includes 127.0.0.1/fe80::1 in SAN, not 10.20.66.1
+          # Risk: Vulnerable to MITM on 10.20.66.0/24 network segment
+          # Acceptable for homelab with network segmentation + physical control
           - name: UNIFI_SKIP_TLS_VERIFY
-            value: "false"
+            value: "true"
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

Fixes unifi-dns pod crash loop caused by TLS certificate verification failure when connecting to UniFi UDM-SE API.

## Problem

The unifi-dns deployment (external-dns with UniFi webhook) was failing to start with the following error:

```
error: tls: failed to verify certificate: x509: certificate is valid for 127.0.0.1, fe80::1, not 10.20.66.1
```

The UniFi UDM-SE uses a self-signed certificate that only includes `127.0.0.1` and `fe80::1` in its Subject Alternative Names (SAN). We connect to the UDM via its cluster VLAN IP address (`10.20.66.1`), which is not included in the certificate, causing TLS verification to fail.

## Solution

Set `UNIFI_SKIP_TLS_VERIFY=true` in the UniFi webhook environment configuration to disable TLS certificate verification for the UDM API connection.

## Changes

- `kubernetes/apps/network/unifi-dns/app/helmrelease.yaml`:
  - Changed `UNIFI_SKIP_TLS_VERIFY` from `"false"` to `"true"`
  - Added inline security comments documenting the trade-off

## Security Review

**Status**: ✅ APPROVED by security-guardian agent

**Security Trade-off**:
- **Risk**: Disables TLS verification for internal UDM API connection
- **Vulnerability**: Susceptible to MITM attacks on 10.20.66.0/24 network segment
- **Assessment**: Acceptable risk for homelab environment with controlled network access

**Mitigations**:
- Network segmentation (isolated cluster VLAN)
- Credentials automatically rotated via 1Password/ExternalSecrets (5m refresh interval)
- Physical access control to homelab environment
- Inline code comments document the risk for future maintainers

## Testing Plan

After merge:
1. Verify unifi-dns pod starts successfully
2. Check external-dns logs for successful UDM API connection
3. Verify DNS records are created in UniFi UDM for HTTPRoutes
4. Test DNS record lifecycle (create/update/delete)

## Related Work Items

- WI-025-3: Deploy unifi-dns via Flux
- Part of STORY-025: Deploy unifi-dns for automatic DNS record management
- Part of EPIC-011: Internal DNS Automation for HTTPS Access