### PR TITLE
feat(iot): enable external-dns for Home Assistant HTTPRoute

### DIFF
--- a/kubernetes/apps/iot/home-assistant/app/httproute.yaml
+++ b/kubernetes/apps/iot/home-assistant/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: home-assistant
   namespace: iot
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: homeassistant.homelab0.org
 spec:
   parentRefs:
     - name: envoy-internal


### PR DESCRIPTION
## Summary
Add external-dns annotation to Home Assistant HTTPRoute to enable automatic internal DNS record creation.

Part of EPIC-011: Internal DNS Automation

## Changes
- Added `external-dns.alpha.kubernetes.io/hostname` annotation to HTTPRoute
- Enables automatic DNS A record creation in UniFi UDM
- DNS record: `homeassistant.homelab0.org` → LoadBalancer IP

## Security Review
- ✅ Security-guardian reviewed and approved
- ✅ Internal DNS only (no external exposure)
- ✅ Hostname validated against HTTPRoute spec
- ✅ No injection vectors identified
- ✅ Gateway: envoy-internal (internal traffic only)

## Testing Plan
Post-merge verification (WI-025-5):
- [ ] Verify DNS record created in UniFi UDM
- [ ] Test DNS resolution: `nslookup homeassistant.homelab0.org`
- [ ] Confirm HTTPRoute still routes correctly
- [ ] Check external-dns logs for successful creation

## Deployment Notes
- DNS TTL: Default (300s)
- Gateway: envoy-internal (internal traffic only)
- No secrets or sensitive data in this change

## Work Items
- WI-025-4: Add external-dns annotation to Home Assistant HTTPRoute
- Part of STORY-025: Deploy unifi-dns for automatic DNS record management
- Part of EPIC-011: Internal DNS Automation for HTTPS Access