### PR TITLE
feat(network): add Gluetun VPN gateway with Surfshark WireGuard

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./k8s-gateway/ks.yaml
   - ./network-attachments/ks.yaml
   - ./unifi-dns/ks.yaml
+  - ./vpn-gateway/ks.yaml

--- a/kubernetes/apps/network/vpn-gateway/app/externalsecret.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: surfshark-wireguard
+  namespace: network
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: surfshark-wireguard
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        # Mount entire WireGuard config file
+        wg0.conf: "{{ .config }}"
+  data:
+    - secretKey: config
+      remoteRef:
+        key: Surfshark VPN
+        property: config

--- a/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vpn-gateway
+  namespace: network
+spec:
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: network
+  interval: 1h
+  values:
+    controllers:
+      vpn-gateway:
+        strategy: Recreate  # Only one instance at a time
+        containers:
+          app:
+            image:
+              repository: ghcr.io/qdm12/gluetun
+              tag: v3.39.1
+            env:
+              # VPN Configuration
+              - name: VPN_SERVICE_PROVIDER
+                value: "custom"
+              - name: VPN_TYPE
+                value: "wireguard"
+              # Timezone
+              - name: TZ
+                value: "America/New_York"
+              # Logging
+              - name: LOG_LEVEL
+                value: "info"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /gluetun-entrypoint
+                      - healthcheck
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /gluetun-entrypoint
+                      - healthcheck
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 1000m
+                memory: 256Mi
+            # CRITICAL: Gluetun needs NET_ADMIN to create WireGuard interface
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+              readOnlyRootFilesystem: false  # Gluetun needs to write to /tmp and /gluetun
+    defaultPodOptions:
+      # Pod-level security
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      # Annotations
+      annotations:
+        reloader.stakater.com/auto: "true"
+    persistence:
+      # Mount WireGuard config from secret
+      wireguard-config:
+        enabled: true
+        type: secret
+        name: surfshark-wireguard
+        globalMounts:
+          - path: /gluetun/wireguard/wg0.conf
+            subPath: wg0.conf
+            readOnly: true
+    service:
+      app:
+        controller: vpn-gateway
+        # Note: This service is for monitoring/health checks
+        # Pods will use Gluetun by sharing network namespace
+        ports:
+          http:
+            port: 8000  # Gluetun control server
+            protocol: TCP

--- a/kubernetes/apps/network/vpn-gateway/app/helmrepository.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bjw-s
+  namespace: network
+spec:
+  interval: 1h
+  url: https://bjw-s-labs.github.io/helm-charts

--- a/kubernetes/apps/network/vpn-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/vpn-gateway/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/network/vpn-gateway/ks.yaml
+++ b/kubernetes/apps/network/vpn-gateway/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vpn-gateway
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/network/vpn-gateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: vpn-gateway
+      namespace: network


### PR DESCRIPTION
## Summary

Deploy Gluetun as shared VPN gateway infrastructure to route pod egress traffic through Surfshark VPN using WireGuard protocol.

## Motivation

Need to route certain workloads' outbound internet traffic through VPN for privacy and security:
- Home Assistant (current)
- qBittorrent (future)
- Ark game servers (future)
- Other privacy-sensitive workloads

Rather than configuring each application individually, deploy a shared VPN gateway that pods can transparently route through.

## Architecture

### Shared Network Namespace Pattern

```
┌─────────────────┐
│  Home Assistant │──┐
└─────────────────┘  │
                     │  Share Network Namespace
┌─────────────────┐  │  (shareProcessNamespace)
│   qBittorrent   │──┤
└─────────────────┘  │
                     │
┌─────────────────┐  │    ┌──────────────┐    ┌───────────┐
│   Ark Server    │──┼───▶│ Gluetun Pod  │───▶│ Surfshark │───▶ Internet
└─────────────────┘  │    │  (VPN GW)    │    │    VPN    │
                     │    └──────────────┘    └───────────┘
                     │
     [Other Pods]────┘
```

Pods join Gluetun's network namespace → All traffic routes through VPN tunnel → No application changes needed

### Components

**Gluetun Container**: `ghcr.io/qdm12/gluetun:v3.39.1`
- Lightweight VPN client supporting WireGuard
- Built-in healthcheck and control server
- Requires NET_ADMIN capability to create WireGuard interface

**WireGuard Configuration**:
- Protocol: WireGuard (modern, fast, secure)
- Provider: Surfshark VPN (commercial provider)
- Config source: 1Password item "Surfshark VPN" via ExternalSecret
- Mount: `/gluetun/wireguard/wg0.conf` (read-only)

**Deployment Strategy**:
- Recreate (only one VPN gateway instance at a time)
- Single replica (stateful VPN connection)
- Liveness/readiness probes using Gluetun healthcheck

## Files Changed

```
kubernetes/apps/network/vpn-gateway/
├── app/
│   ├── externalsecret.yaml      # 1Password → Kubernetes Secret
│   ├── helmrelease.yaml         # Gluetun deployment
│   ├── helmrepository.yaml      # bjw-s chart repo
│   └── kustomization.yaml       # Resource aggregation
└── ks.yaml                      # Flux Kustomization

kubernetes/apps/network/kustomization.yaml  # +vpn-gateway reference
```

**Total**: 6 files changed, 166 additions

## Security

### Security Review: APPROVED ✅

security-guardian agent performed comprehensive review:
- ✅ No plaintext secrets or credentials
- ✅ All secrets managed via ExternalSecret + 1Password
- ✅ NET_ADMIN capability justified and properly scoped
- ✅ No sensitive infrastructure details exposed
- ✅ Container image from trusted source (qdm12/gluetun)
- ✅ Resource limits prevent exhaustion attacks
- ✅ Seccomp RuntimeDefault profile applied

### Security Posture

**Privileged Requirements** (justified):
- `NET_ADMIN` capability: Required to create WireGuard interface
- `readOnlyRootFilesystem: false`: Gluetun needs write access to `/tmp` and `/gluetun`

**Hardening Applied**:
- Pod-level seccomp profile: `RuntimeDefault`
- Pod-level fsGroup: 1000 (restrict file ownership)
- WireGuard config mounted read-only
- Resource limits: CPU 1000m, Memory 256Mi
- Recreate strategy for clean state
- Health checks prevent zombie pods

**Secret Management**:
- WireGuard config in 1Password (not in git)
- ExternalSecret syncs to Kubernetes Secret
- 5-minute refresh interval
- Retain deletion policy (prevents accidental loss)

## Testing Plan

After Flux deploys (post-merge):

### 1. Verify Deployment
```bash
# Check pod status
kubectl get pods -n network -l app.kubernetes.io/name=vpn-gateway

# Check logs
kubectl logs -n network -l app.kubernetes.io/name=vpn-gateway --tail=50

# Verify WireGuard tunnel
kubectl logs -n network -l app.kubernetes.io/name=vpn-gateway | grep -i "wireguard\|tunnel\|connected"
```

### 2. Verify Secret Sync
```bash
# Check ExternalSecret
kubectl get externalsecret -n network surfshark-wireguard

# Check generated Secret
kubectl get secret -n network surfshark-wireguard
kubectl get secret -n network surfshark-wireguard -o jsonpath='{.data.wg0\.conf}' | base64 -d | head -5
```

### 3. Test VPN Connectivity
```bash
# Check Gluetun healthcheck
kubectl exec -n network -l app.kubernetes.io/name=vpn-gateway -- /gluetun-entrypoint healthcheck

# Check public IP (should be Surfshark exit node)
kubectl exec -n network -l app.kubernetes.io/name=vpn-gateway -- wget -qO- ifconfig.me

# Verify WireGuard interface exists
kubectl exec -n network -l app.kubernetes.io/name=vpn-gateway -- ip addr show wg0
```

### 4. Future: Integrate Home Assistant

After VPN gateway validated, modify Home Assistant deployment:
```yaml
# kubernetes/apps/iot/home-assistant/app/helmrelease.yaml
spec:
  values:
    defaultPodOptions:
      shareProcessNamespace: true
    controllers:
      home-assistant:
        containers:
          app:
            # ... existing config ...
          vpn:
            image:
              repository: ghcr.io/qdm12/gluetun
              tag: v3.39.1
            # Network namespace sharing pattern
```

Then verify Home Assistant traffic routes through VPN:
```bash
# Get Home Assistant pod name
kubectl get pods -n iot -l app.kubernetes.io/name=home-assistant

# Check public IP from Home Assistant container
kubectl exec -n iot <pod-name> -c home-assistant -- wget -qO- ifconfig.me
# Should match Surfshark exit node IP
```

## Dependencies

**Required**:
- ExternalSecrets Operator (already deployed)
- 1Password Connect (already deployed)
- 1Password item "Surfshark VPN" with `config` property containing WireGuard config

**Chart**:
- bjw-s/app-template v4.4.0

## Flux Deployment

After merge, Flux will:
1. Reconcile `network` kustomization (1h interval)
2. Apply `vpn-gateway` Kustomization
3. Sync ExternalSecret from 1Password
4. Deploy HelmRelease
5. Wait for health checks to pass

Force immediate reconciliation:
```bash
flux reconcile kustomization network --with-source
```

## Future Work

1. **Integrate Home Assistant** (STORY-027 continuation)
   - Modify Home Assistant HelmRelease
   - Add Gluetun sidecar with network namespace sharing
   - Verify traffic routes through VPN

2. **Add qBittorrent** (future story)
   - Deploy qBittorrent with VPN routing
   - Use VPN kill switch to prevent leaks

3. **Add Ark Game Servers** (future story)
   - Route Ark server traffic through VPN
   - Prevents ISP throttling of game traffic

4. **NetworkPolicy** (optional hardening)
   - Restrict which pods can access vpn-gateway service
   - Allowlist only authorized namespaces

5. **Monitoring** (nice-to-have)
   - Add ServiceMonitor for Prometheus
   - Track VPN uptime, connection drops, bandwidth

## Related Stories

- STORY-027: VPN Gateway for Privacy-Sensitive Workloads
- STORY-023: Home Assistant Deployment (completed)
- STORY-024: Internal DNS Automation (completed)

## References

- Gluetun: https://github.com/qdm12/gluetun
- WireGuard: https://www.wireguard.com/
- bjw-s app-template: https://bjw-s.github.io/helm-charts/docs/app-template/

---

**Security Review**: ✅ Approved by security-guardian
**GitOps Workflow**: ✅ Followed (no direct cluster deployment)
**Ready for Merge**: ✅ Yes