### PR TITLE
feat(network): Deploy Gluetun VPN Gateway with Surfshark WireGuard (STORY-024)

### DIFF
--- a/kubernetes/apps/network/gluetun/app/externalsecret.yaml
+++ b/kubernetes/apps/network/gluetun/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gluetun-surfshark-credentials
+  namespace: network
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gluetun-surfshark-credentials
+    creationPolicy: Owner
+  refreshInterval: 1h
+  data:
+    - secretKey: WIREGUARD_PRIVATE_KEY
+      remoteRef:
+        key: surfshark_wireguard
+        property: WIREGUARD_PRIVATE_KEY
+    - secretKey: WIREGUARD_ADDRESSES
+      remoteRef:
+        key: surfshark_wireguard
+        property: WIREGUARD_ADDRESSES

--- a/kubernetes/apps/network/gluetun/app/helmrelease.yaml
+++ b/kubernetes/apps/network/gluetun/app/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gluetun
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gluetun
+  interval: 1h
+  values:
+    controllers:
+      gluetun:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/qdm12/gluetun
+              tag: v3.39.1
+            env:
+              # VPN Provider Configuration
+              - name: VPN_SERVICE_PROVIDER
+                value: "custom"
+              - name: VPN_TYPE
+                value: "wireguard"
+
+              # HTTP Proxy Configuration (CRITICAL)
+              - name: HTTPPROXY
+                value: "on"
+              - name: HTTPPROXY_LOG
+                value: "on"
+
+              # Firewall Kill Switch (CRITICAL)
+              - name: FIREWALL
+                value: "on"
+              - name: FIREWALL_VPN_INPUT_PORTS
+                value: "8888,8388,8000"
+              - name: FIREWALL_OUTBOUND_SUBNETS
+                value: ""
+
+              # Logging
+              - name: LOG_LEVEL
+                value: "info"
+              - name: TZ
+                value: "America/New_York"
+
+            # Credentials from 1Password via ExternalSecret
+            envFrom:
+              - secretRef:
+                  name: gluetun-surfshark-credentials
+
+            # Security Context (from security-guardian review)
+            securityContext:
+              capabilities:
+                drop: [ALL]
+                add: [NET_ADMIN]  # Required for WireGuard
+              seccompProfile:
+                type: RuntimeDefault
+              readOnlyRootFilesystem: false  # Gluetun needs /tmp
+              runAsNonRoot: false  # Gluetun requires root
+
+            # Resource Limits
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+
+            # Probes
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/openvpn/status
+                    port: &controlPort 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/openvpn/status
+                    port: *controlPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+
+    # Service Configuration
+    service:
+      app:
+        controller: gluetun
+        ports:
+          http-proxy:
+            port: 8888  # HTTP proxy (primary)
+            protocol: TCP
+          socks-proxy:
+            port: 8388  # SOCKS5 proxy (future)
+            protocol: TCP
+          control:
+            port: *controlPort  # Gluetun control server
+            protocol: TCP

--- a/kubernetes/apps/network/gluetun/app/kustomization.yaml
+++ b/kubernetes/apps/network/gluetun/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/gluetun/app/ocirepository.yaml
+++ b/kubernetes/apps/network/gluetun/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gluetun
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/gluetun/ks.yaml
+++ b/kubernetes/apps/network/gluetun/ks.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gluetun
+  namespace: flux-system
+spec:
+  targetNamespace: network
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/network/gluetun/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: gluetun
+      namespace: network

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./cloudflare-dns/ks.yaml
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml
+  - ./gluetun/ks.yaml
   - ./k8s-gateway/ks.yaml
   - ./network-attachments/ks.yaml
   - ./unifi-dns/ks.yaml


### PR DESCRIPTION
## Summary

Deploys **Gluetun** as a standalone VPN gateway service in the `network` namespace, providing HTTP proxy capabilities for routing Home Assistant outbound traffic through Surfshark VPN.

This is the foundation for **EPIC-013: VPN Egress for IoT Services** and implements the security-approved service-based routing architecture (NOT `shareProcessNamespace`).

---

## What This PR Does

### New Resources Created

1. **ExternalSecret** (`externalsecret.yaml`)
   - Syncs Surfshark WireGuard credentials from 1Password
   - Keys: `WIREGUARD_PRIVATE_KEY`, `WIREGUARD_ADDRESSES`
   - Secret name: `gluetun-surfshark-credentials`

2. **Gluetun HelmRelease** (`helmrelease.yaml`)
   - Deploys Gluetun container with Surfshark WireGuard backend
   - **HTTP Proxy**: Port 8888 (primary feature for routing app traffic)
   - **SOCKS5 Proxy**: Port 8388 (future use)
   - **Control API**: Port 8000 (monitoring)
   - **Firewall Kill-Switch**: Layer 1 protection (blocks all non-VPN traffic)

3. **Supporting Manifests**
   - `ocirepository.yaml`: bjw-s app-template chart reference
   - `kustomization.yaml`: Resource aggregation
   - `ks.yaml`: Flux Kustomization for deployment

4. **Modified**: `kubernetes/apps/network/kustomization.yaml` - Added Gluetun to network namespace

---

## Architecture

### Service-Based Routing Pattern

```
┌─────────────────────────────────────────────────────────┐
│            Home Assistant Pod (Future Work)             │
│                                                         │
│  Proxy Config:                                          │
│  - HTTP_PROXY=http://gluetun.network.svc:8888          │
│  - HTTPS_PROXY=http://gluetun.network.svc:8888         │
│  - NO_PROXY=localhost,127.0.0.1,10.20.62.0/23,...      │
│                                                         │
└──────────────────┬──────────────────────────────────────┘
                   │
                   │ HTTP Proxy Request
                   ▼
        ┌──────────────────────────┐
        │   Gluetun Service        │
        │   (network namespace)    │
        │                          │
        │  Port 8888: HTTP Proxy   │
        │  Port 8388: SOCKS5       │
        │  Port 8000: Control API  │
        └──────────┬───────────────┘
                   │
                   │ VPN Tunnel
                   ▼
        ┌──────────────────────────┐
        │  Surfshark WireGuard     │
        │  Exit Node               │
        │  (Public Internet)       │
        └──────────────────────────┘
```

**Why NOT `shareProcessNamespace`**: That only shares `/proc` visibility, NOT network routing. This approach uses Gluetun's built-in HTTP proxy service, which is the correct method for routing application traffic.

---

## Security Posture

### ✅ Security Review: APPROVED

**Reviewed by**: security-guardian agent  
**Status**: APPROVED ✅ (0 vulnerabilities, 0 required changes)  
**Risk Level**: LOW

### Security Controls

1. **ExternalSecret Pattern**: Credentials from 1Password (no plaintext in Git)
2. **Firewall Kill-Switch**: `FIREWALL=on` blocks all non-VPN traffic (Layer 1)
3. **Security Context**:
   - `capabilities.drop: [ALL]` (drop all capabilities)
   - `capabilities.add: [NET_ADMIN]` (required for WireGuard interface)
   - `seccompProfile.type: RuntimeDefault` (syscall filtering)
   - `readOnlyRootFilesystem: false` (Gluetun needs /tmp writes)
   - `runAsNonRoot: false` (Gluetun requires root for networking)
4. **Resource Limits**: Prevents resource exhaustion
5. **No Namespace Sharing**: Isolated pod (no shareProcessNamespace)

### Security Trade-offs (Accepted)

- **Root Required**: Gluetun needs root for WireGuard interface creation
- **NET_ADMIN Capability**: Required for network interface manipulation
- **Read-Write Filesystem**: Gluetun writes to /tmp for state tracking

All trade-offs are **justified** and **necessary** for VPN functionality. Security is hardened through firewall kill-switch, capability dropping, seccomp profile, and resource limits.

---

## Testing Plan

### Post-Merge Validation (WI-024-6)

After this PR is merged and Flux deploys Gluetun:

1. **Verify Pod Running**:
   ```bash
   kubectl get pods -n network -l app.kubernetes.io/name=gluetun
   # Expected: Running
   ```

2. **Check VPN Connection**:
   ```bash
   kubectl logs -n network -l app.kubernetes.io/name=gluetun | grep "connected"
   # Expected: WireGuard connected to Surfshark
   ```

3. **Verify External IP**:
   ```bash
   kubectl exec -n network -l app.kubernetes.io/name=gluetun -- curl -s ifconfig.me
   # Expected: Surfshark exit node IP (NOT homelab IP)
   ```

4. **Test HTTP Proxy**:
   ```bash
   kubectl run test-proxy --rm -it --image=curlimages/curl --restart=Never -- \
     curl -x http://gluetun.network.svc.cluster.local:8888 -s ifconfig.me
   # Expected: Surfshark exit node IP
   ```

5. **Check Control API**:
   ```bash
   kubectl exec -n network -l app.kubernetes.io/name=gluetun -- curl -s localhost:8000/v1/openvpn/status
   # Expected: JSON status response
   ```

---

## Epic Context

**Epic**: EPIC-013: VPN Egress for IoT Services  
**Story**: STORY-024: Deploy Gluetun VPN Gateway  
**Work Items Completed**: WI-024-1 through WI-024-5  
**Next Work Item**: WI-024-6 (Deployment Validation - after PR merge)

### Epic Progress

- ✅ **Phase 1**: Gluetun Deployment (this PR)
- ⏳ **Phase 2**: Home Assistant HTTP Proxy Configuration (STORY-025)
- ⏳ **Phase 3**: VPN Kill-Switch NetworkPolicy (STORY-026)
- ⏳ **Phase 4**: VPN Monitoring (STORY-027)
- ⏳ **Phase 5**: Documentation (STORY-028)

---

## Dependencies

**Required**:
- 1Password Connect deployed and functional
- 1Password item: `surfshark_wireguard` with keys:
  - `WIREGUARD_PRIVATE_KEY`
  - `WIREGUARD_ADDRESSES`
- bjw-s app-template chart accessible at `ghcr.io/bjw-s-labs/helm/app-template:4.4.0`

**Blocks**:
- STORY-025: Configure Home Assistant HTTP Proxy (needs Gluetun service running)
- STORY-026: Implement VPN Kill-Switch NetworkPolicy (needs proxy working)

---

## Rollback Plan

If issues arise:

1. **Disable Flux Kustomization**:
   ```bash
   flux suspend kustomization gluetun -n flux-system
   ```

2. **Delete Gluetun Resources**:
   ```bash
   kubectl delete helmrelease gluetun -n network
   kubectl delete externalsecret gluetun-surfshark-credentials -n network
   ```

3. **Revert Git Changes**: Merge revert PR

**No Impact**: Home Assistant does NOT yet use Gluetun proxy, so disabling Gluetun has zero impact on running services.

---

## Related Documentation

- **Epic**: `.claude/.ai-docs/epics/EPIC-013-vpn-egress-iot-services.md`
- **Story**: `.claude/.ai-docs/stories/STORY-024-deploy-gluetun-vpn-gateway.md`
- **Work Item Tracking**: `.claude/.ai-docs/stories/EPIC-013-WI-TRACKING.md`
- **Home Assistant Future State**: `.claude/.ai-docs/apps/home-assistant/FUTURE-STATE.md`

---

## Checklist

- [x] Security review completed (security-guardian APPROVED)
- [x] No plaintext secrets in Git
- [x] ExternalSecret configured with 1Password
- [x] Gluetun firewall kill-switch enabled (`FIREWALL=on`)
- [x] Resource limits defined
- [x] Security context hardened (NET_ADMIN justified)
- [x] Flux Kustomization health checks configured
- [x] Documentation updated
- [ ] User merges PR
- [ ] Flux deploys Gluetun
- [ ] WI-024-6 validation executed

---