### PR TITLE
fix(network): Add missing namespace to Gluetun GitRepository sourceRef

### DIFF
--- a/kubernetes/apps/network/gluetun/ks.yaml
+++ b/kubernetes/apps/network/gluetun/ks.yaml
@@ -14,6 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+    namespace: flux-system
   wait: true
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Problem

PR #40 deployed Gluetun but it fails to reconcile with error:

```
GitRepository.source.toolkit.fluxcd.io "flux-system" not found
```

## Root Cause

The Gluetun Kustomization in `kubernetes/apps/network/gluetun/ks.yaml` is missing the `namespace` field in the `sourceRef`:

```yaml
sourceRef:
  kind: GitRepository
  name: flux-system
  # ← Missing: namespace: flux-system
```

Because the Kustomization is created in the `network` namespace (by the parent), it looks for the GitRepository in the `network` namespace, not `flux-system`.

## Fix

Added `namespace: flux-system` to sourceRef, matching the pattern used by all other network services:

```yaml
sourceRef:
  kind: GitRepository
  name: flux-system
  namespace: flux-system  # ← Added this line
```

## Testing

After merge, Gluetun Kustomization will reconcile and deploy Gluetun pod.

Validation:
```bash
# Check Kustomization reconciles
flux get kustomizations -n network gluetun

# Check pod deploys
kubectl get pods -n network -l app.kubernetes.io/name=gluetun
```

## Impact

**Current State**: Gluetun cannot deploy (blocking STORY-024 WI-024-6)  
**After Fix**: Gluetun will deploy successfully

This is a **critical hotfix** blocking VPN epic progress.

---