### PR TITLE
fix(network): Update Gluetun ExternalSecret to use existing Surfshark VPN item

### DIFF
--- a/kubernetes/apps/network/gluetun/app/externalsecret.yaml
+++ b/kubernetes/apps/network/gluetun/app/externalsecret.yaml
@@ -15,9 +15,9 @@ spec:
   data:
     - secretKey: WIREGUARD_PRIVATE_KEY
       remoteRef:
-        key: surfshark_wireguard
+        key: Surfshark VPN
         property: WIREGUARD_PRIVATE_KEY
     - secretKey: WIREGUARD_ADDRESSES
       remoteRef:
-        key: surfshark_wireguard
+        key: Surfshark VPN
         property: WIREGUARD_ADDRESSES


### PR DESCRIPTION
## Problem

Gluetun ExternalSecret is failing to sync from 1Password with error:

```
key not found in 1Password Vaults: surfshark_wireguard in: map[Automation:1]
```

## Root Cause

The ExternalSecret references a non-existent 1Password item `surfshark_wireguard`. The actual item in the Automation vault is named `Surfshark VPN`.

## Fix

Updated ExternalSecret to reference the correct 1Password item:

```yaml
# Before
remoteRef:
  key: surfshark_wireguard

# After
remoteRef:
  key: Surfshark VPN
```

User confirmed the `Surfshark VPN` item exists with required fields:
- `WIREGUARD_PRIVATE_KEY`
- `WIREGUARD_ADDRESSES`

## Impact

**Current State**: Gluetun pod cannot start (CreateContainerConfigError)  
**After Fix**: ExternalSecret will sync successfully, Gluetun will connect to Surfshark VPN

## Testing

After merge, validate:

```bash
# Wait ~60s for ExternalSecret to sync
kubectl get externalsecret -n network gluetun-surfshark-credentials
# Expected: READY: True

# Verify Gluetun pod starts
kubectl get pods -n network -l app.kubernetes.io/name=gluetun
# Expected: STATUS: Running

# Check VPN connection
kubectl logs -n network -l app.kubernetes.io/name=gluetun --tail=50
# Expected: "connected" or "WireGuard tunnel established"
```

## Security

✅ security-guardian APPROVED
- No plaintext secrets added
- Only configuration reference updated
- Safe for public repository
- Risk Level: MINIMAL

## Related

- PR #40: Initial Gluetun deployment
- PR #41: GitRepository namespace fix
- STORY-024 WI-024-6: Blocked on this fix