### PR TITLE
fix(network): set Gluetun PUID/PGID to remain as root

### DIFF
--- a/kubernetes/apps/network/gluetun/app/helmrelease.yaml
+++ b/kubernetes/apps/network/gluetun/app/helmrelease.yaml
@@ -55,6 +55,12 @@ spec:
               - name: TZ
                 value: "America/New_York"
 
+              # Process UID/GID (must be root for VPN operations)
+              - name: PUID
+                value: "0"
+              - name: PGID
+                value: "0"
+
             # Credentials from 1Password via ExternalSecret
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary
Configures Gluetun to stay as root by setting PUID=0 and PGID=0 environment variables.

## Changes
- Add PUID=0 environment variable
- Add PGID=0 environment variable

## Problem
Even with runAsUser: 0 in securityContext, Gluetun has built-in user switching that defaults to PUID=1000 and PGID=1000. After starting as root, Gluetun drops privileges to these UIDs, causing 'chown /etc/unbound: operation not permitted' errors.

## Solution
Set PUID=0 and PGID=0 to tell Gluetun to remain as root throughout its lifecycle, which is required for VPN operations (WireGuard interface management, iptables, DNS configuration).

## Security
This change is covered by the security approval from PR #45 where running as root was already approved with proper constraints (capabilities dropped, seccomp profile).

## Testing
- [ ] Verify pod starts without errors
- [ ] Confirm UID 0 in logs (not UID 1000)
- [ ] Test VPN connection
- [ ] Test HTTP proxy

## Related
Resolves: WI-024-6  
Story: STORY-024 (EPIC-013)