### PR TITLE
fix(network): update Gluetun probes for WireGuard VPN type

### DIFF
--- a/kubernetes/apps/network/gluetun/app/helmrelease.yaml
+++ b/kubernetes/apps/network/gluetun/app/helmrelease.yaml
@@ -94,7 +94,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /v1/openvpn/status
+                    path: /v1/publicip/ip
                     port: &controlPort 8000
                   initialDelaySeconds: 30
                   periodSeconds: 30
@@ -105,7 +105,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /v1/openvpn/status
+                    path: /v1/publicip/ip
                     port: *controlPort
                   initialDelaySeconds: 15
                   periodSeconds: 10


### PR DESCRIPTION
## Summary
Fixes Gluetun pod readiness probe failures when using WireGuard VPN.

## Problem
Pod shows 0/1 Ready despite VPN being healthy and connected:
- Probes check `/v1/openvpn/status` which returns `{"status":"stopped"}` for WireGuard
- This causes Kubernetes to mark the pod as not ready even though VPN is working
- Logs show: `Public IP address is 185.141.119.99 (United States, Michigan, Detroit)`
- Healthcheck shows: `[healthcheck] healthy!`

## Root Cause
The liveness and readiness probes use the OpenVPN status endpoint, but we're running WireGuard VPN. OpenVPN and WireGuard use different status APIs.

## Changes
- Updated both probes to use `/v1/publicip/ip` endpoint instead of `/v1/openvpn/status`
- This endpoint works for both OpenVPN and WireGuard
- Returns VPN public IP when connected, 4xx/5xx when disconnected

## Testing
Verified `/v1/publicip/ip` returns valid response:
```json
{
  "public_ip":"185.141.119.99",
  "region":"Michigan",
  "country":"United States",
  "city":"Detroit"
}
```

## Expected Result
- Pod should transition to 1/1 Ready after merge
- Probes correctly detect VPN connectivity state
- No impact on existing functionality

Related: WI-024-6 (STORY-024: Deploy Gluetun VPN Gateway)