### PR TITLE
fix(network): allow Gluetun control port for Kubernetes probes

### DIFF
--- a/kubernetes/apps/network/gluetun/app/helmrelease.yaml
+++ b/kubernetes/apps/network/gluetun/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               - name: FIREWALL_OUTBOUND_SUBNETS
                 value: "10.43.0.0/16"
               - name: FIREWALL_INPUT_PORTS
-                value: ""
+                value: "8000"  # Allow Kubernetes probes to control server
               - name: DISABLE_IPV6
                 value: "yes"
 


### PR DESCRIPTION
## Summary
Fixes Kubernetes probe timeouts by allowing port 8000 access on the pod network interface (eth0).

## Problem
After PR #49 changed probes to use `/v1/publicip/ip`, pods still fail to become Ready:
```
Readiness probe failed: Get "http://10.42.11.124:8000/v1/publicip/ip": context deadline exceeded
Liveness probe failed: Get "http://10.42.11.124:8000/v1/publicip/ip": context deadline exceeded
```

Root cause: Gluetun's internal firewall only allows port 8000 through the VPN interface (tun0) via `FIREWALL_VPN_INPUT_PORTS`, but Kubernetes probes originate from the pod network (eth0).

## Changes
- Set `FIREWALL_INPUT_PORTS=8000` to allow port 8000 on all interfaces including eth0
- Maintains VPN kill-switch functionality (outbound filtering unchanged)
- Enables Kubernetes probes to reach control server for health checks

## Security
Reviewed and approved by security-guardian agent:
- VPN kill-switch preserved (FIREWALL_OUTBOUND_SUBNETS still enforces routing)
- Port 8000 protected by NetworkPolicy (only network namespace allowed)
- Service remains ClusterIP (not externally exposed)
- Defense-in-depth maintained: Firewall + NetworkPolicy + Service type

## Testing
- [ ] Verify pod transitions to 1/1 Ready
- [ ] Confirm probes succeed without timeout
- [ ] Test VPN kill-switch still enforces tunnel routing
- [ ] Validate control API accessible only from network namespace

Resolves: WI-024-6 (STORY-024: Deploy Gluetun VPN Gateway)