### PR TITLE
fix(network): allow Gluetun proxy ports in NetworkPolicy ingress

### DIFF
--- a/kubernetes/apps/network/gluetun/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/gluetun/app/networkpolicy.yaml
@@ -21,8 +21,11 @@ spec:
               kubernetes.io/metadata.name: network
       ports:
         - protocol: TCP
-          port: 8000  # Control server (if enabled)
-        # Add application ports here as needed (e.g., qBittorrent, Prowlarr)
+          port: 8000  # Control server
+        - protocol: TCP
+          port: 8888  # HTTP proxy
+        - protocol: TCP
+          port: 8388  # SOCKS5 proxy
 
   # Egress: Allow VPN connection + Kubernetes DNS + tunneled traffic
   egress:


### PR DESCRIPTION
## Summary
Adds HTTP proxy (8888) and SOCKS5 proxy (8388) ports to NetworkPolicy ingress rules to allow pods to use Gluetun as VPN gateway.

## Problem
Pods in the `network` namespace cannot access Gluetun proxy ports due to NetworkPolicy ingress restrictions. Currently only port 8000 (control server) is allowed, blocking legitimate proxy traffic.

Testing showed:
- Connection to port 8888 times out
- NetworkPolicy only allows control server port (8000)
- Proxy functionality unavailable to other pods

## Changes
Added two ingress ports to NetworkPolicy:
- Port 8888 (HTTP proxy)
- Port 8388 (SOCKS5 proxy)

Ingress remains restricted to `network` namespace only via namespaceSelector.

## Security
Reviewed and approved by security-guardian agent:
- Namespace-level isolation maintained (only network namespace)
- Service remains ClusterIP (no external exposure)
- Gluetun firewall provides additional layer (FIREWALL_VPN_INPUT_PORTS)
- Defense-in-depth preserved: NetworkPolicy + Firewall + Service type
- Explicit port allowlist (not blanket allow)

## Testing
- [ ] Verify pods can connect to proxy ports from network namespace
- [ ] Test HTTP proxy returns VPN exit IP
- [ ] Confirm cross-namespace access still blocked
- [ ] Validate VPN kill-switch functionality

Resolves: WI-024-6 (STORY-024: Deploy Gluetun VPN Gateway)