### PR TITLE
fix(network): allow Gluetun proxy ports on pod network interface

### DIFF
--- a/kubernetes/apps/network/gluetun/app/helmrelease.yaml
+++ b/kubernetes/apps/network/gluetun/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               - name: FIREWALL_OUTBOUND_SUBNETS
                 value: "10.43.0.0/16"
               - name: FIREWALL_INPUT_PORTS
-                value: "8000"  # Allow Kubernetes probes to control server
+                value: "8000,8888,8388"  # Allow probes and proxy access from pod network
               - name: DISABLE_IPV6
                 value: "yes"
 


### PR DESCRIPTION
## Summary
Adds HTTP proxy (8888) and SOCKS5 proxy (8388) ports to Gluetun's FIREWALL_INPUT_PORTS to allow pods to connect to proxy services.

## Problem
After PR #51 added NetworkPolicy ingress rules for proxy ports, proxy connections still timeout. Testing shows:
- NetworkPolicy allows ingress to ports 8888/8388
- Gluetun firewall blocks connections to these ports on eth0
- `FIREWALL_INPUT_PORTS=8000` (only control server allowed)
- `FIREWALL_VPN_INPUT_PORTS=8888,8388,8000` (proxy only on VPN interface)

Result: Configuration mismatch - NetworkPolicy allows traffic but Gluetun firewall blocks it.

## Root Cause
Gluetun's internal firewall has separate configuration for:
- `FIREWALL_INPUT_PORTS`: Ports allowed on pod network interface (eth0)
- `FIREWALL_VPN_INPUT_PORTS`: Ports allowed on VPN interface (tun0)

We only added port 8000 to FIREWALL_INPUT_PORTS in PR #50 (for health probes), but proxy ports 8888/8388 were missing.

## Changes
Changed `FIREWALL_INPUT_PORTS` from `"8000"` to `"8000,8888,8388"`.

This allows:
- Port 8000: Control server (for Kubernetes probes)
- Port 8888: HTTP proxy (for pod-to-pod VPN routing)
- Port 8388: SOCKS5 proxy (for future use)

## Security
Reviewed and approved by security-guardian agent:
- VPN kill-switch intact (egress firewall unchanged)
- NetworkPolicy still restricts to network namespace only
- Defense-in-depth maintained (NetworkPolicy + Gluetun firewall + Service)
- No secrets exposed
- Configuration now consistent across all security layers

## Testing
- [ ] Verify pods can connect to proxy: `curl -x http://gluetun:8888 https://ifconfig.me`
- [ ] Confirm VPN IP returned (not real IP)
- [ ] Validate VPN kill-switch still enforces routing
- [ ] Confirm cross-namespace access still blocked

Resolves: WI-024-6 (STORY-024: Deploy Gluetun VPN Gateway)