### PR TITLE
feat(media): add Plex namespace and NFS ExternalSecret configuration

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./plex/ks.yaml

--- a/kubernetes/apps/media/namespace.yaml
+++ b/kubernetes/apps/media/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media
+  labels:
+    kubernetes.io/metadata.name: media
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nfs-externalsecret.yaml

--- a/kubernetes/apps/media/plex/app/nfs-externalsecret.yaml
+++ b/kubernetes/apps/media/plex/app/nfs-externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: plex-nfs-config
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: plex-nfs-config
+    creationPolicy: Owner
+  data:
+    - secretKey: server
+      remoteRef:
+        key: plex-nfs-storage
+        property: server
+    - secretKey: path
+      remoteRef:
+        key: plex-nfs-storage
+        property: path

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plex
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/plex/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false


### PR DESCRIPTION
## Summary
Implements WI-029-1 to set up NFS configuration for Plex using the ExternalSecret pattern, integrating with 1Password for secure credential management.

## Changes
- Created media namespace with restricted Pod Security Standards
- Added Plex application directory structure following GitOps conventions
- Implemented ExternalSecret to fetch NFS server and path from 1Password item `plex-nfs-storage`
- Configured Flux Kustomization for automatic deployment

## Dependencies
- 1Password Connect already deployed
- ClusterSecretStore `onepassword-connect` configured
- 1Password item `plex-nfs-storage` created with `server` and `path` fields
- NAS firewall configured to allow GPU node IPs (10.20.67.7, 10.20.67.13)

## Testing Plan
After merge and Flux reconciliation:
- [ ] Verify ExternalSecret syncs successfully
- [ ] Confirm secret `plex-nfs-config` created in media namespace
- [ ] Test NFS mount from GPU node using test pod
- [ ] Create PV/PVC manifests after successful test

## Notes
This is Phase 1 of Plex deployment. PV/PVC manifests will be added in a follow-up PR after NFS connectivity is verified.