### PR TITLE
feat(media): add PersistentVolume and PVCs for Plex storage

### DIFF
--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -3,3 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./nfs-externalsecret.yaml
+  - ./nfs-pv.yaml
+  - ./nfs-pvc.yaml
+  - ./storage-pvcs.yaml

--- a/kubernetes/apps/media/plex/app/nfs-pv.yaml
+++ b/kubernetes/apps/media/plex/app/nfs-pv.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: plex-media-nfs
+spec:
+  capacity:
+    storage: 50Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+    - noatime
+    - ro
+  nfs:
+    server: 10.20.66.11
+    path: /mnt/Heimdall/Media
+    readOnly: true

--- a/kubernetes/apps/media/plex/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/plex/app/nfs-pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-media
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: plex-media-nfs
+  resources:
+    requests:
+      storage: 50Ti

--- a/kubernetes/apps/media/plex/app/storage-pvcs.yaml
+++ b/kubernetes/apps/media/plex/app/storage-pvcs.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-transcode
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## Summary
Implements storage layer for Plex deployment by creating NFS PersistentVolume for media library and Rook-Ceph PVCs for config and transcode storage.

## Changes
- Create NFS PersistentVolume `plex-media-nfs` (50Ti capacity, read-only)
  - Mounts from NFS server 10.20.66.11:/mnt/Heimdall/Media
  - Read-only access mode for media consumption
  - ReadWriteMany (RWX) for multi-pod access
- Add NFS PVC `plex-media` binding to static PV
- Create Rook-Ceph PVC `plex-config` (100Gi) for Plex database and metadata
- Create Rook-Ceph PVC `plex-transcode` (50Gi) for temporary transcoding files
- Update kustomization.yaml to include new storage manifests

## Storage Architecture
| Volume | Type | Size | Access Mode | Purpose |
|--------|------|------|-------------|---------|
| plex-media | NFS PV | 50Ti | RWX | Media library (read-only) |
| plex-config | Rook-Ceph | 100Gi | RWO | Database, metadata, thumbnails |
| plex-transcode | Rook-Ceph | 50Gi | RWO | Temporary transcoding files |

## Dependencies
- NFS server connectivity verified in WI-029-1
- ExternalSecret `plex-nfs-config` already deployed
- Rook-Ceph StorageClass `ceph-block` available

## Testing
After merge, Flux will deploy resources. Verify with:
```bash
kubectl get pv plex-media-nfs
kubectl get pvc -n media plex-media plex-config plex-transcode
kubectl describe pvc -n media plex-media
```

## Notes
- NFS mount configured as read-only since Plex only needs read access to media
- Static PV provisioning used for NFS (no dynamic provisioner)
- Ceph block storage used for config/transcode (requires RWO)
- PV reclaim policy set to Retain to prevent accidental data loss

Related: WI-029-2