### PR TITLE
fix(media): enable read-write NFS access for Plex media management

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -87,6 +87,8 @@ spec:
         runAsNonRoot: true
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 1000  # ubuntu group for NFS media access
         seccompProfile:
           type: RuntimeDefault
     persistence:
@@ -105,7 +107,6 @@ spec:
         existingClaim: plex-media
         globalMounts:
           - path: /data
-            readOnly: true
     service:
       app:
         controller: plex

--- a/kubernetes/apps/media/plex/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/plex/app/networkpolicy.yaml
@@ -51,7 +51,7 @@ spec:
         - matchName: "plex.tv"
         - matchPattern: "*.plex.tv"
         - matchPattern: "*.plex.direct"
-    # Allow NFS server access (read-only media library)
+    # Allow NFS server access (read-write media library for management)
     - toCIDR:
         - 10.20.66.11/32
       toPorts:

--- a/kubernetes/apps/media/plex/app/nfs-pv.sops.yaml
+++ b/kubernetes/apps/media/plex/app/nfs-pv.sops.yaml
@@ -13,11 +13,9 @@ spec:
     - nfsvers=4.2
     - hard
     - noatime
-    - ro
   nfs:
     server: ENC[AES256_GCM,data:Eu+KPsv1nAnlrbo=,iv:i/vUoNYKPX/Hh84hszdIW384eTt3YtTTBIbLVuMUVug=,tag:xsNrbTWbJX0/UGY1Eshz/A==,type:str]
     path: ENC[AES256_GCM,data:sVCRPmpybnrV5VhxLUE93YiK0Q==,iv:XL0pDAR/OF0AthMHeqYhFvdGocfQYplZDb9uDKHCfc4=,tag:oojRWppB7CtEL76mQGoqew==,type:str]
-    readOnly: true
 sops:
   age:
     - recipient: age1metxlry78wefrmm5ny2zjavtucsmdvw2r3ctexu6h05ak4x2vc7qa02drd


### PR DESCRIPTION
## Summary
Enable read-write NFS access for Plex to manage (create/delete) media files on the NFS share.

## Changes
- Add `supplementalGroups: [1000]` to pod security context for NFS file access (ubuntu group)
- Remove `readOnly: true` from HelmRelease media mount configuration
- Remove `ro` mount option from PersistentVolume
- Remove `readOnly: true` from PersistentVolume nfs spec
- Update NetworkPolicy comment to reflect read-write access

## Security Review
✅ Security-guardian reviewed and approved:
- NFS egress restricted to single IP (10.20.66.11/32) and port (2049/TCP)
- Pod maintains non-root execution (UID 568) with seccomp profile
- SOPS-encrypted NFS credentials remain protected
- Network policy provides defense-in-depth isolation
- Safe for public repository (no sensitive data exposed)

## Testing
After merge, verify with:
```bash
# Verify pod has supplementalGroups
kubectl -n media get pod -l app.kubernetes.io/name=plex -o jsonpath='{.items[0].spec.securityContext.supplementalGroups}'

# Test write access
kubectl exec -n media deploy/plex -- touch /data/test-write.txt
kubectl exec -n media deploy/plex -- rm /data/test-write.txt

# Check NFS mount options (ro should NOT be present)
kubectl exec -n media deploy/plex -- mount | grep /data
```

## Fixes
Resolves permission denied error when accessing NFS media files at `/data`