### PR TITLE
fix(media): require RTX A2000 GPU node for Plex transcoding

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -70,10 +70,9 @@ spec:
         nvidia.com/gpu.present: "true"
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: gpu.nvidia.com/model
                     operator: In
                     values:


### PR DESCRIPTION
## Summary
Change Plex node affinity from preferred to required scheduling for RTX A2000 GPU.

## Changes
- Changed `preferredDuringSchedulingIgnoredDuringExecution` to `requiredDuringSchedulingIgnoredDuringExecution`
- Ensures Plex always schedules on k8s-work-4 (RTX A2000) instead of falling back to k8s-work-14 (RTX A5000)

## Rationale
- Reserves the RTX A2000 specifically for Plex media transcoding
- Prevents scheduling on the more powerful A5000 (reserved for other workloads)
- Plex is currently running on A5000 but should be on A2000

## Testing
- GPU transcoding confirmed working on A5000 (10-11% encoder usage during transcode)
- After PR merge, Flux will reschedule Plex to A2000 node
- Verify GPU transcoding still works on A2000 after migration

## Node Details
- **Current**: k8s-work-14 (RTX A5000, 24GB VRAM)
- **Target**: k8s-work-4 (RTX A2000, 12GB VRAM)