### PR TITLE
feat(ci): add Renovate Bot for automated dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    "helpers:pinGitHubActionDigests",
+    "github>jlengelbrecht/prox-ops//.github/renovate/autoMerge.json5",
+    "github>jlengelbrecht/prox-ops//.github/renovate/customManagers.json5",
+    "github>jlengelbrecht/prox-ops//.github/renovate/groups.json5",
+    "github>jlengelbrecht/prox-ops//.github/renovate/semanticCommits.json5",
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dashboard",
+  "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
+  "rebaseWhen": "conflicted",
+  "schedule": ["every weekend"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "flux": {
+    "fileMatch": ["kubernetes/.+\\.ya?ml$"]
+  },
+  "helm-values": {
+    "fileMatch": ["kubernetes/.+\\.ya?ml$"]
+  },
+  "kubernetes": {
+    "fileMatch": ["kubernetes/.+\\.ya?ml$"]
+  },
+  "regexManagers": [
+    {
+      "description": "Process custom dependencies in YAML files",
+      "fileMatch": ["kubernetes/.+\\.ya?ml$"],
+      "matchStrings": [
+        // Match patterns like: tag: 1.2.3 with renovate comment
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"?(?<currentValue>[^\\s\"]+)\"?"
+      ],
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Disable kubernetes-api",
+      "matchDatasources": ["kubernetes-api"],
+      "enabled": false
+    },
+    {
+      "description": "Disable Talos updates (managed via Terraform)",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["ghcr.io/siderolabs/talos", "ghcr.io/siderolabs/installer"],
+      "enabled": false
+    },
+    {
+      "description": "Loose versioning for Plex (extended version format)",
+      "matchDatasources": ["docker"],
+      "versioning": "loose",
+      "matchPackageNames": ["ghcr.io/onedr0p/plex"]
+    },
+    {
+      "description": "Loose versioning for Home Assistant (calendar versioning)",
+      "matchDatasources": ["docker"],
+      "versioning": "loose",
+      "matchPackageNames": ["ghcr.io/home-assistant/home-assistant"]
+    },
+    {
+      "description": "Loose versioning for http-https-echo (single number tags)",
+      "matchDatasources": ["docker"],
+      "versioning": "loose",
+      "matchPackageNames": ["ghcr.io/mendhak/http-https-echo"]
+    }
+  ],
+  "ignorePaths": [
+    "**/*.sops.*",
+    "**/resources/**"
+  ]
+}

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Auto-merge container digests for vetted official images",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "branch",
+      "ignoreTests": true,
+      "matchUpdateTypes": ["digest"],
+      "matchPackageNames": [
+        "ghcr.io/home-assistant/home-assistant",
+        "ghcr.io/controlplaneio-fluxcd/flux-operator",
+        "ghcr.io/controlplaneio-fluxcd/flux-instance",
+        "docker.io/cloudflare/cloudflared",
+        "ghcr.io/coredns/coredns",
+        "mirror.gcr.io/coredns/coredns"
+      ]
+    },
+    {
+      "description": "Auto-merge container digests for trusted maintainers",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "branch",
+      "ignoreTests": true,
+      "matchUpdateTypes": ["digest"],
+      "matchPackageNames": [
+        "ghcr.io/onedr0p/plex",
+        "ghcr.io/qdm12/gluetun",
+        "ghcr.io/spegel-org/spegel",
+        "ghcr.io/stakater/reloader",
+        "ghcr.io/k8snetworkplumbingwg/multus-cni",
+        "ghcr.io/kashalls/external-dns-unifi-webhook"
+      ]
+    },
+    {
+      "description": "Auto-merge patch updates for stable system charts",
+      "matchDatasources": ["helm"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": [
+        "cert-manager",
+        "external-secrets",
+        "metrics-server",
+        "reloader",
+        "spegel"
+      ]
+    },
+    {
+      "description": "Auto-merge GitHub Actions digest updates",
+      "matchDatasources": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["digest"],
+      "ignoreTests": true
+    },
+    {
+      "description": "Require manual review for critical infrastructure",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackagePatterns": [
+        "cilium",
+        "rook",
+        "ceph",
+        "kube-prometheus-stack",
+        "envoy-gateway",
+        "nvidia"
+      ]
+    },
+    {
+      "description": "Require manual review for major and minor updates",
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
+    }
+  ]
+}

--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Process annotated dependencies in YAML files",
+      "fileMatch": [
+        "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?$",
+        "(^|/).+\\.ya?ml(\\.j2)?$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.+?\"?(?<currentValue>[^\\s\"]+)\"?"
+      ],
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Process OCI dependencies in YAML files",
+      "fileMatch": ["(^|/)kubernetes/.+\\.ya?ml(\\.j2)?$"],
+      "matchStrings": [
+        "registryUrl=(?<registryUrl>\\S+)\\n.*?oci:\\/\\/(?<depName>[^:]+):(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Flux Components",
+      "groupName": "Flux",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "^ghcr\\.io\\/controlplaneio-fluxcd\\/.*",
+        "flux-operator",
+        "flux-instance"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} components"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Cilium CNI",
+      "groupName": "Cilium",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["cilium"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} CNI"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Rook-Ceph Storage",
+      "groupName": "Rook-Ceph",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["rook", "ceph"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} storage"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Prometheus Stack (Prometheus + Grafana + AlertManager)",
+      "groupName": "kube-prometheus-stack",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "kube-prometheus-stack",
+        "prometheus",
+        "grafana",
+        "alertmanager"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} monitoring"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Loki Stack (Loki + Promtail)",
+      "groupName": "Loki",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["loki", "promtail"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} logging"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "External Secrets Management",
+      "groupName": "External Secrets",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "external-secrets",
+        "1password-connect",
+        "onepassword"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} management"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Envoy Gateway",
+      "groupName": "Envoy Gateway",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "envoy-gateway",
+        "envoyproxy"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} API"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "External DNS Components",
+      "groupName": "External DNS",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "external-dns",
+        "cloudflare-dns",
+        "unifi-dns"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} components"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "NVIDIA GPU Support",
+      "groupName": "NVIDIA",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "nvidia-device-plugin",
+        "nvidia",
+        "gpu-operator"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} GPU support"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "System Utilities",
+      "groupName": "System Utilities",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackageNames": [
+        "metrics-server",
+        "reloader",
+        "spegel"
+      ],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}}"
+      },
+      "separateMinorPatch": false
+    },
+    {
+      "description": "Certificate Management",
+      "groupName": "cert-manager",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["cert-manager"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} certificates"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Multi-CNI Support",
+      "groupName": "Multus",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["multus", "cni-plugins"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} CNI"
+      },
+      "separateMinorPatch": true
+    },
+    {
+      "description": "bjw-s App Template",
+      "groupName": "bjw-s-app-template",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["app-template"],
+      "matchRepositories": ["ghcr.io/bjw-s-labs/helm"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} charts"
+      },
+      "separateMinorPatch": false
+    }
+  ]
+}

--- a/.github/renovate/semanticCommits.json5
+++ b/.github/renovate/semanticCommits.json5
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat({{datasource}})!:"
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "{{datasource}}"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "{{datasource}}"
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "{{datasource}}"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(container)!:",
+      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageExtra": "( {{currentVersion}} → {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}} )"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "container",
+      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageExtra": "( {{currentVersion}} → {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}} )"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "container",
+      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageExtra": "( {{currentVersion}} → {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}} )"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "container",
+      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageExtra": "( {{currentVersion}} → {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}} )"
+    },
+    {
+      "matchDatasources": ["helm"],
+      "commitMessageTopic": "{{{depName}}}",
+      "semanticCommitScope": "helm"
+    },
+    {
+      "matchDatasources": ["github-releases", "github-tags"],
+      "commitMessageTopic": "{{{depName}}}",
+      "semanticCommitScope": "github-release"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "github-action",
+      "commitMessageTopic": "{{{depName}}}"
+    }
+  ]
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,60 @@
+---
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: Dry Run
+        default: false
+        required: false
+        type: boolean
+      logLevel:
+        description: Log Level
+        default: debug
+        required: false
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
+  schedule:
+    - cron: "0 * * * *"
+  push:
+    branches: ["main"]
+    paths:
+      - .github/renovate.json5
+      - .github/renovate/**.json5
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: "${{ steps.app-token.outputs.token }}"
+
+      - name: Override default config from dispatch variables
+        shell: bash
+        run: |
+          echo "RENOVATE_DRY_RUN=${{ inputs.dryRun || 'false' }}" >> "${GITHUB_ENV}"
+          echo "LOG_LEVEL=${{ inputs.logLevel || 'debug' }}" >> "${GITHUB_ENV}"
+
+      - name: Renovate
+        uses: renovatebot/github-action@v40.3.13
+        with:
+          configurationFile: .github/renovate.json5
+          token: "${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
## Summary
Implement Renovate Bot following onedr0p's home-ops pattern using GitHub Actions workflow instead of GitHub App installation.

## Changes
- Added `.github/workflows/renovate.yaml` - GitHub Actions workflow with hourly schedule
- Added `.github/renovate.json5` - Main Renovate configuration
- Added `.github/renovate/autoMerge.json5` - Auto-merge rules for trusted digests
- Added `.github/renovate/customManagers.json5` - Custom managers for OCI and annotated dependencies
- Added `.github/renovate/groups.json5` - Package grouping for related updates (Talos, Cilium, Rook-Ceph)
- Added `.github/renovate/semanticCommits.json5` - Semantic commit message formatting

## Features
- Hourly automated dependency scanning for Flux, Helm, and Kubernetes manifests
- Semantic commit messages for all dependency updates
- Package grouping for related updates
- Auto-merge for trusted container digests (bjw-s, onedr0p images)
- Custom managers for OCI dependencies and annotated versions
- Excludes SOPS encrypted files from processing
- Dependency dashboard for tracking available updates

## Configuration Details
- **Datasources**: Docker, Helm, Kubernetes, GitHub Releases
- **File Patterns**: `kubernetes/.+\.ya?ml$`
- **Schedule**: Hourly via GitHub Actions cron
- **Secrets**: Uses existing `BOT_APP_ID` and `BOT_APP_PRIVATE_KEY`
- **Manual Trigger**: Supports workflow_dispatch with dry-run option

## Security Review
✅ Security-guardian reviewed and approved configuration
- No secrets or credentials exposed
- SOPS files properly excluded (`**/*.sops.*`)
- GitHub secrets used correctly
- Auto-merge limited to trusted sources

## Testing
- [ ] Verify workflow triggers successfully after merge
- [ ] Confirm dependency dashboard issue is created
- [ ] Review first Renovate PR for format and quality
- [ ] Monitor auto-merge behavior for digest updates

## Follow-up Items
As noted in security review:
1. Renovate will auto-pin GitHub Actions to SHA digests on first run
2. Consider adding explicit workflow permissions in follow-up PR
3. Monitor auto-merge behavior and adjust if needed

## References
- Epic-016: Renovate Dependency Management
- Security review: Approved with minor recommendations
- Pattern source: onedr0p/home-ops