### PR TITLE
fix(ci): update Renovate GitHub Action to v44.0.2

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "LOG_LEVEL=${{ inputs.logLevel || 'debug' }}" >> "${GITHUB_ENV}"
 
       - name: Renovate
-        uses: renovatebot/github-action@v40.3.13
+        uses: renovatebot/github-action@v44.0.2
         with:
           configurationFile: .github/renovate.json5
           token: "${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
## Summary
Fixes Renovate workflow failure caused by invalid GitHub Action version.

## Problem
Renovate workflow was failing with error:
```
Unable to resolve action `renovatebot/github-action@v40.3.13`, unable to find version `v40.3.13`
```

## Solution
Updated `renovatebot/github-action` from non-existent v40.3.13 to latest stable v44.0.2 (released 2025-11-10).

## Testing
Workflow will run automatically after merge to validate the fix.