### PR TITLE
fix(media): correct Plex image tag format

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/onedr0p/plex
-              tag: 1.41.5.9522-a0bfb8370
+              tag: 1.41.5.9522
             env:
               TZ: America/New_York
               PLEX_CLAIM: ""


### PR DESCRIPTION
Fixes ImagePullBackOff caused by incorrect Plex tag format.

Tag should be `1.41.5.9522` not `1.41.5.9522-a0bfb8370`