### PR TITLE
fix(security): correct Falco prometheus extralabels format

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
         enabled: false
       config:
         prometheus:
-          extralabels: "cluster:homelab"
+          extralabels: ""
 
     # ServiceMonitor for Prometheus scraping
     serviceMonitor:


### PR DESCRIPTION
Fixes falcosidekick CrashLoopBackOff caused by invalid Prometheus label format.

## Issue
Falcosidekick pods crashing with error:
```
"cluster:homelab" is not a valid label name for metric "falco_events"
```

## Root Cause
Prometheus label names cannot contain colons. The `extralabels: "cluster:homelab"` configuration is invalid.

## Fix
Changed `extralabels: "cluster:homelab"` to `extralabels: ""` (empty string)

## Testing
After merge, falcosidekick pods should start successfully and Falco DaemonSet should become operational.