### PR TITLE
fix(security): correct Falco rule priorities and invalid config

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
             Shell spawned in DMZ container
             (user=%user.name container=%container.name shell=%proc.name
             parent=%proc.pname cmdline=%proc.cmdline)
-          priority: CRITICAL
+          priority: critical
           tags: [container, shell, dmz, plex]
 
         - rule: Unexpected Network Connection from Plex
@@ -63,7 +63,7 @@ spec:
             Unexpected connection from Plex
             (user=%user.name container=%container.name
             connection=%fd.name)
-          priority: HIGH
+          priority: warning
           tags: [network, dmz, plex]
 
         - rule: Privilege Escalation Attempt
@@ -75,7 +75,7 @@ spec:
             Privilege escalation attempt
             (user=%user.name container=%container.name
             command=%proc.cmdline)
-          priority: CRITICAL
+          priority: critical
           tags: [privilege_escalation, container]
 
         - rule: Sensitive File Access in Container
@@ -87,7 +87,7 @@ spec:
             Sensitive file accessed
             (user=%user.name container=%container.name
             file=%fd.name)
-          priority: HIGH
+          priority: warning
           tags: [filesystem, container]
 
     # Falco exporter for Prometheus
@@ -114,13 +114,6 @@ spec:
       metrics:
         enabled: true
         interval: 1h
-
-      # Output channels
-      outputs:
-        rate: 1
-        max_burst: 1000
-        stdout_output:
-          enabled: true
 
     # Resource limits
     resources:


### PR DESCRIPTION
Fixes Falco DaemonSet CrashLoopBackOff caused by invalid rule configuration.

## Issues
1. **Invalid priority values**: Falco v0.39+ requires lowercase priorities
   - Changed  → 
   - Changed  → 
2. **Invalid outputs config**: Schema validation failure on  section
   - Removed deprecated  configuration

## Errors Fixed
```
Schema validation: failed for <root>[1][priority]: Failed to match against any enum values
Schema validation: failed for <root>: Object contains property 'outputs' that could not be validated
```

## Testing
After merge, Falco DaemonSet should start successfully on all 15 nodes.

Related: PR #74, PR #75