### PR TITLE
fix(security): disable Plex network rule until IP whitelist defined

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -52,19 +52,20 @@ spec:
           priority: critical
           tags: [container, shell, dmz, plex]
 
-        - rule: Unexpected Network Connection from Plex
-          desc: Detect suspicious outbound connections from Plex
-          condition: >
-            outbound and container and
-            k8s.ns.name = "media" and
-            k8s.pod.label.app = "plex" and
-            not fd.sip in (allowed_plex_ips)
-          output: >
-            Unexpected connection from Plex
-            (user=%user.name container=%container.name
-            connection=%fd.name)
-          priority: warning
-          tags: [network, dmz, plex]
+        # Commented out until we can define allowed_plex_ips list
+        # - rule: Unexpected Network Connection from Plex
+        #   desc: Detect suspicious outbound connections from Plex
+        #   condition: >
+        #     outbound and container and
+        #     k8s.ns.name = "media" and
+        #     k8s.pod.label.app = "plex" and
+        #     not fd.sip in (allowed_plex_ips)
+        #   output: >
+        #     Unexpected connection from Plex
+        #     (user=%user.name container=%container.name
+        #     connection=%fd.name)
+        #   priority: warning
+        #   tags: [network, dmz, plex]
 
         - rule: Privilege Escalation Attempt
           desc: Detect privilege escalation in any container


### PR DESCRIPTION
Temporarily disable Plex network monitoring rule to unblock Falco deployment.

## Issue
Falco crashes with: `LOAD_ERR_COMPILE_CONDITION: unrecognized IPv6 address allowed_plex_ips`

The rule references an undefined `allowed_plex_ips` list.

## Fix
Comment out the rule until we can define the IP whitelist during post-deployment tuning (STORY-033 WI-033-6).

## Remaining Active Rules
- Shell spawn detection in DMZ (critical)
- Privilege escalation attempts (critical)  
- Sensitive file access (warning)

## Follow-up
Will re-enable Plex network monitoring after collecting legitimate outbound IPs.