### PR TITLE
fix(falco): switch to classic eBPF driver to resolve Talos kernel 6.12 compatibility

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -29,7 +29,9 @@ spec:
     # eBPF driver configuration
     driver:
       enabled: true
-      kind: modern_ebpf
+      kind: ebpf  # Switching to classic eBPF driver for better Talos compatibility
+      loader:
+        enabled: true  # Required for classic eBPF driver to download/build probe
 
     # DaemonSet configuration
     tolerations:


### PR DESCRIPTION
## Summary
Switches Falco from modern_ebpf to classic ebpf driver to resolve initialization failures on Talos Linux kernel 6.12.52.

## Problem
All 15 Falco pods are in CrashLoopBackOff with the error:
```
Opening 'syscall' source with modern BPF probe.
An error occurred in an event source, forcing termination...
Error: Initialization issues during scap_init
```

## Root Cause
The modern_ebpf driver has compatibility issues with certain kernel configurations, particularly:
- Talos Linux kernel 6.12.52
- Potential kernel lockdown mode restrictions
- Missing or incompatible eBPF features

## Solution
Switch to the classic ebpf driver which:
- Has broader kernel compatibility
- Works with older eBPF implementations
- Has resolved similar issues in other deployments (ref: falcosecurity/falco#3323)

## Changes
- Changed driver.kind from 'modern_ebpf' to 'ebpf'
- Enabled driver.loader.enabled=true (required for classic driver)

## Testing Plan
- [ ] Flux will reconcile the HelmRelease after merge
- [ ] Verify Falco pods start successfully (0/15 → 15/15 Ready)
- [ ] Check logs for successful eBPF probe initialization
- [ ] Validate security rules are loaded correctly
- [ ] Test rule triggers with sample violations

## References
- falcosecurity/falco#3323 - scap_init errors with modern_ebpf
- falcosecurity/falco#3416 - modern_ebpf failures on Talos Linux
- STORY-033: Deploy Falco Runtime Security
- Previous PRs: #74, #75, #76, #77, #78 (configuration fixes)