### PR TITLE
fix(falco): reduce eBPF buffer size for Talos compatibility

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -118,6 +118,13 @@ spec:
         enabled: true
         interval: 1h
 
+      # eBPF buffer configuration for Talos Linux
+      # Reduce buffer size to 1MB (preset 1) for Talos kernel compatibility
+      # Default 8MB (preset 4) causes perf buffer mmap errors
+      engine:
+        ebpf:
+          buf_size_preset: 1
+
     # Resource limits
     resources:
       limits:


### PR DESCRIPTION
## Summary

Fix Falco crash loop by reducing eBPF perf buffer size from default 8MB to 1MB for Talos Linux kernel compatibility.

## Problem

After switching from modern_ebpf to classic ebpf driver (PR #79), Falco pods crash with:
```
Error: unable to mmap the perf-buffer for cpu '0': Invalid argument
```

All 15 DaemonSet pods in CrashLoopBackOff/Error state.

## Root Cause

Talos Linux kernel has stricter memory limits for perf buffers. The default `buf_size_preset: 4` (8MB) exceeds kernel limits and fails mmap allocation.

## Solution

Set `buf_size_preset: 1` (1MB buffer) in Falco engine configuration. This is a documented tuning parameter for kernel compatibility.

**Trade-off**: Smaller buffer may drop events under extreme load, but acceptable for homelab monitoring.

## Changes

- Added `engine.ebpf.buf_size_preset: 1` to HelmRelease values
- Documented Talos compatibility requirement in comments

## Testing Plan

After merge and Flux deployment:
- [ ] Verify all 15 Falco pods reach Running state
- [ ] Check logs for successful eBPF probe initialization
- [ ] Test DMZ security rule by spawning shell in Plex container
- [ ] Verify Prometheus metrics are being collected

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials
- [x] Configuration follows best practices
- [x] Standard Falco tuning parameter

## Related

- PR #79: Switched to classic eBPF driver
- STORY-033: Deploy Falco Runtime Security
- EPIC-018: Security Monitoring and Runtime Protection