### PR TITLE
fix(falco): correct eBPF buffer size configuration path

### DIFF
--- a/kubernetes/apps/security-system/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security-system/falco/app/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
       kind: ebpf  # Switching to classic eBPF driver for better Talos compatibility
       loader:
         enabled: true  # Required for classic eBPF driver to download/build probe
+      ebpf:
+        bufSizePreset: 1  # 1MB buffer for Talos kernel compatibility (default 4 = 8MB causes mmap errors)
 
     # DaemonSet configuration
     tolerations:
@@ -117,13 +119,6 @@ spec:
       metrics:
         enabled: true
         interval: 1h
-
-      # eBPF buffer configuration for Talos Linux
-      # Reduce buffer size to 1MB (preset 1) for Talos kernel compatibility
-      # Default 8MB (preset 4) causes perf buffer mmap errors
-      engine:
-        ebpf:
-          buf_size_preset: 1
 
     # Resource limits
     resources:


### PR DESCRIPTION
## Summary

Fix buffer size configuration by using the correct Helm chart values path.

## Problem

PR #80 added buffer size configuration but used incorrect YAML path:
```yaml
falco:
  engine:
    ebpf:
      buf_size_preset: 1  # ❌ WRONG - this path doesn't exist in Helm chart
```

This configuration was silently ignored, so Falco continued using the default 8MB buffer, causing the same mmap errors.

## Root Cause

The Falco Helm chart uses a different values structure than the base falco.yaml config file. The correct path is `driver.ebpf.bufSizePreset`, not `falco.engine.ebpf`.

## Solution

Move configuration to correct location:
```yaml
driver:
  ebpf:
    bufSizePreset: 1  # ✅ CORRECT - this is the Helm chart path
```

## Changes

- Removed incorrect `falco.engine.ebpf.buf_size_preset`
- Added correct `driver.ebpf.bufSizePreset: 1`
- Same 1MB buffer size, just correct configuration path

## Testing Plan

After merge:
- [ ] Verify Falco logs show "1048576 bytes (1 MBs)" instead of "8388608 bytes (8 MBs)"
- [ ] Check all 15 pods reach Running state
- [ ] No more "unable to mmap the perf-buffer" errors

## References

- Falco Helm chart values: https://github.com/falcosecurity/charts/blob/master/charts/falco/values.yaml
- PR #80: First attempt with wrong config path