### PR TITLE
fix(security): correct Tetragon GitRepository reference

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/ks.yaml
+++ b/kubernetes/apps/kube-system/tetragon/ks.yaml
@@ -16,7 +16,8 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-kubernetes
+    name: flux-system
+    namespace: flux-system
   wait: true
   postBuild:
     substitute: {}


### PR DESCRIPTION
## Issue

Tetragon Kustomization fails to reconcile with error:
```
GitRepository.source.toolkit.fluxcd.io "home-kubernetes" not found
```

## Fix

Change GitRepository reference from `home-kubernetes` to `flux-system` to match the actual GitRepository name in the cluster.

## Verification

After merge:
```bash
flux get ks tetragon -n flux-system
# Should show: READY True

kubectl get ds -n kube-system tetragon
# Should show DaemonSet deploying
```

## Related

- Fixes deployment issue from PR #83 (Tetragon runtime security)
- Required for STORY-033 completion