### PR TITLE
fix(security): remove invalid Tetragon policy field

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/policies/privilege-escalation.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/privilege-escalation.yaml
@@ -20,7 +20,6 @@ spec:
         - "CAP_SYS_ADMIN"   # Full system admin privileges
         - "CAP_NET_ADMIN"   # Network configuration
         - "CAP_SYS_PTRACE"  # Process tracing (debuggers)
-      isNamespaceCapability: false
       matchActions:
       - action: Sigkill  # ENFORCE: Kill process attempting escalation
       - action: Post     # LOG: Record escalation attempt


### PR DESCRIPTION
## Issue

Tetragon policies fail to deploy with schema validation error:
```
.spec.kprobes[0].selectors[0].isNamespaceCapability: 
field not declared in schema
```

## Root Cause

The `isNamespaceCapability` field in privilege-escalation policy is not part of the Tetragon v1.2.0 TracingPolicy CRD schema.

## Fix

Remove the invalid field from privilege-escalation-detection policy.

## Verification

After merge:
```bash
flux get ks tetragon-policies -n flux-system
# Should show: READY True

kubectl get tracingpolicy -A
kubectl get tracingpolicynamespaced -n media
# Should show all 4 policies deployed
```

## Related

- Fixes policy deployment issue from PR #86
- Required for STORY-033 completion