### PR TITLE
fix(security): use matchBinaries for Tetragon binary path matching

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/policies/privilege-escalation.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/privilege-escalation.yaml
@@ -37,13 +37,12 @@ spec:
     - index: 0
       type: "string"
     selectors:
-    - matchArgs:
-      - index: 0
-        operator: "In"
+    - matchBinaries:
+      - operator: "Prefix"
         values:
         - "/usr/bin/su"
-        - "/usr/bin/sudo"
         - "/bin/su"
+        - "/usr/bin/sudo"
         - "/bin/sudo"
         - "/usr/bin/pkexec"
       matchActions:

--- a/kubernetes/apps/kube-system/tetragon/policies/shell-detection-dmz.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/shell-detection-dmz.yaml
@@ -14,9 +14,8 @@ spec:
     - index: 0
       type: "string"
     selectors:
-    - matchArgs:
-      - index: 0
-        operator: "In"
+    - matchBinaries:
+      - operator: "Prefix"
         values:
         - "/bin/bash"
         - "/bin/sh"


### PR DESCRIPTION
## Issue

Tetragon policies fail with schema validation error:
```
spec.kprobes[0].selectors[0].matchArgs[0].operator: Unsupported value: "In"
```

## Root Cause

Tetragon v1.2.0 `matchArgs` operator does not support `"In"` for matching multiple values. The supported operators are: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, etc.

## Fix

Change binary path matching from `matchArgs` with `In` operator to `matchBinaries` with `Prefix` operator.

**Changes**:
- `setuid-detection` policy: Use matchBinaries for su/sudo detection
- `shell-detection-dmz` policy: Use matchBinaries for shell detection

## Verification

After merge:
```bash
flux get ks tetragon-policies -n flux-system
# Should show: READY True

kubectl get tracingpolicy -A
# Should show: privilege-escalation-detection, setuid-detection

kubectl get tracingpolicynamespaced -n media
# Should show: shell-detection-dmz, network-monitoring-dmz, etc.
```

## Related

- Fixes policy deployment issue from PR #86, #87
- Required for STORY-033 completion