### PR TITLE
fix(security): remove invalid matchNamespaces from Tetragon policies

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/policies/network-monitoring-dmz.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/network-monitoring-dmz.yaml
@@ -14,10 +14,7 @@ spec:
     - index: 0
       type: "sock"
     selectors:
-    - matchNamespaces:
-      - namespace: "media"
-        operator: "In"
-      matchActions:
+    - matchActions:
       - action: Post  # LOG ONLY: Record connections for analysis
 ---
 apiVersion: cilium.io/v1alpha1
@@ -35,8 +32,5 @@ spec:
     - index: 0
       type: "sock"
     selectors:
-    - matchNamespaces:
-      - namespace: "media"
-        operator: "In"
-      matchActions:
+    - matchActions:
       - action: Post  # LOG ONLY

--- a/kubernetes/apps/kube-system/tetragon/policies/sensitive-file-access-dmz.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/sensitive-file-access-dmz.yaml
@@ -28,9 +28,6 @@ spec:
         - "/home/*/.ssh/"      # User SSH keys
         - "/etc/kubernetes/"   # K8s configs
         - "/var/run/secrets/"  # K8s service account tokens
-      matchNamespaces:
-      - namespace: "media"
-        operator: "In"
       matchActions:
       - action: Post  # LOG: Record sensitive file access
 ---
@@ -63,8 +60,5 @@ spec:
         values:
         - "1"  # O_WRONLY
         - "2"  # O_RDWR
-      matchNamespaces:
-      - namespace: "media"
-        operator: "In"
       matchActions:
       - action: Post  # LOG: Record config modifications

--- a/kubernetes/apps/kube-system/tetragon/policies/shell-detection-dmz.yaml
+++ b/kubernetes/apps/kube-system/tetragon/policies/shell-detection-dmz.yaml
@@ -23,9 +23,6 @@ spec:
         - "/bin/zsh"
         - "/usr/bin/bash"
         - "/usr/bin/sh"
-      matchNamespaces:
-      - namespace: "media"
-        operator: "In"
       matchActions:
       - action: Sigkill  # ENFORCE: Kill process attempting shell
       - action: Post     # LOG: Send event to Prometheus/stdout


### PR DESCRIPTION
## Issue

Tetragon TracingPolicyNamespaced resources fail with schema validation:
```
matchNamespaces[0].namespace: Unsupported value: "media": 
supported values: "Uts", "Ipc", "Mnt", "Pid", "PidForChildren", 
"Net", "Time", "TimeForChildren", "Cgroup", "User"
matchNamespaces[0].values: Required value
```

## Root Cause

`matchNamespaces` in Tetragon is for **Linux kernel namespaces** (Uts, Ipc, Mnt, Pid, Net, etc.), NOT Kubernetes namespaces.

TracingPolicyNamespaced resources are already scoped to a specific Kubernetes namespace via `metadata.namespace`, so additional namespace filtering is redundant and uses the wrong field.

## Fix

Remove `matchNamespaces` selectors from all TracingPolicyNamespaced policies. The policies are already namespace-scoped via metadata.

**Affected policies**:
- network-monitoring-dmz (TCP and UDP policies)
- shell-detection-dmz
- sensitive-file-access-dmz (2 policies)

## Verification

After merge:
```bash
flux get ks tetragon-policies -n flux-system
# Should show: READY True

kubectl get tracingpolicynamespaced -n media
# Should show all 4 policies deployed
```

## Related

- Fixes policy deployment issue from PR #86-#88
- Required for STORY-033 completion