### PR TITLE
fix(alertmanager-discord): correct GitRepository reference to flux-system

### DIFF
--- a/kubernetes/apps/observability/alertmanager-discord/ks.yaml
+++ b/kubernetes/apps/observability/alertmanager-discord/ks.yaml
@@ -10,7 +10,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-kubernetes
+    name: flux-system
   targetNamespace: observability
   dependsOn:
     - name: external-secrets-operator


### PR DESCRIPTION
## Summary

Fix broken alertmanager-discord Kustomization by correcting the GitRepository reference.

## Problem

After PR #94 merge, the alertmanager-discord Kustomization was created but immediately failed with:
```
GitRepository.source.toolkit.fluxcd.io "home-kubernetes" not found
```

## Root Cause

The `alertmanager-discord/ks.yaml` file incorrectly referenced a GitRepository named `home-kubernetes`, which does not exist in the cluster.

All other kustomizations correctly reference `flux-system`:
- `kube-prometheus-stack/ks.yaml` → `sourceRef.name: flux-system`
- `loki/ks.yaml` → `sourceRef.name: flux-system`

## Changes

- Update `alertmanager-discord/ks.yaml` sourceRef.name: `home-kubernetes` → `flux-system`

## Impact

This allows Flux to properly reconcile the alertmanager-discord Kustomization and deploy the webhook adapter service.

## Security Review

- [x] security-guardian approval received
- [x] Configuration fix only (no secrets involved)
- [x] Aligns with existing cluster patterns

## Testing Plan

After merge:
- [ ] Verify Kustomization reconciles successfully
- [ ] Verify alertmanager-discord deployment created
- [ ] Verify pods running in observability namespace

## Notes

Security-guardian also identified that `nvidia-dcgm-exporter/ks.yaml` has the same issue. Will fix in separate PR to keep changes focused.

Fixes error introduced in PR #92.