### PR TITLE
fix(kube-system): add nvidia runtime to device plugin

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
     remediation:
       retries: 3
   values:
+    # Use nvidia runtime so device plugin can access NVIDIA libraries
+    runtimeClassName: nvidia
+
     # Only run on nodes with NVIDIA GPUs
     affinity:
       nodeAffinity:
@@ -43,7 +46,6 @@ spec:
         operator: Exists
 
     # Device plugin configuration
-    # Note: Device plugin does NOT need nvidia runtime - only workloads using GPUs do
     config:
       map:
         default: |-


### PR DESCRIPTION
Enables nvidia-device-plugin to access NVIDIA libraries required for NVML initialization and GPU discovery.

The device plugin was failing with ERROR_LIBRARY_NOT_FOUND because it couldn't access libnvidia-ml.so needed to initialize NVML. Adding runtimeClassName: nvidia runs the pod with the nvidia container runtime, which mounts the NVIDIA libraries.

Changes:
- Add runtimeClassName: nvidia to device plugin DaemonSet
- Remove incorrect comment stating device plugin doesn't need nvidia runtime

Fixes: ERROR_LIBRARY_NOT_FOUND on device plugin startup
Depends on: PR #100 (nvidia runtime handler configuration)
Security review: Passed