### PR TITLE
fix(kube-system): revert nvidia-device-plugin to working configuration

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -54,7 +54,6 @@ spec:
             migStrategy: none
             failOnInitError: true
             nvidiaDriverRoot: /
-            deviceDiscoveryStrategy: nvml
       default: "default"
 
     # Resources for the device plugin pods


### PR DESCRIPTION
Restores nvidia-device-plugin to the exact configuration that was working when GPUs were fully functional (Nov 6-10, 2025).

## Changes
- Remove `deviceDiscoveryStrategy: nvml` parameter
- Restore original simple configuration with just `runtimeClassName: nvidia`

## Analysis
Comprehensive git history investigation revealed:
- GPUs were fully functional with original config (no deviceDiscoveryStrategy)
- deviceDiscoveryStrategy was added in PR #101 as experimental fix
- Adding this parameter actually changed behavior and caused failures

## Original Working Config
- `runtimeClassName: nvidia` (present)
- NO `deviceDiscoveryStrategy` setting
- Simple flags: migStrategy, failOnInitError, nvidiaDriverRoot only

## Testing
After merge, nvidia-device-plugin should start successfully with containerd runtime configuration from PR #100 (already merged).

Security review: Passed
Relates to: GPU troubleshooting, restore working state