### PR TITLE
fix(nvidia): remove runtimeClassName from device plugin

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -22,8 +22,9 @@ spec:
     remediation:
       retries: 3
   values:
-    # Use nvidia runtime so device plugin can access NVIDIA libraries
-    runtimeClassName: nvidia
+    # Device plugin does NOT need runtimeClassName: nvidia
+    # Only GPU workloads (Plex, etc.) should use runtimeClassName: nvidia in their pod specs
+    # The device plugin just discovers GPUs and advertises them to Kubernetes
 
     # Only run on nodes with NVIDIA GPUs
     affinity:


### PR DESCRIPTION
## Summary

Fix nvidia-device-plugin crashes caused by eBPF device filter errors when using `runtimeClassName: nvidia`.

## Problem

The nvidia-device-plugin was failing with this error:
```
nvidia-container-cli: mount error: failed to add device rules: 
unable to generate new device filter program from existing programs: 
unable to create new device filters program: load program: invalid argument: 
last insn is not an exit or jmp
```

## Root Cause

The device plugin pods themselves do **not** need GPU access. They only:
- Discover GPUs via hostPath mounts to `/dev` and `/sys`
- Advertise GPU resources to Kubernetes scheduler

Using `runtimeClassName: nvidia` on the device plugin caused nvidia-container-runtime to try setting up GPU device filters using eBPF, which conflicted with the `net.core.bpf_jit_harden: 1` sysctl required by the nvidia driver.

## Solution

Remove `runtimeClassName: nvidia` from nvidia-device-plugin HelmRelease.

**Only GPU workload pods** (like Plex, ML training jobs, etc.) should specify `runtimeClassName: nvidia` in their pod specs.

## Changes

- Removed `runtimeClassName: nvidia` from device plugin values
- Added clarifying comments about proper runtime class usage

## Testing Plan

After merge:
- [ ] Flux reconciles HelmRelease
- [ ] Device plugin pods start successfully (no CrashLoopBackOff)
- [ ] Verify no eBPF mount errors in logs
- [ ] Confirm GPUs advertised: `kubectl describe node k8s-work-4 k8s-work-14 | grep nvidia.com/gpu`
- [ ] Test GPU workload (Plex transcoding)

## Related Work

- PR #100: Added nvidia runtime config to Talos patches ✅
- PR #101: Attempted deviceDiscoveryStrategy fix (wrong approach)
- PR #102: Re-added runtimeClassName (caused this issue)
- PR #103: Removed deviceDiscoveryStrategy (partial fix)

## Technical Details

**Architecture**:
```
Talos GPU Nodes → nvidia runtime configured in containerd
                ↓
nvidia-device-plugin → discovers GPUs → advertises to K8s
                ↓
GPU workloads (Plex) → uses runtimeClassName: nvidia → gets GPU access
```

**Key Insight**: Device plugin is a **discovery service**, not a GPU consumer.

## Security Review

✅ Security-guardian approval received
✅ No secrets or credentials
✅ Configuration-only change
✅ YAML syntax validated