### PR TITLE
fix(kube-system): configure nvidia-device-plugin to use NVML discovery

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
             migStrategy: none
             failOnInitError: true
             nvidiaDriverRoot: /
+            deviceDiscoveryStrategy: nvml
       default: "default"
 
     # Resources for the device plugin pods


### PR DESCRIPTION
## Summary

Configure nvidia-device-plugin to use NVML (NVIDIA Management Library) discovery strategy instead of auto-detection.

## Problem

After PR #104 removed `runtimeClassName: nvidia` to fix eBPF errors, the device plugin is still failing with:
```
E1113 05:56:37.016626     118 factory.go:112] Incompatible strategy detected auto
E1113 05:56:37.016682     118 factory.go:113] If this is a GPU node, did you configure the NVIDIA Container Toolkit?
```

The default "auto" discovery strategy requires the device plugin to verify the NVIDIA Container Toolkit is properly configured by checking specific filesystem paths. In Talos Linux, these paths are not accessible from within device plugin pods.

## Solution

Explicitly set `deviceDiscoveryStrategy: nvml` to use NVIDIA Management Library for GPU discovery. NVML uses the nvidia-smi interface directly and does not require Container Toolkit path verification.

## Changes

- Added `deviceDiscoveryStrategy: nvml` to device plugin configuration flags

## Technical Details

**Discovery Strategies**:
- `auto`: Detects toolkit config (fails on Talos - paths not accessible)
- `nvml`: Uses nvidia-smi/NVML directly (works on Talos) ✅
- `tegra`: For Jetson devices (not applicable)

**Architecture**:
```
Talos GPU Node
  ↓
/usr/local/bin/nvidia-smi (from extensions)
  ↓
Device Plugin (with NVML discovery) → Discovers GPUs via nvidia-smi
  ↓
Advertises nvidia.com/gpu resources to Kubernetes
  ↓
GPU Workloads (Plex, etc.) → Use runtimeClassName: nvidia → Get GPU access
```

## Testing Plan

After merge:
- [ ] Flux reconciles HelmRelease
- [ ] Device plugin pods start successfully (no CrashLoopBackOff)
- [ ] No "Incompatible strategy detected" errors in logs
- [ ] GPUs discovered: `kubectl describe node k8s-work-4 k8s-work-14 | grep nvidia.com/gpu`
- [ ] Test GPU workload (Plex transcoding)

## Related Work

- PR #100: Added nvidia runtime to Talos patches ✅
- PR #104: Removed runtimeClassName from device plugin (fixed eBPF errors) ✅
- **This PR #105**: Add NVML discovery strategy (fixes auto-detection errors)

## References

- Talos GPU Troubleshooting: `.claude/.ai-docs/gpu/NVIDIA_GPU_TROUBLESHOOTING_2025-11-12.md` (Option 1, lines 131-146)
- NVIDIA Device Plugin Docs: https://github.com/NVIDIA/k8s-device-plugin#deployment-via-helm

## Security Review

✅ Security-guardian approval received
✅ No secrets or credentials
✅ Configuration-only change (single parameter)
✅ YAML syntax validated
✅ Appropriate for public repository