### PR TITLE
fix(kube-system): add runtimeClassName to provide NVML library access

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -22,9 +22,9 @@ spec:
     remediation:
       retries: 3
   values:
-    # Device plugin does NOT need runtimeClassName: nvidia
-    # Only GPU workloads (Plex, etc.) should use runtimeClassName: nvidia in their pod specs
-    # The device plugin just discovers GPUs and advertises them to Kubernetes
+    # Use nvidia runtime to provide access to NVIDIA libraries (libnvidia-ml.so) for NVML discovery
+    # The runtime will mount /usr/lib from host so the device plugin can initialize NVML
+    runtimeClassName: nvidia
 
     # Only run on nodes with NVIDIA GPUs
     affinity:


### PR DESCRIPTION
## Summary

Add `runtimeClassName: nvidia` back to nvidia-device-plugin to provide access to NVIDIA libraries required for NVML initialization.

## Problem Evolution

This PR represents the culmination of systematic GPU troubleshooting:

1. **PR #104**: Removed `runtimeClassName` → Fixed eBPF errors, but introduced new issue
2. **PR #105**: Added `deviceDiscoveryStrategy: nvml` → Device plugin tried NVML discovery but failed with:
   ```
   E1113 06:18:24.006739 89 factory.go:93] Failed to initialize NVML: ERROR_LIBRARY_NOT_FOUND
   ```

## Root Cause

The NVML discovery strategy requires access to NVIDIA libraries (`libnvidia-ml.so`) which are located on the host at `/usr/lib` or `/usr/lib64`. Without `runtimeClassName: nvidia`, the nvidia-container-runtime does not inject these library mounts into the pod, causing NVML initialization to fail.

## Solution

Use **both** configurations together:
- `runtimeClassName: nvidia` - nvidia-container-runtime mounts NVIDIA libraries from host
- `deviceDiscoveryStrategy: nvml` - device plugin uses NVML for GPU discovery

This matches the original working configuration from Nov 6-10, 2025.

## Changes

- Re-added `runtimeClassName: nvidia` with updated comment explaining library access requirement
- Kept `deviceDiscoveryStrategy: nvml` from PR #105

## Testing Plan

After merge:
- [ ] Flux reconciles HelmRelease  
- [ ] Device plugin pods start successfully
- [ ] Check logs for NVML initialization success
- [ ] Verify GPUs discovered: `kubectl describe node k8s-work-4 k8s-work-14 | grep nvidia.com/gpu`
- [ ] Test GPU workload (Plex transcoding)

## Potential Issue

**eBPF Device Filter Errors**: This configuration MAY reintroduce eBPF errors we saw earlier:
```
nvidia-container-cli: mount error: failed to add device rules: 
unable to generate new device filter program
```

**Why this might work now**:
- PR #100 added `net.core.bpf_jit_harden: 1` sysctl to Talos patches
- Current nodes were temporarily patched via `talosctl apply-config`
- Sysctl should prevent eBPF issues

**If errors recur**: Full resolution requires cattle upgrade (destroy/recreate VMs) with Talos patches from PR #100.

## Related Work

- PR #100: Added nvidia runtime to Talos patches ✅ (merged, applied temporarily)
- PR #104: Removed `runtimeClassName` (fixed eBPF, caused library access issue)
- PR #105: Added `deviceDiscoveryStrategy: nvml` (attempted NVML discovery)
- **This PR #106**: Combines both for complete solution

## Technical Architecture

```
Talos GPU Node
  ↓
nvidia-container-runtime (triggered by runtimeClassName: nvidia)
  ↓
Mounts /usr/lib, /usr/lib64 from host into pod
  ↓
Device Plugin Container
  ↓
NVML library (libnvidia-ml.so) now accessible
  ↓
deviceDiscoveryStrategy: nvml initializes NVML
  ↓
Discovers GPUs via nvidia-smi/NVML
  ↓
Advertises nvidia.com/gpu resources to Kubernetes
```

## Security Review

✅ Security-guardian approval received  
✅ No secrets or credentials  
✅ Configuration-only change  
✅ YAML syntax validated  
✅ Appropriate for public repository