### PR TITLE
fix(kube-system): downgrade nvidia-device-plugin to v0.13.0 for Talos compatibility

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: nvidia-device-plugin
-      version: 0.17.1
+      version: 0.13.0  # Downgrade to Talos-recommended stable version
       sourceRef:
         kind: HelmRepository
         name: nvidia-device-plugin
@@ -22,6 +22,16 @@ spec:
     remediation:
       retries: 3
   values:
+    # CRITICAL: Use nvidia runtime to inject NVIDIA libraries
+    runtimeClassName: nvidia
+
+    # CRITICAL: Add SYS_ADMIN capability for library access with volume-mounts
+    # This is required for v0.16+ but won't hurt in v0.13.0
+    securityContext:
+      capabilities:
+        add:
+          - SYS_ADMIN
+
     # Only run on nodes with NVIDIA GPUs
     affinity:
       nodeAffinity:
@@ -42,18 +52,6 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
 
-    # Device plugin configuration
-    config:
-      map:
-        default: |-
-          version: v1
-          flags:
-            migStrategy: none
-            failOnInitError: true
-            nvidiaDriverRoot: /
-            deviceDiscoveryStrategy: nvml
-      default: "default"
-
     # Resources for the device plugin pods
     resources:
       requests:
@@ -70,19 +68,3 @@ spec:
       type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-
-    # Enable GFD (GPU Feature Discovery) to expose GPU properties as node labels
-    gfd:
-      enabled: true
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
-      tolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
-      resources:
-        requests:
-          cpu: 50m
-          memory: 100Mi
-        limits:
-          memory: 200Mi


### PR DESCRIPTION
## Summary
Fixes the nvidia-device-plugin ERROR_LIBRARY_NOT_FOUND issue that has been preventing GPU utilization since the cattle upgrade.

## Problem
After the cattle upgrade, the nvidia-device-plugin v0.17.1 cannot initialize NVML due to missing library access. This creates a Catch-22:
- WITHOUT `runtimeClassName: nvidia` → Libraries not mounted → ERROR_LIBRARY_NOT_FOUND
- WITH `runtimeClassName: nvidia` → eBPF conflicts → Init container fails

## Solution
Based on extensive research and Talos documentation:
1. **Downgrade to v0.13.0** - Talos-recommended stable version
2. **Add `runtimeClassName: nvidia`** - Enables NVIDIA library injection
3. **Add `SYS_ADMIN` capability** - Required for NVML access with volume-mounts strategy
4. **Simplify configuration** - Remove complex discovery strategies

## Changes
- Downgraded nvidia-device-plugin from v0.17.1 to v0.13.0
- Added `runtimeClassName: nvidia` to use nvidia container runtime
- Added `SYS_ADMIN` capability to security context
- Temporarily disabled GFD (can re-enable once main plugin works)
- Removed explicit deviceDiscoveryStrategy config (let v0.13.0 use defaults)

## Testing Plan
After merge and Flux reconciliation:
1. [ ] Monitor pod startup: `kubectl logs -n kube-system -l app.kubernetes.io/name=nvidia-device-plugin -f`
2. [ ] Verify pods reach Running state
3. [ ] Check GPU discovery: `kubectl describe nodes k8s-work-4 | grep nvidia`
4. [ ] Verify GPU resources appear: `kubectl describe nodes k8s-work-14 | grep nvidia`
5. [ ] Test with GPU workload (e.g., Plex transcoding)

## References
- Talos GPU Documentation (recommends v0.13.0)
- NVIDIA/k8s-device-plugin Issue #856 (SYS_ADMIN requirement)
- NVIDIA/k8s-device-plugin Issue #478 (NVML library access)

## Notes
The root cause was that v0.16+ removed the default SYS_ADMIN capability, which is required for accessing NVIDIA libraries when using container-optimized/immutable OSes like Talos Linux. The v0.13.0 version is more stable for Talos deployments.