### PR TITLE
test(kube-system): upgrade nvidia-device-plugin from v0.13.0 to v0.18.0

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: nvidia-device-plugin
-      version: 0.13.0  # Downgrade to Talos-recommended stable version
+      version: 0.18.0  # Testing upgrade - eBPF issue was in nvidia-container-toolkit, not device plugin
       sourceRef:
         kind: HelmRepository
         name: nvidia-device-plugin


### PR DESCRIPTION
## Summary

Testing whether we can safely upgrade nvidia-device-plugin from v0.13.0 to v0.18.0 (latest).

## Root Cause Analysis

The eBPF incompatibility issue that prompted the downgrade to v0.13.0 in PR #108 was actually in **nvidia-container-toolkit 1.17.8**, NOT in the nvidia-device-plugin itself.

**Evidence**:
- Error was: `nvidia-container-cli: mount error: failed to add device rules: unable to generate new device filter program`
- This error originates from `nvidia-container-toolkit`'s eBPF device filtering code
- We fixed it by disabling eBPF in nvidia-container-runtime config (`no-cgroups = true`)
- Device plugin changelog (v0.14.0-v0.18.0) shows no eBPF implementation

## Why v0.16+ Should Work Better

**v0.16.2 improvements**:
- Automatically adds `CAP_SYS_ADMIN` when using volume-mounts strategy
- This is exactly what PR #108 added manually for v0.13.0
- Newer versions should be MORE compatible with our configuration

**v0.14.0-v0.18.0 features**:
- v0.14.0: CDI (Container Device Interface) support (more modern, reliable)
- v0.16.2: Automatic capability handling
- v0.18.0: Latest features, bug fixes, klog integration

## Configuration Kept

The helmrelease.yaml maintains the working configuration from v0.13.0:
- `runtimeClassName: nvidia` (required for library injection)
- `CAP_SYS_ADMIN` capability (v0.16+ adds automatically, but explicit is fine)
- Node affinity for `nvidia.com/gpu.present=true` label

## Testing Plan

After merge and Flux reconciliation:

1. **Monitor device plugin startup** (should not CrashLoopBackOff):
   ```bash
   kubectl logs -n kube-system -l app.kubernetes.io/name=nvidia-device-plugin -f
   ```

2. **Verify pods Running**:
   ```bash
   kubectl get pods -n kube-system -l app.kubernetes.io/name=nvidia-device-plugin
   # Should show Running 1/1 on both GPU nodes
   ```

3. **Verify GPU resources advertised**:
   ```bash
   kubectl describe nodes k8s-work-4 k8s-work-14 | grep nvidia.com/gpu
   # Both should show: nvidia.com/gpu: 1
   ```

4. **Test GPU access**:
   ```bash
   kubectl run nvidia-smi --rm -i --image=nvidia/cuda:12.8.0-base-ubuntu24.04 \
     --restart=Never --limits=nvidia.com/gpu=1 -- nvidia-smi
   # Should successfully detect GPU
   ```

## Rollback Plan

If the upgrade fails:
- Revert this PR
- Device plugin will return to v0.13.0
- Pin version permanently and document why

## Expected Outcome

**✅ SUCCESS**: Device plugin v0.18.0 works correctly, allowing Renovate to manage updates going forward

**❌ FAILURE**: Revert to v0.13.0 and document that version pin is required (but this is unlikely given root cause analysis)

## Related

- PR #108 (downgrade to v0.13.0 - incorrect eBPF diagnosis)
- GPU boot loop resolution (2025-11-13)
- nvidia-container-runtime `no-cgroups = true` fix (the actual solution)
- `.claude/.ai-docs/gpu/GPU_CATTLE_UPGRADE_LESSONS_2025-11-13.md` (full analysis)