### PR TITLE
fix(observability): increase Prometheus startup timeout to 60 minutes

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -43,17 +43,10 @@ spec:
             memory: 4Gi
 
         # Startup probe - allow extended time for WAL replay after downtime
-        # WAL replay can take 20-30 minutes with 546 segments
+        # WAL replay can take up to 40 minutes with 548 segments
+        # Chart default periodSeconds is 15s, so 240 failures = 60 minutes max startup
         startupProbe:
-          httpGet:
-            path: /-/ready
-            port: 9090
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 180  # 180 * 10s = 30 minutes max startup time
+          failureThreshold: 240  # 240 * 15s (chart default) = 60 min max startup
 
         # Storage configuration
         storageSpec:


### PR DESCRIPTION
## Summary
Increase Prometheus startup probe timeout from 15 to 60 minutes to accommodate WAL replay of 548 segments after extended downtime.

## Problem
PR #110 set `failureThreshold: 180` with custom probe settings, but the Helm chart overrode these with defaults:
- Chart applied: `failureThreshold: 60`, `periodSeconds: 15s` = **15 minutes total**
- WAL replay takes: **~40 minutes** for 548 segments at ~4 seconds/segment
- Result: Prometheus continued crash-looping

## Root Cause
The kube-prometheus-stack Helm chart has built-in defaults for startup probe that override explicit httpGet/periodSeconds configuration. Only `failureThreshold` value is reliably overridable.

## Solution
Simplified configuration - only override `failureThreshold`:
```yaml
startupProbe:
  failureThreshold: 240  # 240 × 15s (chart default) = 60 min
```

This allows the chart to use its defaults while extending the timeout to 60 minutes.

## Changes
- Remove explicit `httpGet`, `periodSeconds`, `timeoutSeconds` config
- Set `failureThreshold: 240` (was 60 by default)
- Total startup time: 60 minutes (was 15 minutes)
- Uses chart defaults for probe endpoint and timing

## Testing
After merge:
- Flux will deploy updated HelmRelease
- Prometheus pod will restart with 60-minute startup window
- WAL replay should complete successfully (currently at segment 329/548)
- Grafana dashboards will resume once Prometheus is ready

## Notes
- Configuration-only change, no security impact
- Previous approach (PR #110) was correct conceptually but overridden by chart
- This fix addresses the chart override behavior

Related to issue reported in chat: monitoring stack unavailable, Grafana showing "dial tcp error"