### PR TITLE
fix(kube-system): correct GitRepository reference for nvidia-dcgm-exporter

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-dcgm-exporter/ks.yaml
+++ b/kubernetes/apps/kube-system/nvidia-dcgm-exporter/ks.yaml
@@ -13,7 +13,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-kubernetes
+    name: flux-system
   wait: false
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Summary

Fix GPU metrics collection by correcting GitRepository reference in nvidia-dcgm-exporter Kustomization.

## Problem

All GPU monitoring dashboards showing **"No data"** due to failed Flux reconciliation:

```
nvidia-dcgm-exporter   2d1h   False   GitRepository.source.toolkit.fluxcd.io "home-kubernetes" not found
```

## Root Cause

The `nvidia-dcgm-exporter/ks.yaml` referenced non-existent GitRepository `home-kubernetes` instead of the actual `flux-system` GitRepository.

## Changes

**File**: `kubernetes/apps/kube-system/nvidia-dcgm-exporter/ks.yaml`

```diff
  sourceRef:
    kind: GitRepository
-   name: home-kubernetes
+   name: flux-system
```

## Impact

**Before**: 
- DCGM exporter Kustomization failing for 2+ days
- Zero GPU metrics in Prometheus
- GPU Monitoring dashboard completely empty
- Cluster Overview dashboard missing "Total GPUs" metric

**After**:
- Flux will successfully reconcile nvidia-dcgm-exporter Kustomization
- DCGM exporter DaemonSet will deploy to GPU nodes
- GPU metrics will populate in Grafana dashboards

## Testing Plan

After merge:
- [ ] Verify Kustomization reconciles: `kubectl get kustomization -n kube-system nvidia-dcgm-exporter`
- [ ] Verify HelmRelease deploys: `kubectl get helmrelease -n kube-system nvidia-dcgm-exporter`
- [ ] Verify DCGM pods running on GPU nodes: `kubectl get pods -n kube-system | grep dcgm`
- [ ] Check Prometheus metrics: Query `DCGM_FI_DEV_GPU_UTIL`
- [ ] Validate Grafana GPU dashboard shows data

## Security Review

✅ Security-guardian review passed:
- No secrets or credentials exposed
- Metadata-only change (Git source reference)
- No security vulnerabilities introduced
- Safe for public GitHub repository

## Related Issues

Part of Grafana dashboard audit - fixing missing metrics across monitoring stack.