### PR TITLE
fix(kube-system): add namespace to GitRepository sourceRef

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-dcgm-exporter/ks.yaml
+++ b/kubernetes/apps/kube-system/nvidia-dcgm-exporter/ks.yaml
@@ -14,6 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+    namespace: flux-system
   wait: false
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Summary

Add missing namespace field to GitRepository sourceRef in nvidia-dcgm-exporter Kustomization.

## Problem

Follow-up issue from PR #115. After merging the GitRepository name fix, the Kustomization still failed:

```
nvidia-dcgm-exporter   False   GitRepository.source.toolkit.fluxcd.io "flux-system" not found
```

## Root Cause

The sourceRef was missing the `namespace` field, causing Flux to look for the GitRepository in the same namespace as the Kustomization (`kube-system`) instead of where it actually exists (`flux-system`).

## Change

```diff
  sourceRef:
    kind: GitRepository
    name: flux-system
+   namespace: flux-system
```

## Impact

This completes the fix for GPU metrics collection:
- Flux will find the correct GitRepository
- DCGM exporter Kustomization will reconcile successfully
- HelmRelease will deploy DCGM exporter pods
- GPU metrics will populate in Grafana

## Testing

After merge, verify:
- `kubectl get kustomization -n flux-system nvidia-dcgm-exporter` shows READY=True
- `kubectl get pods -n kube-system | grep dcgm` shows running pods
- GPU dashboard in Grafana shows metrics