### PR TITLE
fix(kube-system): add nvidia runtimeClassName to DCGM exporter

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-dcgm-exporter/app/helmrelease.yaml
@@ -53,6 +53,9 @@ spec:
     securityContext:
       privileged: true
 
+    # Runtime class for NVIDIA GPU access
+    runtimeClassName: nvidia
+
     # Resource limits
     resources:
       requests:


### PR DESCRIPTION
## Summary

Fix DCGM exporter CrashLoopBackOff by adding NVIDIA runtime class for GPU access.

## Problem

After PR #116, DCGM exporter pods deployed but immediately crashed:

```
nvidia-dcgm-exporter-kdrjg   0/1   CrashLoopBackOff   3 (22s ago)   105s
nvidia-dcgm-exporter-qkkk7   0/1   CrashLoopBackOff   3 (18s ago)   105s
```

Logs showed successful DCGM initialization but immediate exit:
```
time="2025-11-14T06:31:28Z" level=info msg="DCGM successfully initialized!"
(container exits immediately)
```

## Root Cause

DCGM exporter requires **NVIDIA Container Runtime** to access GPU devices and libraries. Without `runtimeClassName: nvidia`, the container cannot communicate with GPUs via DCGM APIs.

## Change

```yaml
# Runtime class for NVIDIA GPU access
runtimeClassName: nvidia
```

## Impact

With NVIDIA runtime:
- Pods will have access to NVIDIA device libraries
- DCGM can communicate with GPUs
- Exporter will successfully collect and expose GPU metrics
- Prometheus can scrape metrics
- Grafana GPU dashboards will populate

## Testing

After merge:
- [ ] Verify pods start successfully: `kubectl get pods -n kube-system | grep dcgm`
- [ ] Check logs show metrics being collected
- [ ] Verify Prometheus scrapes metrics: Query `DCGM_FI_DEV_GPU_UTIL`
- [ ] Confirm GPU dashboard in Grafana shows data

## Related

- Fixes final issue from GPU metrics audit
- Completes chain: PR #115 → PR #116 → PR #117 (this)