### PR TITLE
fix(kube-system): increase DCGM exporter memory limits to prevent OOMKilled

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-dcgm-exporter/app/helmrelease.yaml
@@ -60,10 +60,10 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: 128Mi
-      limits:
-        cpu: 200m
         memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
 
     # Arguments for DCGM exporter
     arguments:


### PR DESCRIPTION
## Summary

Fix DCGM exporter OOMKilled crashes by increasing memory limits from 256Mi to 512Mi.

## Problem

After PR #117 added nvidia runtime, pods still crashed with **exit code 137 (OOMKilled)**:

```json
{
  "exitCode": 137,
  "reason": "OOMKilled",
  "containerID": "containerd://5b4bf9e..."
}
```

Logs showed successful initialization before being killed:
```
time="2025-11-14T06:37:42Z" level=info msg="DCGM successfully initialized!"
(immediately killed by OOM)
```

## Root Cause

DCGM exporter requires more memory than initially allocated when:
- Loading NVIDIA GPU libraries via nvidia runtime
- Initializing DCGM daemon communication
- Collecting GPU metrics from multiple devices

Original limits (256Mi) were insufficient for NVIDIA runtime overhead.

## Changes

```yaml
resources:
  requests:
-   memory: 128Mi
+   memory: 256Mi
  limits:
-   cpu: 200m
-   memory: 256Mi
+   cpu: 500m
+   memory: 512Mi
```

## Impact

With increased limits:
- Pods will have sufficient memory for NVIDIA runtime and DCGM
- No more OOM kills
- Metrics collection will start successfully
- GPU dashboards will populate

## Testing

After merge:
- [ ] Verify pods reach Running state: `kubectl get pods -n kube-system | grep dcgm`
- [ ] Confirm no OOM kills: Check exit codes stay at 0
- [ ] Validate metrics endpoint: `curl http://<pod-ip>:9400/metrics`
- [ ] Check Prometheus scrapes GPU metrics
- [ ] Verify Grafana GPU dashboard shows data

## Related

Completes GPU metrics chain:
- PR #115: Fixed GitRepository name
- PR #116: Added namespace to sourceRef  
- PR #117: Added nvidia runtimeClassName
- PR #118: Fixed memory limits (this)