### PR TITLE
fix(observability): disable Loki alert rule management in Grafana UI

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -174,8 +174,12 @@ spec:
               url: http://loki:3100
               access: proxy
               isDefault: false
+              # Disable alert rule management - Loki is for logs, not Prometheus-style metrics
+              editable: false
               jsonData:
                 maxLines: 1000
+                # Disable alerting UI - Loki uses LogQL, not PromQL for alerts
+                manageAlerts: false
                 derivedFields:
                   - datasourceUid: Prometheus
                     matcherRegex: "traceID=(\\w+)"


### PR DESCRIPTION
## Summary

Fix Grafana Alert Rules error by disabling alert rule management for Loki datasource.

## Problem

Grafana's Alerting UI showed error:
```
Failed to load the data source configuration for Loki: 
Unable to fetch alert rules. Is the Loki data source properly configured?
```

**Root Cause**: Loki is a log aggregation system using LogQL, not a metrics system using PromQL. Grafana's Alerting UI expects Prometheus-style alert rules, which Loki doesn't support.

## Solution

Disable alert rule management in Grafana UI for Loki datasource:

1. **`editable: false`** - Make datasource read-only in UI (enforces GitOps)
2. **`jsonData.manageAlerts: false`** - Disable alert rule management for Loki

## Changes

- Modified `kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml`
- Added configuration flags to Loki datasource definition
- Added explanatory comments

```diff
+              # Disable alert rule management - Loki is for logs, not Prometheus-style metrics
+              editable: false
               jsonData:
                 maxLines: 1000
+                # Disable alerting UI - Loki uses LogQL, not PromQL for alerts
+                manageAlerts: false
```

## Testing Plan

After merge and Flux deployment:
- [ ] Navigate to Grafana → Alerting → Alert rules
- [ ] Verify error message is gone
- [ ] Verify Loki datasource is read-only in UI
- [ ] Confirm Loki is not shown as option for creating alert rules
- [ ] Check Grafana pod logs for errors: `kubectl logs -n observability deploy/kube-prometheus-stack-grafana`

## Security Review

- [x] Security-guardian approval received
- [x] No secrets or credentials exposed
- [x] Configuration hardening (enforces GitOps workflow)
- [x] YAML syntax validated
- [x] Safe for public repository

## Related Issues

- Grafana dashboard audit identified this error
- Part of dashboard cleanup initiative