### PR TITLE
fix(iot): remove obsolete Gluetun VPN proxy configuration from Home Assistant

### DIFF
--- a/kubernetes/apps/iot/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/home-assistant/app/helmrelease.yaml
@@ -25,9 +25,6 @@ spec:
               tag: 2024.11.1
             env:
               TZ: America/New_York
-              HTTP_PROXY: http://gluetun.network.svc.cluster.local:8888
-              HTTPS_PROXY: http://gluetun.network.svc.cluster.local:8888
-              NO_PROXY: 10.20.62.0/23,10.20.67.0/23,10.43.0.0/16,.svc.cluster.local,localhost,127.0.0.1
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Summary

Remove obsolete Gluetun VPN proxy environment variables from Home Assistant deployment that reference a non-existent service.

## Context

After evaluating VPN integration for Home Assistant outbound traffic routing, we decided **NOT to pursue this approach** (see `.claude/.ai-docs/apps/home-assistant/VPN_DECISION.md`).

The Gluetun VPN service was planned but never deployed. The proxy environment variables in the Home Assistant HelmRelease pointed to this non-existent service, which would cause outbound connection failures once the pod starts.

## Changes

**File**: `kubernetes/apps/iot/home-assistant/app/helmrelease.yaml`

**Removed**:
```yaml
HTTP_PROXY: http://gluetun.network.svc.cluster.local:8888
HTTPS_PROXY: http://gluetun.network.svc.cluster.local:8888
NO_PROXY: 10.20.62.0/23,10.20.67.0/23,10.43.0.0/16,.svc.cluster.local,localhost,127.0.0.1
```

**Result**: Home Assistant will have direct internet access for software updates and cloud integrations.

## Access Policy Compliance

Per `.claude/.ai-docs/apps/home-assistant/ACCESS_POLICY.md`:

- ✅ **Internal-only access**: Maintained (uses `envoy-internal` gateway)
- ✅ **VLAN 62 IoT access**: Preserved (Multus annotation `network/iot-vlan62`)
- ✅ **Internet access**: Allowed for updates/cloud integrations (direct egress)
- ✅ **No public exposure**: No Cloudflare tunnel, no external gateway, no UDM port forward

## Network Architecture

**Access Pattern**:
- **Internal**: `homeassistant.homelab0.org` via Envoy Gateway (internal-only)
- **IoT Devices**: VLAN 62 (10.20.62.0/23) via Multus secondary interface (eth1)
- **Internet**: Direct egress for updates (no VPN proxy)
- **External**: NO public access (internal DNS only)

## Related Documentation Updates

- ✅ Updated `ACCESS_POLICY.md` to allow internet egress
- ✅ Archived `FUTURE-STATE.md` (VPN architecture documentation)
- ✅ Created `VPN_DECISION.md` explaining why VPN was abandoned

## Security Review

- ✅ security-guardian review: **APPROVED**
- ✅ No secrets or credentials exposed
- ✅ YAML syntax validated
- ✅ Access policy compliance verified
- ✅ No external public exposure introduced

## Testing Plan

After merge and Flux reconciliation:

- [ ] Verify proxy env vars removed: `kubectl exec -n iot deploy/home-assistant -- env | grep PROXY`
- [ ] Test internet connectivity: `kubectl exec -n iot deploy/home-assistant -- curl -s https://www.google.com`
- [ ] Verify internal access works: `curl -k https://homeassistant.homelab0.org`
- [ ] Confirm no external exposure: External DNS lookup should fail

## Notes

**Current Status**: Home Assistant pod is stuck in ContainerCreating for 27+ hours due to unrelated VLAN networking issue (missing eth1 interface on worker nodes). This PR fixes the proxy configuration. A separate PR will address the NIC issue via Terraform.

**VPN Decision**: Abandoned for simplicity. ISP seeing Home Assistant update traffic is acceptable for homelab environment. VPN adds unnecessary complexity and failure modes.

## Rationale

**Why VPN was abandoned**:
1. Unnecessary complexity for marginal privacy benefit
2. VPN kill switch could break Home Assistant during failures
3. Home Assistant's primary function is local IoT device management
4. Simpler architecture is more maintainable for homelab

**Why direct internet access is acceptable**:
- Personal homelab environment (not commercial)
- Update traffic to Home Assistant servers is not sensitive
- Cloud integrations are optional and can be disabled if needed
- Local-only mode is available if privacy becomes a concern

See `.claude/.ai-docs/apps/home-assistant/VPN_DECISION.md` for complete decision rationale.