### PR TITLE
fix(github-actions): remove invalid external-secrets dependency

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/ks.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/ks.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   dependsOn:
     - name: gha-runner-scale-set-controller
-    - name: external-secrets
   interval: 1h
   path: ./kubernetes/apps/github-actions/gha-runner-scale-set/app
   prune: true


### PR DESCRIPTION
## Problem

The gha-runner-scale-set Kustomization is failing to deploy with:
```
dependency 'github-actions/external-secrets' not found
```

## Root Cause

The dependency name `external-secrets` doesn't exist. The Kustomization was looking for a dependency that doesn't exist in the cluster.

## Solution

Removed the invalid `external-secrets` dependency. Following repository pattern (gluetun, cloudflare-dns, cloudflare-tunnel), apps with ExternalSecret don't need to declare external-secrets as a dependency since the ExternalSecret controller is cluster-wide.

## Impact

This unblocks the runner scale set deployment. The fix is minimal and follows existing patterns in the repository.

## Changes

- Removed `external-secrets` from dependsOn array
- Kept `gha-runner-scale-set-controller` dependency only

## Testing

After merge, Flux will reconcile and the gha-runner-scale-set Kustomization should deploy successfully.