### PR TITLE
fix(workflows): use ARC runner scale set name directly in runs-on

### DIFF
--- a/.github/workflows/test-self-hosted-runner.yaml
+++ b/.github/workflows/test-self-hosted-runner.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   test-runner-basic:
     name: Test Basic Runner Functionality
-    runs-on: [self-hosted, cattle-upgrade]
+    runs-on: cattle-upgrade
     if: inputs.test_type == 'basic' || inputs.test_type == ''
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
 
   test-runner-kubectl:
     name: Test kubectl Access
-    runs-on: [self-hosted, cattle-upgrade]
+    runs-on: cattle-upgrade
     if: inputs.test_type == 'kubectl'
     steps:
       - name: Install kubectl
@@ -99,7 +99,7 @@ jobs:
 
   test-runner-terraform:
     name: Test Terraform Access
-    runs-on: [self-hosted, cattle-upgrade]
+    runs-on: cattle-upgrade
     if: inputs.test_type == 'terraform'
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

Fix test workflow to use modern ARC 0.13.0 syntax for runner selection.

## Changes

Changed workflow `runs-on` syntax from:
```yaml
runs-on: [self-hosted, cattle-upgrade]  # ❌ Legacy syntax
```

To:
```yaml
runs-on: cattle-upgrade  # ✅ ARC 0.13.0 syntax
```

## Root Cause

With modern Actions Runner Controller (v0.13.0), the runner scale set name is used **directly** as the runs-on label, not as part of an array with `self-hosted`.

This is why workflows were staying queued - GitHub couldn't match jobs to runners because the runners only have the scale set name as their label, not the array format.

## Testing

After merge, trigger the test workflow:
```bash
gh workflow run test-self-hosted-runner.yaml -f test_type=basic
```

The runner should immediately pick up the job.

## References

- GitHub Docs: [Using ARC runners in a workflow](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/using-actions-runner-controller-runners-in-a-workflow)
- ARC 0.13.0 uses installation name directly as the runner label