### PR TITLE
fix(github-actions): downgrade ARC to 0.12.1 to fix JIT token bug

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set-controller/app/ocirepository.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 12h
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
   ref:
-    tag: "0.13.0"
+    tag: "0.12.1"

--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/ocirepository.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/ocirepository.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 12h
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
   ref:
-    tag: "0.13.0"
+    tag: "0.12.1"


### PR DESCRIPTION
## Summary

Downgrade Actions Runner Controller from 0.13.0 to 0.12.1 to fix critical bug preventing runners from acquiring assigned GitHub Actions jobs.

## Problem

After deploying ARC 0.13.0, workflows using `runs-on: cattle-upgrade` stay stuck in "queued" state indefinitely, despite:
- Listener successfully receiving job assignments from GitHub
- Controller creating runner pods with JIT tokens
- Runners completing with exitCode 0 (no errors logged)

## Root Cause

ARC 0.13.0 changelog states: **"Remove JIT config from ephemeral runner status field"**

This architectural change breaks job acquisition when using `minRunners > 0`:
- Listener assigns jobs: `totalAssignedJobs: 1` ✅
- Runners created with JIT tokens ✅
- **Runners fail to acquire jobs**: `totalAcquiredJobs: 0` ❌
- Job completion messages show empty `RunnerId` and `RunnerName`
- Jobs stay queued forever

## Solution

Downgrade to version 0.12.1 (last stable release before JIT token changes):
- **Released**: June 27, 2024
- **No known CVEs** or security vulnerabilities
- Proper JIT token storage in ephemeral runner status field
- Proven stability with `minRunners` configuration

## Changes

- `kubernetes/apps/github-actions/gha-runner-scale-set-controller/app/ocirepository.yaml`: tag `0.13.0` → `0.12.1`
- `kubernetes/apps/github-actions/gha-runner-scale-set/app/ocirepository.yaml`: tag `0.13.0` → `0.12.1`

## Testing Plan

After merge and Flux reconciliation:
- [ ] Verify OCIRepositories pull 0.12.1 charts successfully
- [ ] Verify HelmReleases upgrade to 0.12.1 without errors
- [ ] Verify controller pod restarts successfully
- [ ] Trigger test workflow: `.github/workflows/test-self-hosted-runner.yaml`
- [ ] Verify runners acquire jobs (`totalAcquiredJobs > 0`)
- [ ] Verify workflow completes successfully (not stuck in queued)
- [ ] Verify anti-affinity still enforces runners on different nodes

## Security Review

- [x] security-guardian approval received
- [x] Version 0.12.1 is official GitHub release (no CVEs)
- [x] No secrets exposed in changes
- [x] No infrastructure details leaked
- [x] YAML syntax validated

## Notes

- This is a **temporary workaround** until ARC 0.13.x addresses the JIT token issue
- Configuration remains unchanged (3 fixed runners with anti-affinity)
- Cattle upgrade resilience design unaffected
- Relates to EPIC-019 Story 3: Deploy self-hosted runners for automated Talos cattle upgrades