### PR TITLE
fix(github-actions): remove minAvailable from PDB (invalid spec)

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/pdb.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/pdb.yaml
@@ -10,9 +10,8 @@ metadata:
     app.kubernetes.io/name: gha-runner-scale-set
     app.kubernetes.io/component: pdb
 spec:
-  # Allow all runners to be evicted if absolutely necessary
-  # But limit voluntary disruptions to one at a time
-  minAvailable: 0
+  # Limit voluntary disruptions to one runner at a time during node drains
+  # No minAvailable set, allowing all runners to be evicted if necessary
   maxUnavailable: 1
 
   # Select runner pods


### PR DESCRIPTION
## Problem

Flux reconciliation failing with error:


## Root Cause

Kubernetes PodDisruptionBudget validation requires **either**  **or** , not both.

## Fix

Remove , keep only 

## Result

This achieves the same intended behavior:
- ✅ Limits voluntary disruptions (node drains) to one runner at a time
- ✅ Allows all runners to be evicted if necessary (no minimum enforced)
- ✅ Compatible with dynamic scaling (minRunners: 0)

## Testing

After merge, Flux should reconcile successfully and PDB should be created.