### PR TITLE
fix(github-actions): add RUNNER_LABELS env var to fix ARC 0.13.0 empty labels bug

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -65,6 +65,14 @@ spec:
                 cpu: 2000m
                 memory: 4Gi
 
+            # CRITICAL FIX: ARC 0.13.0 doesn't propagate runnerScaleSetName to GitHub as a label
+            # We must explicitly set RUNNER_LABELS env var to force runner registration with label
+            # Without this, runners register with labels:[] and workflows stay queued forever
+            # Reference: ChatGPT Deep Research (arc-empty-labels-issue.md)
+            env:
+              - name: RUNNER_LABELS
+                value: "cattle-upgrade"
+
             # Security context (container-level)
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Fixes critical ARC 0.13.0 bug where runners register with **empty labels** (`labels:[]`), causing all workflows to stay stuck in "queued" state forever.

## Root Cause (ChatGPT Deep Research)

**The Problem**:
- ARC 0.13.0 has known bug where `runnerScaleSetName` doesn't propagate to GitHub as a runner label
- Runners register with GitHub successfully but have `labels:[]` (completely empty)
- Workflows use `runs-on: cattle-upgrade` expecting label match
- No match → jobs never acquired → runners exit after 2 seconds → workflows queued forever

**Evidence**:
```bash
# GitHub API shows empty labels
gh api repos/jlengelbrecht/prox-ops/actions/runners
{"id": 9224, "name": "cattle-upgrade-runner-xxx", "labels": []}  # ← EMPTY!

# Listener shows jobs assigned but never acquired
totalAssignedJobs: 4   # ✅ Jobs assigned to scale set
totalAcquiredJobs: 0   # ❌ No runner acquired jobs

# 9 workflows stuck in queued state for hours
```

## Solution

Add `RUNNER_LABELS` environment variable to runner container template:

```yaml
env:
  - name: RUNNER_LABELS
    value: "cattle-upgrade"
```

This forces the runner's `config.sh` to register with `--labels "cattle-upgrade"` during GitHub registration, bypassing ARC's broken label propagation.

## Changes

**File**: `kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml`

**Change**: Added 6 lines (env var + comments) to runner container spec

```yaml
# CRITICAL FIX: ARC 0.13.0 doesn't propagate runnerScaleSetName to GitHub as a label
# We must explicitly set RUNNER_LABELS env var to force runner registration with label
# Without this, runners register with labels:[] and workflows stay queued forever
# Reference: ChatGPT Deep Research (arc-empty-labels-issue.md)
env:
  - name: RUNNER_LABELS
    value: "cattle-upgrade"
```

## Expected Outcome

✅ **Before Merge** (current broken state):
- Runners register with `labels:[]`
- Workflows stuck in "queued" state
- `totalAcquiredJobs: 0`
- Runners exit after 2 seconds (no work)

✅ **After Merge** (fixed):
- Runners register with `labels:["cattle-upgrade"]`
- GitHub immediately matches jobs to runners
- Workflows transition from "queued" to "in progress"
- `totalAcquiredJobs` increments
- Runners stay alive to execute jobs

## Testing Plan

After merge, verify:

1. **Flux reconciles HelmRelease**:
   ```bash
   flux logs --kind=HelmRelease --name=gha-runner-scale-set -n github-actions --follow
   ```

2. **Verify env var applied**:
   ```bash
   kubectl get pods -n github-actions -l actions.github.com/scale-set-name=cattle-upgrade -o jsonpath='{.items[0].spec.containers[0].env}' | jq '.[] | select(.name=="RUNNER_LABELS")'
   ```

3. **Check runner registration**:
   ```bash
   gh api repos/jlengelbrecht/prox-ops/actions/runners --jq '.runners[] | select(.name | startswith("cattle-upgrade")) | {id, name, labels: [.labels[].name]}'
   ```
   Expected: `labels:["self-hosted","Linux","X64","cattle-upgrade"]`

4. **Test workflow execution**:
   - Trigger test workflow
   - Should pick up runner immediately (no queue delay)
   - `totalAcquiredJobs` should increment

## Security Review

✅ **APPROVED** by security-guardian agent

- No secrets, credentials, or sensitive data exposed
- Static string value (`"cattle-upgrade"` is non-sensitive public metadata)
- YAML syntax validated
- Follows Kubernetes env var best practices
- Safe to push to public GitHub repository

## References

- **ChatGPT Deep Research**: `.claude/.ai-docs/openai-deepresearch/GitHub ARC (Autoscaling Runner Scale Sets) – __Empty Labels & Queued Jobs__.pdf`
- **Issue Doc**: `.claude/.ai-docs/openai-deepresearch/arc-empty-labels-issue.md`
- **ARC Issue #3330**: `self-hosted` label missing from scale-set runners
- **ARC Issue #4000**: Runners removed for being idle before job assignment
- **StackOverflow**: Explicitly set `runnerLabels` in values to force label registration

## Related Issues

- Closes all 9 queued workflows (oldest from 4+ hours ago)
- Enables cattle upgrade automation (EPIC-019)
- Unblocks self-hosted runner deployment

## Risk Assessment

**Risk**: LOW
- Single environment variable addition
- No secrets or RBAC changes
- Rollback: Remove env var, Flux redeploys
- Security approved by automated review

**Impact**: HIGH
- Critical blocker for cattle upgrade automation
- Fixes 9+ queued workflows
- Enables all future self-hosted runner workflows