### PR TITLE
fix(github-actions): add ACTIONS_RUNNER_INPUT_LABELS for ARC 0.13.0 compatibility

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -66,11 +66,14 @@ spec:
                 memory: 4Gi
 
             # CRITICAL FIX: ARC 0.13.0 doesn't propagate runnerScaleSetName to GitHub as a label
-            # We must explicitly set RUNNER_LABELS env var to force runner registration with label
+            # We must explicitly set runner label env vars to force runner registration with label
             # Without this, runners register with labels:[] and workflows stay queued forever
             # Reference: ChatGPT Deep Research (arc-empty-labels-issue.md)
+            # Trying both env var names since different runner versions may use different names
             env:
               - name: RUNNER_LABELS
+                value: "cattle-upgrade"
+              - name: ACTIONS_RUNNER_INPUT_LABELS
                 value: "cattle-upgrade"
 
             # Security context (container-level)


### PR DESCRIPTION
## Summary

Add second environment variable (`ACTIONS_RUNNER_INPUT_LABELS`) to fix ARC 0.13.0 runner label propagation bug. This is a follow-up to PR #144.

## Problem

PR #144 added `RUNNER_LABELS` env var per ChatGPT deep research, but **verification showed it didn't work**:

- ✅ Kubernetes specs correctly show `RUNNER_LABELS` env var
- ❌ GitHub API shows runners with `labels:[]` (empty)
- ❌ 9+ workflows stuck in "queued" state
- ❌ `totalAcquiredJobs: 0` (jobs never acquired)

## Root Cause

Different GitHub Actions runner image versions may use different environment variable names for label configuration. The `actions-runner:2.329.0` image may expect `ACTIONS_RUNNER_INPUT_LABELS` instead of (or in addition to) `RUNNER_LABELS`.

## Changes

Added `ACTIONS_RUNNER_INPUT_LABELS` environment variable alongside existing `RUNNER_LABELS`:

```yaml
env:
  - name: RUNNER_LABELS
    value: "cattle-upgrade"
  - name: ACTIONS_RUNNER_INPUT_LABELS
    value: "cattle-upgrade"
```

Both variables set to the same value to ensure compatibility with different runner versions.

## Expected Outcome

After merge and Flux deployment:

1. Runners register with GitHub showing `labels:["cattle-upgrade"]`
2. Workflow matching works (`runs-on: cattle-upgrade` matches runner labels)
3. Jobs transition from "queued" to "in progress"
4. `totalAcquiredJobs` increments (currently stuck at 0)
5. Workflows complete successfully

## Testing Plan

- [ ] User merges PR
- [ ] Monitor Flux reconciliation
- [ ] Verify env vars in pod specs: `kubectl get pods -n github-actions -o yaml`
- [ ] Check GitHub runner labels: `gh api repos/jlengelbrecht/prox-ops/actions/runners`
- [ ] Trigger test workflow
- [ ] Verify job acquisition succeeds

## Security Review

- ✅ security-guardian approval received
- ✅ No secrets or credentials exposed
- ✅ YAML syntax validated
- ✅ Static string values only

## Related

- PR #144: First attempt with `RUNNER_LABELS` only
- ChatGPT Deep Research: `.claude/.ai-docs/openai-deepresearch/GitHub ARC (Autoscaling Runner Scale Sets) – __Empty Labels & Queued Jobs__.pdf`
- ARC Issue: Runner labels empty despite `runnerScaleSetName` configured

## Notes

This is attempt #2 to fix the label propagation bug. If this doesn't work, we may need to:
- Investigate ARC source code for actual env var names
- Try different runner image versions
- Report bug to actions/actions-runner-controller project