### PR TITLE
fix(github-actions): adopt onedr0p pattern to fix ARC 0.13.0 label propagation bug

### DIFF
--- a/.github/workflows/test-self-hosted-runner.yaml
+++ b/.github/workflows/test-self-hosted-runner.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   test-runner-basic:
     name: Test Basic Runner Functionality
-    runs-on: cattle-upgrade
+    runs-on: gha-runner-scale-set
     if: inputs.test_type == 'basic' || inputs.test_type == ''
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
 
   test-runner-kubectl:
     name: Test kubectl Access
-    runs-on: cattle-upgrade
+    runs-on: gha-runner-scale-set
     if: inputs.test_type == 'kubectl'
     steps:
       - name: Install kubectl
@@ -99,7 +99,7 @@ jobs:
 
   test-runner-terraform:
     name: Test Terraform Access
-    runs-on: cattle-upgrade
+    runs-on: gha-runner-scale-set
     if: inputs.test_type == 'terraform'
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -20,8 +20,8 @@ spec:
     remediation:
       retries: 3
   values:
-    # Runner scale set name (used in runs-on: [self-hosted, cattle-upgrade])
-    runnerScaleSetName: "cattle-upgrade"
+    # Runner scale set name defaults to HelmRelease name: gha-runner-scale-set
+    # Following onedr0p's working pattern - do NOT set runnerScaleSetName explicitly
 
     # GitHub configuration
     githubConfigUrl: "https://github.com/jlengelbrecht/prox-ops"
@@ -65,16 +65,8 @@ spec:
                 cpu: 2000m
                 memory: 4Gi
 
-            # CRITICAL FIX: ARC 0.13.0 doesn't propagate runnerScaleSetName to GitHub as a label
-            # We must explicitly set runner label env vars to force runner registration with label
-            # Without this, runners register with labels:[] and workflows stay queued forever
-            # Reference: ChatGPT Deep Research (arc-empty-labels-issue.md)
-            # Trying both env var names since different runner versions may use different names
-            env:
-              - name: RUNNER_LABELS
-                value: "cattle-upgrade"
-              - name: ACTIONS_RUNNER_INPUT_LABELS
-                value: "cattle-upgrade"
+            # Following onedr0p pattern: do NOT set explicit RUNNER_LABELS env vars
+            # Let ARC default to HelmRelease name (gha-runner-scale-set) for label propagation
 
             # Security context (container-level)
             securityContext:
@@ -130,7 +122,7 @@ spec:
                       - key: actions.github.com/scale-set-name
                         operator: In
                         values:
-                          - cattle-upgrade
+                          - gha-runner-scale-set
                   topologyKey: kubernetes.io/hostname
 
         # Tolerations (avoid GPU nodes unless necessary)

--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/pdb.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/pdb.yaml
@@ -17,7 +17,7 @@ spec:
   # Select runner pods
   selector:
     matchLabels:
-      actions.github.com/scale-set-name: cattle-upgrade
+      actions.github.com/scale-set-name: gha-runner-scale-set
 
   # Optional: Track disruptions
   unhealthyPodEvictionPolicy: IfHealthyBudget


### PR DESCRIPTION
## Summary

Adopts onedr0p's working pattern to fix ARC 0.13.0 bug where runners register with empty labels, causing workflows to remain stuck in "queued" state indefinitely.

## Root Cause

ARC 0.13.0 has a label propagation bug:
- Setting `runnerScaleSetName: "cattle-upgrade"` explicitly doesn't propagate to GitHub as a runner label
- Runners register with GitHub showing `labels: []` (empty)
- Workflows with `runs-on: cattle-upgrade` can't match runners with empty labels
- Jobs timeout after 50 seconds with no runner acquisition

Previous attempts:
- PR #143: Set `minRunners: 1` to fix "race condition" (didn't work - wrong diagnosis)
- PR #144: Add `RUNNER_LABELS` env var (didn't work - runners still had empty labels)
- PR #145: Add both `RUNNER_LABELS` and `ACTIONS_RUNNER_INPUT_LABELS` (didn't work)

Real-time monitoring showed:
- `totalAssignedJobs: 5` (Listener receives jobs ✅)
- `totalAcquiredJobs: 0` (Runners never acquire jobs ❌)
- Runners exit after 3 seconds with code 0
- GitHub API shows: `{"labels": []}`

## Solution

Adopt onedr0p's working pattern from [home-ops repository](https://github.com/onedr0p/home-ops):

1. **Remove explicit `runnerScaleSetName`** from Helm values
2. **Remove `RUNNER_LABELS` environment variables** from runner container
3. **Rely on ARC default behavior**: HelmRelease name becomes the runner scale set name
4. **Update workflow labels** to match HelmRelease name: `gha-runner-scale-set`
5. **Update PodDisruptionBudget selector** to match new label

## Changes

### kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml

- Removed `runnerScaleSetName: "cattle-upgrade"` explicit configuration
- Removed `RUNNER_LABELS` and `ACTIONS_RUNNER_INPUT_LABELS` env vars
- Updated pod anti-affinity value from `cattle-upgrade` to `gha-runner-scale-set`
- Added comments explaining onedr0p pattern

### .github/workflows/test-self-hosted-runner.yaml

- Updated all three job `runs-on` labels:
  - `test-runner-basic`: `cattle-upgrade` → `gha-runner-scale-set`
  - `test-runner-kubectl`: `cattle-upgrade` → `gha-runner-scale-set`
  - `test-runner-terraform`: `cattle-upgrade` → `gha-runner-scale-set`

### kubernetes/apps/github-actions/gha-runner-scale-set/app/pdb.yaml

- Updated selector label from `cattle-upgrade` to `gha-runner-scale-set`
- Ensures PDB correctly matches runner pods for controlled eviction

## Expected Outcome

After Flux deploys these changes:
- ✅ Runners will register with GitHub with label: `gha-runner-scale-set`
- ✅ GitHub workflows using `runs-on: gha-runner-scale-set` will match runners
- ✅ `totalAcquiredJobs` will increment (currently stuck at 0)
- ✅ Workflows will transition from "queued" to "in progress"
- ✅ Runners will stay alive to execute jobs (not exit after 3 seconds)
- ✅ PDB will correctly control node drain evictions

## Testing Plan

After merge and Flux reconciliation:

- [ ] Verify Flux reconciliation succeeds
- [ ] Check runner pod labels: `kubectl get pods -n github-actions -l actions.github.com/scale-set-name=gha-runner-scale-set`
- [ ] Verify PDB matches pods: `kubectl get pdb -n github-actions`
- [ ] Trigger test workflow: `gh workflow run test-self-hosted-runner.yaml -f test_type=basic`
- [ ] Monitor listener logs for job acquisition
- [ ] Verify runner labels in GitHub UI (Settings → Actions → Runners)
- [ ] Confirm workflow completes successfully

## Security Review

✅ **Approved by security-guardian**

- No secrets, credentials, or sensitive data exposed
- YAML syntax validated for all files
- Label consistency verified (no remaining `cattle-upgrade` references)
- GitOps compliant (file-based changes, Flux-deployable)
- Security contexts, RBAC, resource limits properly configured

## Rollback Plan

If deployment fails:

```bash
# Immediate rollback via GitOps
git revert 6df619f
git push origin main
# Wait for Flux reconciliation (~30s)
```

## References

- onedr0p's working configuration: https://github.com/onedr0p/home-ops
- Previous attempts: PRs #137, #138, #139, #140, #141, #142, #143, #144, #145
- Deep research: `.claude/.ai-docs/openai-deepresearch/arc-empty-labels-issue.md`

Relates to EPIC-019: Cattle Upgrade Infrastructure