### PR TITLE
feat(renovate): add Talos version monitoring for automated upgrades

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -22,6 +22,17 @@
         "registryUrl=(?<registryUrl>\\S+)\\n.*?oci:\\/\\/(?<depName>[^:]+):(?<currentValue>.*)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Monitor Talos version in Terraform variables",
+      "fileMatch": ["^terraform/variables\\.tf$"],
+      "matchStrings": [
+        "variable \"talos_version\"[^}]+default\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "siderolabs/talos",
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.3"
+  default     = "1.11.5"
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## Summary

Configure Renovate to automatically monitor Talos Linux releases and create PRs when new versions are available. This completes the first step in the automated upgrade pipeline for STORY-045.

## Changes

### Renovate Custom Manager
- Added regex manager to monitor `terraform/variables.tf`
- Datasource: `github-releases` (siderolabs/talos)
- Version matching: `\d+\.\d+\.\d+` (semantic versioning)
- File pattern: `^terraform/variables\.tf$` (highly specific)

### Terraform Variable Sync
- Updated `talos_version`: 1.11.3 → 1.11.5
- Syncs Terraform with actual cluster state
- Resolves infrastructure drift from manual cattle upgrade

## Automation Flow

```
Renovate Detects New Talos Release
    ↓
Creates PR updating terraform/variables.tf
    ↓
User Reviews and Merges PR
    ↓
Router Workflow Auto-Triggers (STORY-045)
    ↓
Detects Version Type (MAJOR/MINOR/PATCH)
    ↓
Calls Cattle (MAJOR/MINOR) or Pets (PATCH) Workflow
    ↓
Automated Upgrade Completes
```

## Testing Plan

After merge:
1. Wait for Renovate to run (scheduled: every weekend)
2. Verify Renovate detects talos_version correctly
3. When next Talos version releases, verify Renovate creates PR
4. Test end-to-end: Merge Renovate PR → Router triggers → Workflow executes

## Security Review

✅ **APPROVED** - No security vulnerabilities

- Regex pattern secure (no injection risks)
- GitHub Releases is trusted datasource
- File matching highly specific (no traversal risks)
- Human review required (no auto-merge)
- Integration with cattle/pets workflows is secure

## Completes

- Automation foundation for STORY-045
- Enables end-to-end testing of cattle upgrade workflow
- Unblocks testing: Renovate → Router → Cattle → Validation