### PR TITLE
revert: restore Talos 1.11.5 after successful router workflow test

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.4"
+  default     = "1.11.5"
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## ✅ Restore Production Version After Successful Test

This PR restores Talos version to **1.11.5** (current cluster version) after successfully testing the router workflow.

## Test Results: SUCCESS ✅

**Test PR**: #154  
**Router Workflow Run**: https://github.com/jlengelbrecht/prox-ops/actions/runs/19476535990  
**Duration**: 16 seconds total

### What Was Validated

✅ **Version Detection** (grep -A3 fix from PR #153):
```
Old version: 1.11.5
New version: 1.11.4
```

✅ **Routing Logic**:
- Detected: PATCH change (MAJOR.MINOR unchanged: 1.11 → 1.11)
- Routed to: **pets workflow** (correct!)
- Skipped: cattle workflow (correct - PATCH changes don't need cattle)

✅ **Error Handling** (set -euo pipefail from PR #153):
- No pipeline errors
- Fail-fast working correctly

✅ **Workflow Execution**:
- Detect Version Change: 6s ✓
- Route to Pets Workflow: 2s ✓  
- Route to Cattle Workflow: 0s (skipped) ✓

### Bonus Validation

Merging this PR will trigger the router again with a **PATCH upgrade** (1.11.4 → 1.11.5), providing additional validation of bidirectional PATCH detection.

Expected behavior after merge:
- Router detects PATCH upgrade (not downgrade)
- Routes to pets workflow again
- Validates router works for both directions

## Impact

- ✅ No infrastructure changes (pets workflow is stub only)
- ✅ Restores production version alignment
- ✅ Completes STORY-045 testing requirements

---

**Story**: STORY-045 (Automated Version Router + Cattle Workflow)  
**Test Status**: PASSED  
**Ready to merge**: Yes - restores production state