### PR TITLE
fix(cattle): correct AWS credential secret names in workflow

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -68,8 +68,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Initialize Terraform
@@ -220,8 +220,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Initialize Terraform
@@ -420,8 +420,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Initialize Terraform


### PR DESCRIPTION
## Summary

Fixes the cattle upgrade workflow authentication failure by correcting AWS credential secret names to match existing GitHub repository secrets.

## Problem

Workflow run #19482134778 failed with:
```
Credentials could not be loaded, please check your action inputs: 
Could not load credentials from any providers
```

**Root Cause**: The workflow referenced non-existent secrets:
- `TERRAFORM_AWS_ACCESS_KEY_ID`
- `TERRAFORM_AWS_SECRET_ACCESS_KEY`

**Actual secrets** in the repository:
- `AWS_ACCESS_KEY_ID` 
- `AWS_SECRET_ACCESS_KEY`

## Changes

Updated AWS credential references in `.github/workflows/upgrade-cattle.yaml`:

**Before** (3 occurrences):
```yaml
aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
```

**After** (3 occurrences):
```yaml
aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
```

**Jobs updated**:
1. `rebuild-templates` (lines 71-72)
2. `upgrade-control-plane` (lines 223-224)
3. `upgrade-workers` (lines 423-424)

## Security Review

✅ **APPROVED** by security-guardian agent

- No secrets exposed or hardcoded
- Proper GitHub Actions secret interpolation syntax
- No infrastructure disclosure
- YAML syntax validated
- No credential leakage vectors

## Impact

After merge, the cattle upgrade workflow will:
- ✅ Successfully authenticate to AWS S3 backend
- ✅ Load Terraform remote state from `prox-ops-terraform-state` bucket
- ✅ Execute automated template rebuilds
- ✅ Perform cattle upgrades (destroy/recreate VMs)

## Testing Plan

After merge:
- [ ] Re-run cattle workflow in test mode (2 workers only)
- [ ] Verify AWS credentials load successfully
- [ ] Verify Terraform state backend connection
- [ ] Validate template rebuild phase completes
- [ ] Confirm worker upgrade phase executes

**Test command**:
```bash
gh workflow run upgrade-cattle.yaml \
  --field old_version=1.11.5 \
  --field new_version=1.11.5 \
  --field test_mode=true
```

## Notes

- **No cluster impact**: Previous workflow failed before destroying any resources
- **Test mode**: Only affects k8s-work-1 and k8s-work-2 (safe for testing)
- **No outage risk**: Workflow validates credentials before any destructive operations

Fixes workflow run: https://github.com/jlengelbrecht/prox-ops/actions/runs/19482134778

Relates to: STORY-045 (Automated Cattle Upgrade Workflow Testing)