### PR TITLE
fix(github-actions): remove containerMode kubernetes causing job failures

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -36,11 +36,6 @@ spec:
     minRunners: 1   # One warm runner for immediate job pickup
     maxRunners: 10  # Allow scaling for parallel jobs
 
-    # Container mode configuration (following onedr0p's pattern)
-    # Required for runners to properly register with labels
-    containerMode:
-      type: "kubernetes"
-
     # Runner template
     template:
       spec:
@@ -63,14 +58,6 @@ spec:
             # Official image (ghcr.io/actions/actions-runner:2.329.0) has empty label bug
             image: ghcr.io/home-operations/actions-runner@sha256:1d26dc36431014527e0d920e7b84878dcf8fd69fb9639598de1af5ccf9210131
             imagePullPolicy: IfNotPresent
-
-            # Explicit command override (following onedr0p's pattern)
-            command: ["/home/runner/run.sh"]
-
-            # Environment variables (following onedr0p's pattern)
-            env:
-              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
-                value: "false"
 
             # Resource allocation
             resources:


### PR DESCRIPTION
Fixes critical issue where all GitHub Actions workflows fail during "Set up job" phase.

## Problem
All workflows failing immediately with "Set up job" failure. Runners accept jobs but fail before executing any actual workflow steps.

## Root Cause
PR #148 added  configuration which requires runners to create additional pods for job steps. This is:
- Unnecessary for cattle workflow (no Docker operations)
- Causing setup failures
- Adding complexity without benefit

## Solution
Remove containerMode configuration and related settings:
- containerMode: kubernetes
- Explicit command override
- ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER env var

Use default containerMode (ARC handles automatically).

## Impact  
- Runners will work again
- Simpler configuration
- onedr0p's custom image still used for label fix

Blocking: Cattle workflow testing (STORY-045)