### PR TITLE
Revert "fix(github-actions): remove containerMode kubernetes causing action download failures (#163)"

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -36,9 +36,10 @@ spec:
     minRunners: 1   # One warm runner for immediate job pickup
     maxRunners: 10  # Allow scaling for parallel jobs
 
-    # containerMode: kubernetes removed - only needed for workflows using container: steps
-    # Our cattle workflow runs bash/terraform/kubectl directly in runner pod
-    # This mode was causing "Failed to resolve action download info" errors
+    # Container mode configuration (following onedr0p's pattern)
+    # Required for runners to properly register with labels
+    containerMode:
+      type: "kubernetes"
 
     # Runner template
     template:
@@ -63,6 +64,14 @@ spec:
             image: ghcr.io/home-operations/actions-runner@sha256:1d26dc36431014527e0d920e7b84878dcf8fd69fb9639598de1af5ccf9210131
             imagePullPolicy: IfNotPresent
 
+            # Explicit command override (following onedr0p's pattern)
+            command: ["/home/runner/run.sh"]
+
+            # Environment variables (following onedr0p's pattern)
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+
             # Resource allocation
             resources:
               requests:
@@ -74,10 +83,6 @@ spec:
 
             # Following onedr0p pattern: do NOT set explicit RUNNER_LABELS env vars
             # Let ARC default to HelmRelease name (gha-runner-scale-set) for label propagation
-
-            # Note: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER env var removed
-            # Only needed with containerMode: kubernetes (which we removed)
-            # Workflows run directly in runner pod for better tool/credential access
 
             # Security context (container-level)
             securityContext:


### PR DESCRIPTION
## URGENT REVERT

Reverting PR #163 because removing `containerMode: kubernetes` broke runner stability.

## Problem

After merging PR #163 (which removed containerMode), runners immediately started failing:
- Runners exit after 2-3 seconds (same as original bug)
- Rapid pod churn (create → complete → delete → repeat)
- No stable runners available for workflows

## Evidence

```bash
kubectl get pods -n github-actions
NAME                                      READY   STATUS      RESTARTS   AGE
gha-runner-scale-set-2twbl-runner-q9jfs   0/1     Completed   0          2s    # ❌ Only 2 seconds old, already completed
```

This is the same immediate-exit behavior we had before containerMode was added in PR #148.

## Root Cause

`containerMode: kubernetes` IS required for the custom runner image to work correctly. The reference docs were right - all 4 components are REQUIRED together:

1. ✅ Custom image (ghcr.io/home-operations/actions-runner)
2. ✅ containerMode: kubernetes (THIS WAS NEEDED!)
3. ✅ command: ["/home/runner/run.sh"]
4. ✅ ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER: "false"

## What This Revert Does

Restores the working configuration:
- Adds back `containerMode: kubernetes`
- Adds back `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER: "false"` env var
- Runners will stay running again (not exit after 2-3 seconds)

## Original Problem Still Unsolved

We still have the "Failed to resolve action download info" error in workflows. Removing containerMode was NOT the solution. We need to investigate further.

Possible next steps:
- Check if containerMode requires additional RBAC permissions
- Investigate network policies blocking action downloads
- Check if there's a proxy/egress configuration issue
- Look for GitHub service disruptions

## Impact

After merge:
- Runners will stabilize (stay running, not exit immediately)
- Runners can register and pick up jobs
- BUT: "Failed to resolve action download info" issue remains
- Cattle workflow still won't work until we find the real fix

---

**Priority**: CRITICAL - Runners completely broken without this revert
**Risk**: LOW - Restoring known-working configuration