### PR TITLE
fix(github-actions): increase runner resources for long-running Terraform ops

### DIFF
--- a/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/gha-runner-scale-set/app/helmrelease.yaml
@@ -73,13 +73,15 @@ spec:
                 value: "false"
 
             # Resource allocation
+            # Increased from 500m/1Gi to 1000m/2Gi (requests) and 2000m/4Gi to 4000m/8Gi (limits)
+            # to support long-running Terraform operations (destroy/create templates across 4 Proxmox hosts)
             resources:
               requests:
-                cpu: 500m
-                memory: 1Gi
+                cpu: 1000m
+                memory: 2Gi
               limits:
-                cpu: 2000m
-                memory: 4Gi
+                cpu: 4000m
+                memory: 8Gi
 
             # Following onedr0p pattern: do NOT set explicit RUNNER_LABELS env vars
             # Let ARC default to HelmRelease name (gha-runner-scale-set) for label propagation


### PR DESCRIPTION
## Summary

Increase GitHub Actions runner resource limits to prevent pod crashes during cattle upgrade workflow Terraform operations.

## Problem

Workflow run 19491064578 failed with "runner lost communication with server" error during the "Destroy all old templates" step after 10 minutes of execution. Root cause: runner pod hit CPU/memory limits and crashed while executing long-running Terraform operations that SSH into 4 Proxmox hosts simultaneously.

## Changes

**Resource Limits (doubled)**:
- Requests: CPU 500m → 1000m (1 vCPU), Memory 1Gi → 2Gi
- Limits: CPU 2000m → 4000m (4 vCPUs), Memory 4Gi → 8Gi

**Justification**:
- Terraform destroy operation took 10+ minutes (destroying 8 templates across 4 Proxmox hosts)
- Concurrent SSH operations and Terraform state management are resource-intensive
- Current limits insufficient for cattle upgrade workflow requirements

## Cluster Impact

**Capacity Analysis**:
- Cluster total: 12 worker nodes, 191.4 vCPUs, ~388 GB RAM
- Maximum theoretical load (10 runners at limits): 40 vCPUs + 80 GB RAM = 10-15% of cluster capacity
- Realistic load (1-3 concurrent runners): 3 vCPUs + 6 GB RAM
- Runners are ephemeral (destroyed after each job)

**Risk Level**: LOW - cluster has ample capacity to absorb this increase

## Security Review

**Status**: ✅ APPROVED by security-guardian agent

**Key Findings**:
- No security vulnerabilities introduced
- Strong pod security context maintained (non-root, all capabilities dropped)
- RBAC follows least-privilege for cattle workflow
- No secrets exposure
- Resource limits prevent unbounded consumption

**Medium Priority Recommendations** (for future hardening):
1. Add ResourceQuota to github-actions namespace for defense-in-depth
2. Add PriorityClass for critical infrastructure workflows
3. Monitor runner resource usage via Prometheus
4. Consider migrating to official ARC image when upstream bug is fixed

## Testing Plan

After merge and Flux reconciliation:
- [ ] Wait for new runner pod to spawn with increased resources
- [ ] Trigger test cattle workflow: `gh workflow run upgrade-cattle.yaml -f old_version=1.11.4 -f new_version=1.11.5 -f test_mode=true`
- [ ] Monitor resource usage: `kubectl top pods -n github-actions --watch`
- [ ] Verify workflow completes "Destroy all old templates" step without runner crash
- [ ] Check for no OOMKilled events or pod restarts

## Related Work

- Relates to: STORY-045 (Automated Cattle Upgrade Workflow)
- Failed run: https://github.com/jlengelbrecht/prox-ops/actions/runs/19491064578
- Security review: security-guardian agent (2025-11-19)

## Notes

This fix addresses the immediate blocker for cattle upgrade workflow testing. Future PRs may implement the medium-priority security hardening recommendations from the security review.