### PR TITLE
fix(cattle): migrate workflow to external runner k8s-cattle

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -48,7 +48,7 @@ jobs:
   # ==========================================================================
   rebuild-templates:
     name: Rebuild Templates v${{ inputs.new_version }}
-    runs-on: gha-runner-scale-set
+    runs-on: k8s-cattle
     timeout-minutes: 60
     # Skip template rebuild if versions are identical (prevents VM destruction due to implicit clone dependencies)
     if: inputs.old_version != inputs.new_version
@@ -248,7 +248,7 @@ jobs:
   upgrade-control-plane:
     name: Upgrade Control ${{ matrix.node.name }}
     needs: rebuild-templates
-    runs-on: gha-runner-scale-set
+    runs-on: k8s-cattle
     timeout-minutes: 30
     if: inputs.test_mode == false
     strategy:
@@ -660,7 +660,7 @@ jobs:
       always() &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       (inputs.test_mode || needs.upgrade-control-plane.result == 'success')
-    runs-on: gha-runner-scale-set
+    runs-on: k8s-cattle
     timeout-minutes: 30
     strategy:
       max-parallel: 1
@@ -1230,7 +1230,7 @@ jobs:
     name: Validate Cluster Health
     needs: [rebuild-templates, upgrade-control-plane, upgrade-workers]
     if: always()
-    runs-on: gha-runner-scale-set
+    runs-on: k8s-cattle
     timeout-minutes: 10
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Resolves circular dependency where in-cluster runners get killed during cattle upgrade node drains, causing workflow failure.

## Problem

When cattle workflow drains cluster nodes, in-cluster runners (gha-runner-scale-set) get force-evicted along with other pods. GitHub Actions does not re-queue jobs when ephemeral ARC runners are terminated, resulting in orphaned jobs.

## Solution

Migrate cattle workflow to external runner `k8s-cattle` running in dedicated VM outside cluster.

## Changes

Updated `runs-on:` label in 4 jobs:
- `rebuild-templates` (line 51)
- `upgrade-control-plane` (line 251)
- `upgrade-workers` (line 663)
- `validate-cluster` (line 1233)

Changed from: `gha-runner-scale-set` (in-cluster)
Changed to: `k8s-cattle` (external VM)

## Impact

- External runner survives all cluster node operations
- No job orphaning when cluster nodes are drained/destroyed
- Breaks circular dependency completely
- All workflow logic and security controls preserved

## External Runner Details

- **Name**: k8s-cattle
- **Status**: Idle (verified in GitHub UI)
- **Location**: Ubuntu 24.04 LTS VM outside cluster
- **Labels**: `cattle-runner`, `self-hosted`, `Linux`, `X64`
- **Tools**: All dependencies installed via workflow steps (no changes to installation logic)

## Testing Plan

After merge:
- [ ] Verify workflow triggers successfully
- [ ] Verify runner picks up job (no indefinite queue)
- [ ] Test mode run: 2 workers only
- [ ] Verify node drain does not affect runner
- [ ] Full production cattle upgrade (if test succeeds)

## Security Review

✅ **Approved by security-guardian agent**

- No secrets or credentials exposed
- No logic changes, only runner label modified
- All security controls preserved (machine config injection, log redaction)
- Public repository safe

## Related

- Addresses circular dependency documented in CURRENT_STATE_2025-11-19.md
- External runner architecture defined in docs/architecture/talos-upgrade-automation.md