### PR TITLE
fix(rook-ceph): add missing mon-secret field to rook-ceph-mon secret

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-external/app/externalsecret-mon.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-external/app/externalsecret-mon.yaml
@@ -27,6 +27,9 @@ spec:
         fsid: "{{ .fsid }}"
         # Admin secret (same as ceph-secret for client.k8s user)
         admin-secret: "{{ .cephsecret }}"
+        # Monitor secret (required by Rook operator for cluster identity validation)
+        # For external clusters using client.k8s user, set to same value as ceph-secret
+        mon-secret: "{{ .cephsecret }}"
         # Ceph username
         ceph-username: "{{ .cephusername }}"
         # Ceph secret (keyring)


### PR DESCRIPTION
## Summary

Fixes external Ceph cluster connection by adding the required `mon-secret` field to the `rook-ceph-mon` secret.

## Root Cause

The Rook operator requires a `mon-secret` field in the `rook-ceph-mon` secret for external cluster identity validation. This field was missing, causing:
```
Error: the cluster identity was not established: monitor secret is empty
```

## Changes

**Modified**: `kubernetes/apps/rook-ceph/rook-ceph-external/app/externalsecret-mon.yaml`

Added `mon-secret` field to ExternalSecret template:
```yaml
# Monitor secret (required by Rook operator for cluster identity validation)
# For external clusters using client.k8s user, set to same value as ceph-secret
mon-secret: "{{ .cephsecret }}"
```

For external clusters using `client.k8s` user (not admin), the `mon-secret` should be set to the same value as `ceph-secret` per Rook's `import-external-cluster.sh` script.

## Testing Plan

After merge:
- [ ] Verify ExternalSecret reconciles successfully
- [ ] Verify rook-ceph-mon secret updated with `mon-secret` field
- [ ] Verify CephCluster transitions from "Connecting" to "Connected"
- [ ] Verify CSI config populates
- [ ] Verify Loki PVCs transition from "Pending" to "Bound"

## Security Review

- [x] security-guardian approval received
- [x] No plaintext secrets
- [x] Uses ExternalSecret pattern (1Password)
- [x] YAML syntax validated
- [x] No credentials exposed

## Notes

Relates to cluster recovery - external Ceph storage was non-functional after incident.