### PR TITLE
fix(cert-manager): disable Prometheus ServiceMonitor until kube-prometheus-stack is ready

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager-operator/app/helmrelease.yaml
@@ -15,6 +15,6 @@ spec:
     dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
     dns01RecursiveNameserversOnly: true
     prometheus:
-      enabled: true
+      enabled: false
       servicemonitor:
-        enabled: true
+        enabled: false


### PR DESCRIPTION
## Summary

Quick fix to unblock cert-manager deployment by temporarily disabling Prometheus ServiceMonitor.

## Root Cause

After merging PR #186 (cert-manager CRD split), cert-manager deployment fails with:

```
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
```

**Cascade issue**:
1. external-secrets webhook is down (no endpoints)
2. kube-prometheus-stack can't deploy (needs Grafana ExternalSecret)
3. Prometheus Operator CRDs not installed (no ServiceMonitor CRD)
4. cert-manager HelmRelease fails (requires ServiceMonitor CRD for monitoring)

## Changes

Disable Prometheus monitoring in cert-manager HelmRelease:
- `prometheus.enabled: false`
- `prometheus.servicemonitor.enabled: false`

## Impact

**Immediate**:
- ✅ cert-manager can deploy without ServiceMonitor CRD dependency
- ✅ Unblocks cert-manager-config (ClusterIssuer)
- ✅ Unblocks envoy-gateway-operator (Certificate CRD)
- ✅ Unblocks entire Gateway API cascade
- ⚠️ No cert-manager monitoring metrics temporarily

**Future**:
- Re-enable monitoring after fixing:
  1. external-secrets webhook
  2. kube-prometheus-stack deployment
  3. Prometheus Operator CRDs installed

## Testing

After merge:
```bash
# Watch cert-manager deploy (~2 min)
kubectl get helmrelease -n cert-manager -w

# Verify cert-manager pods running
kubectl get pods -n cert-manager

# Verify ClusterIssuer ready
kubectl get clusterissuer letsencrypt-production
```

## Risk Assessment

**Risk**: MINIMAL
- Only disables optional monitoring feature
- No impact on cert-manager core functionality (TLS cert management)
- Temporary workaround until monitoring stack is fixed
- Rollback: `prometheus.enabled: true` (re-enable after kube-prometheus-stack works)

## Related

- PR #186: cert-manager CRD split (merged)
- Issue: kube-prometheus-stack failing due to external-secrets webhook
- Issue: external-secrets webhook unavailable (no endpoints)