### PR TITLE
fix(envoy-gateway): replace invalid Flux substitution syntax in Certificate name

### DIFF
--- a/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
@@ -2,9 +2,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "${SECRET_DOMAIN/./-}-production"
+  name: "homelab0-org-production"
 spec:
-  secretName: "${SECRET_DOMAIN/./-}-production-tls"
+  secretName: "homelab0-org-production-tls"
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer


### PR DESCRIPTION
## Summary

Fixes envoy-gateway-operator deployment failure by replacing invalid Bash parameter expansion syntax with static certificate name.

## Root Cause

After cert-manager deployed successfully (PR #186 + #187), envoy-gateway-operator fails with:

```
invalid resource name "${SECRET_DOMAIN/./-}-production": [may not contain '/']
```

**Issue**: The certificate.yaml uses Bash parameter expansion:
```yaml
name: "${SECRET_DOMAIN/./-}-production"  # Replaces . with -
```

But **Flux only supports simple ${VAR} substitution**, not parameter expansion. Flux passes the literal string including the `/` character, which is invalid in Kubernetes resource names.

## Changes

Replace invalid Bash syntax with static names:
- `${SECRET_DOMAIN/./-}-production` → `homelab0-org-production`
- `${SECRET_DOMAIN/./-}-production-tls` → `homelab0-org-production-tls`
- Keep `${SECRET_DOMAIN}` in commonName and dnsNames (simple substitution works)

## Impact

**Immediate**:
- ✅ Unblocks envoy-gateway-operator deployment
- ✅ Certificate will be created for homelab0.org domain (wildcard + root)
- ✅ Unblocks envoy-gateway-config (depends on envoy-gateway-operator)
- ✅ Unblocks Gateway API cascade → application HTTPRoutes can deploy

**Future**:
- If SECRET_DOMAIN changes, this file needs manual update
- Alternative: Use Flux post-build variable with pre-computed value

## Testing

After merge:
```bash
# Watch envoy-gateway-operator deploy
kubectl get kustomizations -n network -w

# Verify Certificate created
kubectl get certificate -n network

# Verify envoy-gateway pods running
kubectl get pods -n network
```

## Risk Assessment

**Risk**: MINIMAL
- Static value based on current SECRET_DOMAIN (homelab0.org)
- Certificate still uses ${SECRET_DOMAIN} for actual domain (works correctly)
- No security impact (same certificate domains)
- Rollback: Revert and use different approach

## Related

- PR #186: cert-manager CRD split (merged)
- PR #187: Disabled ServiceMonitor to unblock cert-manager (merged)
- Next: envoy-gateway-config deployment after this fix