### PR TITLE
fix(envoy-gateway): remove PodMonitor to unblock deployment

### DIFF
--- a/kubernetes/apps/network/envoy-gateway-operator/app/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway-operator/app/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - ./certificate.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./podmonitor.yaml


### PR DESCRIPTION
## Summary

Removes PodMonitor resource from envoy-gateway-operator to fix deployment blocker caused by missing Prometheus Operator CRDs.

## Root Cause

- envoy-gateway-operator Kustomization includes `podmonitor.yaml`
- PodMonitor requires `monitoring.coreos.com/v1` CRDs from Prometheus Operator
- kube-prometheus-stack is broken (external-secrets webhook down)
- Prometheus Operator CRDs don't exist in cluster
- Flux dry-run validation fails: `no matches for kind "PodMonitor"`

## Changes

- Remove `./podmonitor.yaml` from kustomization resources list
- Unblocks envoy-gateway-operator deployment
- PodMonitor can be re-enabled after kube-prometheus-stack is fixed

## Impact

- envoy-gateway-operator will deploy without monitoring capability
- Temporary observability gap acceptable to unblock deployment
- Same pattern as PR #187 (cert-manager ServiceMonitor disable)

## Deployment Flow

After merge:
1. envoy-gateway-operator deploys → installs Gateway API CRDs
2. envoy-gateway-config deploys → creates Gateway resources
3. Application HTTPRoutes can deploy

## Testing Plan

- [ ] Verify envoy-gateway-operator Kustomization reconciles successfully
- [ ] Verify envoy-gateway HelmRelease deploys
- [ ] Verify Gateway API CRDs installed
- [ ] Verify envoy-gateway-config deploys
- [ ] Verify no monitoring-related errors

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials exposed
- [x] YAML syntax validated
- [x] No security regressions

## Notes

Relates to cluster recovery cascade fixing CRD chicken-and-egg problems after cert-manager split (PR #186).