### PR TITLE
fix(envoy-gateway): use static domain in Certificate to fix Let's Encrypt validation

### DIFF
--- a/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
@@ -8,5 +8,5 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: "${SECRET_DOMAIN}"
-  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+  commonName: "homelab0.org"
+  dnsNames: ["homelab0.org", "*.homelab0.org"]


### PR DESCRIPTION
## Summary

Fixes Certificate issuance failure by replacing Flux variable substitution with static domain values, completing the fix started in PR #188.

## Root Cause

- Certificate resource uses `${SECRET_DOMAIN}` variables in `commonName` and `dnsNames`
- envoy-gateway-operator Kustomization has **NO** `postBuild.substituteFrom` configuration
- Flux cannot substitute variables, passes literal string `"${secret_domain}"` to cert-manager
- Let's Encrypt rejects certificate request: **"Domain name contains an invalid character"**

## Error from Let's Encrypt

```
Failed to create Order: 400 urn:ietf:params:acme:error:rejectedIdentifier: 
Invalid identifiers requested :: Cannot issue for "${secret_domain}": 
Domain name contains an invalid character
```

## Changes

**File**: `kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml`

- Replace `${SECRET_DOMAIN}` with static `"homelab0.org"` in `commonName`
- Replace `${SECRET_DOMAIN}` with static values in `dnsNames` array: `["homelab0.org", "*.homelab0.org"]`

## Context

PR #188 fixed the Certificate `name` and `secretName` fields, but left `commonName` and `dnsNames` with Flux variables. This PR completes that fix.

## Impact

**Before**:
- Certificate stuck in "InProgress" state
- Let's Encrypt rejects request (invalid domain character)
- envoy-gateway-operator Kustomization health check times out (15m)
- envoy-gateway-config blocked (dependency not ready)

**After**:
- Certificate successfully requests wildcard TLS certificate
- Let's Encrypt issues valid certificate for `homelab0.org` and `*.homelab0.org`
- envoy-gateway-operator Kustomization passes health checks
- envoy-gateway-config unblocked and deploys

## Testing Plan

After merge:
- [ ] Wait 2-3 minutes for cert-manager to process new Certificate
- [ ] Verify Certificate shows Ready status: `kubectl get certificate -n network`
- [ ] Verify TLS secret created: `kubectl get secret -n network homelab0-org-production-tls`
- [ ] Verify envoy-gateway-operator Kustomization shows True: `kubectl get kustomizations -n network`
- [ ] Verify envoy-gateway-config deploys

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials exposed
- [x] Domain is already public (Cloudflare-registered, used throughout repo)
- [x] YAML syntax validated
- [x] No security regressions

## Notes

Completes cluster recovery cascade:
- PR #186: Split cert-manager (operator/config pattern)
- PR #187: Disable cert-manager ServiceMonitor
- PR #188: Fix Certificate name substitution
- PR #189: Remove envoy-gateway PodMonitor
- **PR #190** (this): Fix Certificate dnsNames substitution ← **Final fix**