### PR TITLE
fix(cattle): add immediate failure when VM modules detected in plan

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -211,12 +211,15 @@ jobs:
           echo ""
           echo "Checking for unintended VM modules in plan..."
 
+          BUG_DETECTED=false
+
           if grep -q "module.control_plane_nodes" plan-full.txt; then
             echo "::error::BUG DETECTED: control_plane_nodes module found in plan"
             echo "::error::This would destroy control plane VMs!"
             echo ""
             grep "module.control_plane_nodes" plan-full.txt
             echo ""
+            BUG_DETECTED=true
           else
             echo "✅ No control_plane_nodes in plan"
           fi
@@ -227,8 +230,29 @@ jobs:
             echo ""
             grep "module.worker_nodes" plan-full.txt
             echo ""
+            BUG_DETECTED=true
           else
             echo "✅ No worker_nodes in plan"
+          fi
+
+          # FAIL WORKFLOW if VM modules detected
+          if [ "$BUG_DETECTED" = true ]; then
+            echo ""
+            echo "================================================================"
+            echo "❌ WORKFLOW FAILED: Terraform would destroy VM nodes"
+            echo "================================================================"
+            echo "::error::Terraform plan includes VM modules (control_plane_nodes or worker_nodes)"
+            echo "::error::This is the bug causing cluster outages!"
+            echo "::error::Workflow terminated to prevent accidental node destruction"
+            echo "::error::Review plan output above to identify root cause"
+            echo ""
+            echo "Next steps:"
+            echo "1. Document findings in .claude/.ai-docs/troubleshooting/CLUSTER_OUTAGE_2025-11-21.md"
+            echo "2. Identify why Terraform dependency graph includes VM modules"
+            echo "3. Implement permanent fix"
+            echo "4. Re-test until plan shows ONLY template modules"
+            echo ""
+            exit 1
           fi
 
           # Show resources to be destroyed


### PR DESCRIPTION
## Summary

Enhancement to PR #191 (plan-only safety mode) that adds fail-fast behavior when Terraform bug is detected. Workflow now terminates immediately with exit code 1 if VM modules appear in terraform plan, preventing any progression to node operations.

## Problem

PR #191 implemented plan-only mode which logs errors when VM modules are detected, but the workflow continues running through subsequent steps. This could potentially lead to confusion or partial workflow execution.

## Solution

Add immediate workflow termination when VM modules (control_plane_nodes or worker_nodes) are detected in terraform plan output.

## Changes

- Add `BUG_DETECTED` boolean flag to track VM module detection
- Set flag to `true` when either control_plane_nodes or worker_nodes found in plan
- Add failure block that executes when `BUG_DETECTED=true`:
  - Logs explicit error messages about the bug
  - Provides next steps for investigation
  - Exits with code 1 to terminate workflow

## Safety Benefits

- **Prevents node operations**: Workflow exits before cordoning, draining, or upgrading nodes
- **Clear failure attribution**: Error messages explicitly state this is the cluster outage bug
- **Actionable guidance**: Provides investigation steps in workflow output
- **Forces permanent fix**: Cannot proceed with cattle upgrades until bug is resolved

## Workflow Behavior

**If VM modules detected** (bug present):
```
1. Terraform plan executes (read-only)
2. Bug detection logic identifies VM modules
3. Workflow logs error messages
4. Workflow exits with code 1 (FAILED status)
5. No node operations executed
```

**If only template modules** (bug not present):
```
1. Terraform plan executes (read-only)
2. Bug detection logic confirms no VM modules
3. Workflow continues to show plan output
4. Investigation can proceed with plan analysis
```

## Testing Plan

After merge:
- [ ] Trigger workflow with test parameters (old_version=1.15.5, new_version=1.15.5)
- [ ] Verify workflow behavior based on plan output
- [ ] If bug detected: Confirm workflow fails with clear error messages
- [ ] Document terraform plan output in incident report for root cause analysis

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials exposed
- [x] YAML syntax validated
- [x] Changes improve cluster safety (no regressions)

## Related

- Enhances PR #191 (plan-only safety mode)
- Incident report: `.claude/.ai-docs/troubleshooting/CLUSTER_OUTAGE_2025-11-21.md`
- Root cause: Terraform dependency graph bug targeting VMs instead of templates