### PR TITLE
fix(cattle): allow template rebuild when test_mode enabled

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -51,7 +51,8 @@ jobs:
     runs-on: cattle-runner
     timeout-minutes: 60
     # Skip template rebuild if versions are identical (prevents VM destruction due to implicit clone dependencies)
-    if: inputs.old_version != inputs.new_version
+    # UNLESS test_mode is enabled (for terraform plan bug investigation)
+    if: inputs.old_version != inputs.new_version || inputs.test_mode == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes workflow conditional that prevented template rebuild step from executing during testing with identical versions (1.15.5 → 1.15.5).

## Root Cause

Line 54 had `if: inputs.old_version != inputs.new_version` which skipped template rebuild when versions match. This prevented us from running terraform plan to inspect the dependency graph and identify why VM modules are being destroyed during template rebuilds.

## Changes

- Updated conditional on line 55 to: `if: inputs.old_version != inputs.new_version || inputs.test_mode == true`
- Added inline comment documenting the test_mode exception
- Preserves original behavior for normal upgrades (skip when versions match)

## Impact

**Test Mode** (test_mode=true):
- Template rebuild step will now execute regardless of version equality
- Enables terraform plan inspection to identify VM destruction bug
- Safe: Plan-only mode with explicit failure if VM modules detected (lines 215-256)

**Normal Operation** (test_mode=false):
- No behavior change: Template rebuild skipped when versions are identical
- Prevents unnecessary template rebuilds when no version upgrade needed

## Security Review

- ✅ Security-guardian approval received
- ✅ No secrets or credentials exposed
- ✅ YAML syntax validated
- ✅ Logic preserves original safety mechanisms
- ✅ Plan-only mode remains in effect (no destructive operations)

## Testing Plan

After merge:
- [ ] Trigger workflow with: `old_version=1.15.5 new_version=1.15.5 test_mode=true`
- [ ] Verify template rebuild step executes
- [ ] Inspect terraform plan output for VM module inclusion
- [ ] Document findings in `.claude/.ai-docs/troubleshooting/CLUSTER_OUTAGE_2025-11-21.md`
- [ ] Identify root cause of terraform dependency graph issue

## Related Work

- Relates to: CLUSTER_OUTAGE_2025-11-21 investigation
- Follows: PR #191 (plan-only safety mode), PR #192 (immediate failure enhancement)
- Enables: Terraform plan bug identification and permanent fix