### PR TITLE
fix(workflows): update cattle workflow to use correct runner label

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -48,7 +48,7 @@ jobs:
   # ==========================================================================
   rebuild-templates:
     name: Rebuild Templates v${{ inputs.new_version }}
-    runs-on: cattle-runner
+    runs-on: gha-runner-scale-set
     timeout-minutes: 60
     # Skip template rebuild if versions are identical (prevents VM destruction due to implicit clone dependencies)
     # UNLESS test_mode is enabled (for terraform plan bug investigation)
@@ -321,7 +321,7 @@ jobs:
   upgrade-control-plane:
     name: Upgrade Control ${{ matrix.node.name }}
     needs: rebuild-templates
-    runs-on: cattle-runner
+    runs-on: gha-runner-scale-set
     timeout-minutes: 30
     if: inputs.test_mode == false
     strategy:
@@ -735,7 +735,7 @@ jobs:
       inputs.test_mode == false &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped')
-    runs-on: cattle-runner
+    runs-on: gha-runner-scale-set
     timeout-minutes: 30
     strategy:
       max-parallel: 1
@@ -1305,7 +1305,7 @@ jobs:
     name: Validate Cluster Health
     needs: [rebuild-templates, upgrade-control-plane, upgrade-workers]
     if: always()
-    runs-on: cattle-runner
+    runs-on: gha-runner-scale-set
     timeout-minutes: 10
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes critical bug where cattle upgrade workflow jobs sit in queue indefinitely because runner label doesn't match.

## Problem

After adopting onedr0p's runner pattern in PR #148, runners are registered with label `gha-runner-scale-set`, but the cattle workflow was still using `runs-on: cattle-runner`.

**Result**: Workflow jobs sit in queue forever because no runners match the label.

## Changes

Updated all `runs-on` labels in cattle workflow from `cattle-runner` to `gha-runner-scale-set`:
- rebuild-templates job
- upgrade-control-plane job  
- upgrade-workers job
- validate-cluster-health job

## Impact

- **HIGH PRIORITY** - This completely blocks all cattle upgrades
- Without this fix, no cattle workflow jobs will ever execute
- Once merged, workflows will immediately start executing on available runners

## Testing

After merge:
1. Re-trigger test workflow run 19583562495 (currently stuck in queue)
2. Verify jobs transition from "queued" to "in progress"
3. Continue Renovate fix validation

## Security

No security implications - label name change only.