### PR TITLE
chore(deps): update talos to 1.10.8 (test)

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -44,7 +44,7 @@ proxmox_ssh_user = "root"
 # -----------------------------------------------------------------------------
 # Talos Linux Configuration
 # -----------------------------------------------------------------------------
-talos_version = "1.11.4"
+talos_version = "1.10.8"
 
 # Talos Factory Schematics (SECURE BOOT ENABLED)
 # Generated at: https://factory.talos.dev/

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.4"  # TESTING: Changed from 1.11.5 to test template rebuild
+  default     = "1.10.8"  # TESTING: Changed from 1.11.5 to test template rebuild
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## Summary
Simulating Renovate update to test cattle workflow with minor version downgrade.

## Changes
- Update `terraform/variables.tf` default value to 1.10.8
- Update `terraform/terraform.tfvars` to 1.10.8

## Testing Plan
This PR tests the complete Renovate → Router → Cattle workflow:
- [x] Both terraform files updated (PR #195 fix verified)
- [ ] Router workflow triggers on merge
- [ ] Router detects version change (state=1.11.4, config=1.10.8)
- [ ] Cattle workflow dispatched to cattle-runner
- [ ] Template plan shows ONLY templates (no VMs)
- [ ] 16 resources to rebuild (8 templates × 2 null_resources)

## Expected Outcome
Template rebuild should affect ONLY template modules, with perfect isolation from VM modules.

## Notes
- This is a test/simulation - version 1.10.8 is older than current 1.11.4
- Cattle workflow configured for MAJOR/MINOR version changes
- Workflow is in SAFETY MODE (plan only, no apply)