### PR TITLE
fix(cattle): align AWS_REGION with Terraform S3 backend region

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -38,7 +38,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AWS_REGION: us-east-1
+  AWS_REGION: us-east-2
   TERRAFORM_STATE_BUCKET: prox-ops-terraform-state
   TERRAFORM_VERSION: "latest"
 


### PR DESCRIPTION
## Summary

Fix region mismatch between GitHub Actions workflow environment variable and Terraform S3 backend configuration.

## Problem

The cattle upgrade workflow had an incorrect AWS region configuration:
- **Workflow env var**: `AWS_REGION=us-east-1` (incorrect)
- **Terraform backend**: `region=us-east-2` (correct, defined in `backend.tf`)

## Root Cause Analysis

During investigation of workflow failure (PR #199), discovered:
- Terraform was **correctly** connecting to S3 in `us-east-2` (backend.tf takes precedence)
- But the workflow environment variable caused confusion during debugging
- Local development uses `AWS_DEFAULT_REGION=us-east-2` (correct)
- Workflow was inconsistent with both backend.tf and local config

## Changes

```yaml
# .github/workflows/upgrade-cattle.yaml:41
env:
  AWS_REGION: us-east-2  # Changed from us-east-1
  TERRAFORM_STATE_BUCKET: prox-ops-terraform-state
  TERRAFORM_VERSION: "latest"
```

## Impact

- **Functional**: None (Terraform already using correct region via backend.tf)
- **Clarity**: Eliminates configuration mismatch
- **Consistency**: Workflow now matches backend.tf and local development

## Testing

- ✅ Security review passed (security-guardian)
- ✅ No secrets exposed
- ✅ YAML syntax validated
- ✅ Local Terraform confirms S3 backend in us-east-2
- ✅ S3 bucket verified in us-east-2: `aws s3api get-bucket-location --bucket prox-ops-terraform-state`
- ✅ Clean branch based on latest main (no conflicts)

## References

- Related investigation: PR #199 workflow failure analysis
- Backend configuration: `terraform/backend.tf:20`
- S3 bucket: `prox-ops-terraform-state` (us-east-2)
- DynamoDB table: `prox-ops-terraform-locks` (us-east-2)
- Supersedes: PR #200 (closed due to merge conflicts)

## Security Review

**Status**: ✅ APPROVED (security-guardian)
- No plaintext credentials
- Configuration-only change
- No security regressions