### PR TITLE
test(talos): downgrade to v1.10.8 to test cattle workflow

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -44,7 +44,7 @@ proxmox_ssh_user = "root"
 # -----------------------------------------------------------------------------
 # Talos Linux Configuration
 # -----------------------------------------------------------------------------
-talos_version = "1.11.5"
+talos_version = "1.10.8"
 
 # Talos Factory Schematics (SECURE BOOT ENABLED)
 # Generated at: https://factory.talos.dev/

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.5"  # TESTING: Changed from 1.11.5 to test template rebuild
+  default     = "1.10.8"
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## ⚠️ TEST PR - DO NOT MERGE TO PRODUCTION ⚠️

This PR simulates a Renovate downgrade to **test the cattle workflow** after fixing the S3 backend configuration.

## Purpose

Test that the cattle workflow correctly:
1. Detects version change via talos-version-router
2. Connects to S3 backend in us-east-2
3. Finds templates at 1.11.5 in S3 state
4. Plans template rebuild to 1.10.8
5. Validation detects 8 template modules
6. Workflow PASSES (not fails like PR #199)

## Changes

```diff
- talos_version = "1.11.5"
+ talos_version = "1.10.8"
```

## Expected Workflow Execution

**Version Router**:
- Detects: 1.11.5 → 1.10.8 (MINOR change)
- Routes to: **Cattle workflow**

**Cattle Workflow - Template Rebuild**:
1. ✅ Connects to S3 backend (us-east-2)
2. ✅ Downloads state showing templates at 1.11.5
3. ✅ Runs `terraform plan` targeting 8 template modules
4. ✅ Detects changes needed (1.11.5 → 1.10.8)
5. ✅ Validation finds all 8 template modules in plan
6. ✅ **Should PASS** (not fail like before)

## Comparison to PR #199 Failure

**PR #199 (failed)**:
- Git: 1.10.8 → 1.11.5
- S3 State: Already at 1.11.5
- Result: "No changes" → Validation correctly failed

**This PR (should pass)**:
- Git: 1.11.5 → 1.10.8
- S3 State: Currently at 1.11.5
- Result: Changes needed → Validation should pass

## Testing Scope

- ✅ S3 backend connection (us-east-2)
- ✅ Template rebuild detection
- ✅ Workflow validation logic
- ⚠️ **STOP before actual execution** (test_mode=true should be used)

## ⚠️ IMPORTANT

**DO NOT MERGE THIS PR** unless you intentionally want to downgrade the cluster to 1.10.8.

This is purely a workflow test. Once workflow completes and we verify it works correctly, **CLOSE this PR** without merging.

## Next Steps

1. Wait for workflow to run
2. Verify template rebuild plan is generated
3. Confirm validation passes (finds 8 modules)
4. **CLOSE PR** (do not merge)
5. Restore cluster to 1.11.5 if needed