### PR TITLE
chore(talos): downgrade to 1.11.4 (step 1 of 2 to force template rebuild)

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -44,7 +44,7 @@ proxmox_ssh_user = "root"
 # -----------------------------------------------------------------------------
 # Talos Linux Configuration
 # -----------------------------------------------------------------------------
-talos_version = "1.11.5"
+talos_version = "1.11.4"
 
 # Talos Factory Schematics (SECURE BOOT ENABLED)
 # Generated at: https://factory.talos.dev/

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.5"
+  default     = "1.11.4"
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## Summary

**Step 1 of 2**: Downgrade Talos version from 1.11.5 to 1.11.4 to trigger template rebuild workflow.

## Problem

PR #208 didn't trigger the router workflow because it had a net-zero change (1.11.5 → 1.11.4 → 1.11.5). GitHub's path filter sees no change and doesn't trigger the workflow.

## Solution

Two-PR strategy to force actual version changes in main:

1. **This PR (Step 1)**: Downgrade 1.11.5 → 1.11.4
   - Triggers router workflow to rebuild templates at 1.11.4
2. **Next PR (Step 2)**: Upgrade 1.11.4 → 1.11.5  
   - Triggers router workflow to rebuild templates at 1.11.5 (final production state)

## Expected Behavior

When this PR merges:
- ✅ Router workflow triggers (version change detected: 1.11.5 → 1.11.4)
- ✅ Cattle workflow executes batched template rebuild
- ✅ All 8 templates rebuilt at Talos 1.11.4
- ✅ Cluster VMs remain untouched (only templates affected)

## Next Steps

After this PR merges and templates rebuild to 1.11.4:
1. Verify workflow completes successfully
2. Create PR to upgrade back to 1.11.5 (step 2)
3. Merge step 2 to rebuild templates to production version 1.11.5

## Related Work

- PR #208: Failed to trigger (net-zero change)
- PR #206: Node validation fix + test
- PR #205: Batched template execution fixes