### PR TITLE
feat(workflow): rebuild templates for ALL version changes (cattle + pets)

### DIFF
--- a/.github/workflows/talos-version-router.yaml
+++ b/.github/workflows/talos-version-router.yaml
@@ -123,15 +123,13 @@ jobs:
       test_mode: ${{ inputs.test_mode || true }}
 
   route-to-pets:
-    name: Route to Pets Workflow
+    name: Route to Pets Workflow (Templates Only)
     needs: detect-version-change
     if: needs.detect-version-change.outputs.version_changed == 'true' && needs.detect-version-change.outputs.upgrade_type == 'pets'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Pets workflow placeholder
-        run: |
-          echo "::notice::PATCH upgrade detected: ${{ needs.detect-version-change.outputs.old_version }} → ${{ needs.detect-version-change.outputs.new_version }}"
-          echo "::warning::Pets workflow (in-place talosctl upgrade) not yet implemented"
-          echo ""
-          echo "For now, PATCH upgrades should be done manually:"
-          echo "  talosctl upgrade --nodes <node> --image factory.talos.dev/installer/<schematic>:v${{ needs.detect-version-change.outputs.new_version }}"
+    uses: ./.github/workflows/upgrade-cattle.yaml
+    secrets: inherit
+    with:
+      old_version: ${{ needs.detect-version-change.outputs.old_version }}
+      new_version: ${{ needs.detect-version-change.outputs.new_version }}
+      test_mode: false
+      templates_only: true  # Only rebuild templates, skip VM upgrades

--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -16,6 +16,10 @@ on:
         description: Test mode (only 2 workers, skip control plane)
         type: boolean
         default: true
+      templates_only:
+        description: Only rebuild templates (skip VM upgrades) - used for PATCH upgrades
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       old_version:
@@ -30,6 +34,10 @@ on:
         description: Test mode (only 2 workers, skip control plane)
         type: boolean
         default: true
+      templates_only:
+        description: Only rebuild templates (skip VM upgrades) - used for PATCH upgrades
+        type: boolean
+        default: false
 
 # Prevent concurrent cattle upgrades (Terraform state lock protection)
 # Cancel old queued runs when new run starts (prevents zombie workflow blocking)
@@ -524,7 +532,7 @@ jobs:
     needs: rebuild-templates
     runs-on: cattle-runner
     timeout-minutes: 30
-    if: inputs.test_mode == false
+    if: inputs.test_mode == false && inputs.templates_only == false
     strategy:
       max-parallel: 1
       fail-fast: true
@@ -930,10 +938,11 @@ jobs:
   upgrade-workers:
     name: Upgrade Worker ${{ matrix.node }}
     needs: [rebuild-templates, upgrade-control-plane]
-    # Skip worker upgrades if test_mode is enabled, or if dependencies failed
-    # Workers only run when: test_mode=false AND templates succeeded AND control plane succeeded
+    # Skip worker upgrades if test_mode is enabled, templates_only is enabled, or if dependencies failed
+    # Workers only run when: test_mode=false AND templates_only=false AND templates succeeded AND control plane succeeded
     if: |
       inputs.test_mode == false &&
+      inputs.templates_only == false &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped')
     runs-on: cattle-runner
@@ -1505,7 +1514,7 @@ jobs:
   validate-cluster:
     name: Validate Cluster Health
     needs: [rebuild-templates, upgrade-control-plane, upgrade-workers]
-    if: always()
+    if: always() && inputs.templates_only == false
     runs-on: cattle-runner
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Implements template rebuild for **ALL version changes** (MAJOR, MINOR, and PATCH), regardless of whether the upgrade uses cattle or pets workflow.

## Problem

Currently:
- **MAJOR/MINOR changes** (cattle workflow) → Rebuild templates ✅
- **PATCH changes** (pets workflow) → No template rebuild ❌

This meant PATCH upgrades (e.g., 1.11.4 → 1.11.5) left templates at the old version, creating inconsistency.

## Solution

Add `templates_only` parameter to cattle workflow:
- When `templates_only=false` (default) → Full cattle upgrade (templates + VMs)
- When `templates_only=true` → Only rebuild templates (skip VM upgrades)

## Changes

### 1. upgrade-cattle.yaml
- Added `templates_only` input parameter (default: `false`)
- Made `upgrade-control-plane` job conditional on `templates_only == false`
- Made `upgrade-workers` job conditional on `templates_only == false`
- Made `validate-cluster` job conditional on `templates_only == false`
- `rebuild-templates` job ALWAYS runs (for both cattle and pets)

### 2. talos-version-router.yaml
- Replaced pets placeholder with actual workflow call
- Calls `upgrade-cattle.yaml` with `templates_only=true`
- Sets `test_mode=false` (pets should rebuild all templates, not just 2)

## Workflow Behavior

**MAJOR/MINOR change** (e.g., 1.10.8 → 1.11.5):
- Router detects MAJOR/MINOR change → Routes to cattle workflow
- `templates_only=false` → Runs ALL jobs:
  1. ✅ rebuild-templates (8 templates)
  2. ✅ upgrade-control-plane (3 nodes)
  3. ✅ upgrade-workers (12 nodes)
  4. ✅ validate-cluster

**PATCH change** (e.g., 1.11.4 → 1.11.5):
- Router detects PATCH change → Routes to pets workflow
- `templates_only=true` → Runs ONLY templates:
  1. ✅ rebuild-templates (8 templates)
  2. ⏭️ upgrade-control-plane (skipped)
  3. ⏭️ upgrade-workers (skipped)
  4. ⏭️ validate-cluster (skipped)

## Benefits

1. **Templates always current**: Every version change rebuilds templates
2. **Simplified maintenance**: Single workflow for both cattle and pets
3. **No manual intervention**: PATCH upgrades now automated for templates
4. **Consistent behavior**: Same template rebuild logic for all upgrade types

## Testing

After merge:
1. Merge this PR
2. Trigger a PATCH upgrade (e.g., merge PR #209 which changes 1.11.5 → 1.11.4)
3. Verify router routes to pets workflow
4. Verify only `rebuild-templates` job runs
5. Verify templates rebuilt successfully at new version

## Related Work

- PR #209: Triggered pets workflow (but templates weren't rebuilt)
- PR #210: Closed (workaround approach)
- PR #205: Batched template execution fixes
- PR #206: Node validation bug fix

## Migration Path

Once this PR merges:
1. Close PR #209 (no longer needed - pets now rebuilds templates)
2. Can now safely use PATCH version changes to trigger template rebuilds
3. Templates will stay current automatically for all Renovate PRs