### PR TITLE
chore(talos): restore production version 1.11.5 (test pets workflow)

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -44,7 +44,7 @@ proxmox_ssh_user = "root"
 # -----------------------------------------------------------------------------
 # Talos Linux Configuration
 # -----------------------------------------------------------------------------
-talos_version = "1.11.4"
+talos_version = "1.11.5"
 
 # Talos Factory Schematics (SECURE BOOT ENABLED)
 # Generated at: https://factory.talos.dev/

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "proxmox_ssh_user" {
 variable "talos_version" {
   description = "Talos Linux version to deploy"
   type        = string
-  default     = "1.11.4"
+  default     = "1.11.5"
 }
 
 variable "talos_schematic_controlplane" {


### PR DESCRIPTION
## Summary

Restore Talos to production version 1.11.5 via PATCH upgrade (1.11.4 → 1.11.5).

## Purpose

This PR tests PR #211's new feature where **pets workflow now rebuilds templates**.

## Expected Workflow Execution

When this PR merges:

1. **Router workflow detects PATCH change**:
   - Old version: 1.11.4
   - New version: 1.11.5
   - Change type: PATCH (only patch version differs)

2. **Routes to pets workflow**:
   - Calls `upgrade-cattle.yaml` with `templates_only=true`

3. **Rebuild templates job executes**:
   - ✅ Run terraform plan (target: module.template_*)
   - ✅ Validate plan (positive + negative assertions)
   - ✅ Execute batched rebuild (4 batches × 2 templates)
   - ✅ Verify all 8 templates in state
   - ✅ All safety rails active (no VM changes allowed)

4. **Other jobs are skipped**:
   - ⏭️ upgrade-control-plane (skipped - templates_only=true)
   - ⏭️ upgrade-workers (skipped - templates_only=true)
   - ⏭️ validate-cluster (skipped - templates_only=true)

## Expected Outcome

After workflow completes:
- ✅ Templates rebuilt at Talos 1.11.5 (all 8 templates)
- ✅ Cluster VMs remain untouched (no upgrades)
- ✅ Templates match production version
- ✅ Ready for future Renovate PRs

## Current State

- **Main branch**: 1.11.4 (from PR #209)
- **Templates**: 1.10.8 (from earlier testing)
- **After this PR**: Templates at 1.11.5, VMs unchanged

## Validation

This PR validates that:
- ✅ PATCH upgrades trigger pets workflow
- ✅ Pets workflow rebuilds templates (new feature)
- ✅ Templates-only mode works correctly
- ✅ Safety checks prevent VM modifications
- ✅ Templates stay current for all version changes

## Related Work

- PR #211: Merged - pets workflow now rebuilds templates
- PR #209: Merged - changed version to 1.11.4 (PATCH)
- PR #206: Validation bug fix + testing
- PR #205: Batched template execution fixes