### PR TITLE
feat: Add test_controllers_only mode for safe controller testing

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -20,6 +20,10 @@ on:
         description: Only rebuild templates (skip VM upgrades) - used for PATCH upgrades
         type: boolean
         default: false
+      test_controllers_only:
+        description: Test mode for controllers (only k8s-ctrl-1, skip workers)
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       old_version:
@@ -36,6 +40,10 @@ on:
         default: true
       templates_only:
         description: Only rebuild templates (skip VM upgrades) - used for PATCH upgrades
+        type: boolean
+        default: false
+      test_controllers_only:
+        description: Test mode for controllers (only k8s-ctrl-1, skip workers)
         type: boolean
         default: false
 
@@ -533,21 +541,21 @@ jobs:
     needs: rebuild-templates
     runs-on: cattle-runner
     timeout-minutes: 30
-    if: inputs.test_mode == false && inputs.templates_only == false
+    if: (inputs.test_mode == false && inputs.templates_only == false) || inputs.test_controllers_only == true
     strategy:
       max-parallel: 1
       fail-fast: true
       matrix:
-        node:
-          - name: "k8s-ctrl-1"
-            ip: "10.20.67.1"
-            secret_suffix: "CTRL_1"
-          - name: "k8s-ctrl-2"
-            ip: "10.20.67.2"
-            secret_suffix: "CTRL_2"
-          - name: "k8s-ctrl-3"
-            ip: "10.20.67.3"
-            secret_suffix: "CTRL_3"
+        node: >-
+          ${{
+            inputs.test_controllers_only == true && fromJSON('[
+              {"name": "k8s-ctrl-1", "ip": "10.20.67.1", "secret_suffix": "CTRL_1"}
+            ]') || fromJSON('[
+              {"name": "k8s-ctrl-1", "ip": "10.20.67.1", "secret_suffix": "CTRL_1"},
+              {"name": "k8s-ctrl-2", "ip": "10.20.67.2", "secret_suffix": "CTRL_2"},
+              {"name": "k8s-ctrl-3", "ip": "10.20.67.3", "secret_suffix": "CTRL_3"}
+            ]')
+          }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -1361,11 +1369,12 @@ jobs:
   upgrade-workers:
     name: Upgrade Worker ${{ matrix.node }}
     needs: [rebuild-templates, upgrade-control-plane]
-    # Skip worker upgrades if test_mode is enabled, templates_only is enabled, or if dependencies failed
-    # Workers only run when: test_mode=false AND templates_only=false AND templates succeeded AND control plane succeeded
+    # Skip worker upgrades if test_mode is enabled, templates_only is enabled, test_controllers_only is enabled, or if dependencies failed
+    # Workers only run when: test_mode=false AND templates_only=false AND test_controllers_only=false AND templates succeeded AND control plane succeeded
     if: |
       inputs.test_mode == false &&
       inputs.templates_only == false &&
+      inputs.test_controllers_only == false &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped')
     runs-on: cattle-runner


### PR DESCRIPTION
## Summary

Adds `test_controllers_only` parameter to enable testing controller upgrades in isolation without affecting workers. This addresses the gap where we could test templates and workers separately, but not controllers.

## Problem

Currently:
- `test_mode: true` → Tests templates + 2 workers, **skips controllers**
- `templates_only: true` → Tests templates only, **skips controllers + workers**
- **No way to test controllers** without running full production workflow

After implementing controller safety mechanisms (PR #214), we need a way to test them on just 1 controller before running on all 3.

## Solution

New workflow input: `test_controllers_only`
- When `true`: Upgrades **only k8s-ctrl-1**, skips workers
- When `false`: Normal behavior (all 3 controllers or skip based on other flags)

## Changes

### 1. New Workflow Input
```yaml
test_controllers_only:
  description: Test mode for controllers (only k8s-ctrl-1, skip workers)
  type: boolean
  default: false
```

### 2. Controller Job - Conditional Matrix
```yaml
matrix:
  node: >-
    ${{
      inputs.test_controllers_only == true && fromJSON('[
        {"name": "k8s-ctrl-1", "ip": "10.20.67.1", "secret_suffix": "CTRL_1"}
      ]') || fromJSON('[
        {"name": "k8s-ctrl-1", "ip": "10.20.67.1", "secret_suffix": "CTRL_1"},
        {"name": "k8s-ctrl-2", "ip": "10.20.67.2", "secret_suffix": "CTRL_2"},
        {"name": "k8s-ctrl-3", "ip": "10.20.67.3", "secret_suffix": "CTRL_3"}
      ]')
    }}
```

When `test_controllers_only=true`: Matrix has 1 controller
When `test_controllers_only=false`: Matrix has all 3 controllers

### 3. Controller Job - If Condition
```yaml
if: (inputs.test_mode == false && inputs.templates_only == false) || inputs.test_controllers_only == true
```

Allows controllers to run when `test_controllers_only=true` even if `test_mode=true`

### 4. Worker Job - Skip Condition
```yaml
if: |
  inputs.test_mode == false &&
  inputs.templates_only == false &&
  inputs.test_controllers_only == false &&  # NEW
  ...
```

Ensures workers are skipped when testing controllers only.

## Usage Examples

### Test Single Controller (k8s-ctrl-1 only)
```bash
gh workflow run upgrade-cattle.yaml \
  -f old_version=1.11.5 \
  -f new_version=1.11.6 \
  -f test_controllers_only=true
```

**Workflow execution**:
1. ✅ Rebuild templates
2. ✅ Upgrade k8s-ctrl-1 (all 7 safety phases)
3. ⏭️  Skip k8s-ctrl-2, k8s-ctrl-3
4. ⏭️  Skip workers

**Why**: Fast validation of controller upgrade safety on single node

### Full Production Run (all controllers + workers)
```bash
gh workflow run upgrade-cattle.yaml \
  -f old_version=1.11.5 \
  -f new_version=1.11.6 \
  -f test_mode=false \
  -f test_controllers_only=false
```

**Workflow execution**:
1. ✅ Rebuild templates
2. ✅ Upgrade all 3 controllers (sequential)
3. ✅ Upgrade all 12 workers (sequential)

## Benefits

**Development/Testing**:
- Test controller upgrade logic without cluster-wide impact
- Validate all 7 safety phases on single controller
- Fast iteration (1 controller vs 3 = ~10 minutes vs ~30 minutes)

**Safety**:
- No risk to workers or production workloads
- etcd quorum maintained (2 controllers untouched)
- All safety gates active (plan validation, etcd health, etc.)
- Can abort after testing k8s-ctrl-1 if issues found

**Workflow Flexibility**:
- `test_mode` → Test workers only
- `test_controllers_only` → Test controllers only
- `templates_only` → Test templates only
- Combine flags for different test scenarios

## Testing Plan

After merge:
1. Test with `test_controllers_only=true` on single controller
2. Verify only k8s-ctrl-1 upgrades
3. Verify workers are skipped
4. Verify all safety mechanisms trigger correctly

## Risk Assessment

**Risk**: VERY LOW
- Only affects workflow orchestration logic
- No changes to actual upgrade code
- Defaults to `false` (no behavior change)
- Existing workflows unaffected

---

**Ready for review and merge**