### PR TITLE
fix(cattle): correct bash arithmetic in workflow validation step

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -70,9 +70,9 @@ jobs:
       - name: Validate test flags are mutually exclusive
         run: |
           count=0
-          [[ "${{ inputs.test_templates }}" == "true" ]] && ((count++))
-          [[ "${{ inputs.test_controllers }}" == "true" ]] && ((count++))
-          [[ "${{ inputs.test_workers }}" == "true" ]] && ((count++))
+          [[ "${{ inputs.test_templates }}" == "true" ]] && count=$((count + 1))
+          [[ "${{ inputs.test_controllers }}" == "true" ]] && count=$((count + 1))
+          [[ "${{ inputs.test_workers }}" == "true" ]] && count=$((count + 1))
 
           if [[ $count -gt 1 ]]; then
             echo "::error::Multiple test flags set. Only one test flag can be true at a time."


### PR DESCRIPTION
Fixes bash arithmetic error in the validate-inputs job that was causing workflow failures when test flags were set.

Problem: ((count++)) returns the pre-increment value (0) as its exit code, causing validation to fail incorrectly.

Solution: Changed to explicit arithmetic expansion: count=$((count + 1))

This fix is required to test the controller upgrade workflow from PR #217.

Security review: Approved by security-guardian