### PR TITLE
fix(cattle): allow controller job to run when template rebuild is skipped

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -576,7 +576,10 @@ jobs:
     runs-on: cattle-runner
     timeout-minutes: 30
     # Run when: test_controllers=true OR production mode (all test flags false)
-    if: inputs.test_controllers == true || (inputs.test_templates == false && inputs.test_controllers == false && inputs.test_workers == false)
+    # Also require rebuild-templates to have succeeded OR been skipped (not failed)
+    if: |
+      (inputs.test_controllers == true || (inputs.test_templates == false && inputs.test_controllers == false && inputs.test_workers == false)) &&
+      (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped')
     strategy:
       max-parallel: 1
       fail-fast: true


### PR DESCRIPTION
## Summary

Fixes controller job skipping when `test_controllers=true` by explicitly allowing the job to run when the `rebuild-templates` dependency is skipped.

## Problem

When testing controllers with `test_controllers=true`:
- ✅ Template rebuild job correctly skipped
- ❌ Controller job also skipped (WRONG - should run!)
- ❌ Workflow failed validation (no nodes upgraded)

**Root cause**: GitHub Actions skips jobs when their dependencies are skipped, even if the job's `if` condition evaluates to true.

## Solution

Added explicit dependency result check to controller job condition:

```yaml
if: |
  (inputs.test_controllers == true || (inputs.test_templates == false && inputs.test_controllers == false && inputs.test_workers == false)) &&
  (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped')
```

This allows the controller job to run when `rebuild-templates` is either:
- `success` (production mode - templates rebuilt)
- `skipped` (test mode - templates intentionally skipped)

Prevents running when `rebuild-templates` is:
- `failure` (something went wrong)
- `cancelled` (workflow terminated)

## Testing Plan

After merge:
- [ ] Re-run controller test: `gh workflow run upgrade-cattle.yaml -f old_version=1.11.5 -f new_version=1.11.5 -f test_controllers=true`
- [ ] Verify controller job runs (not skipped)
- [ ] Verify k8s-ctrl-1 is upgraded successfully
- [ ] Verify etcd quorum maintained

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials
- [x] YAML syntax validated
- [x] Follows established pattern (worker job already uses this pattern)

## Notes

This fix matches the pattern already used in the worker upgrade job (lines 1057-1059), applying the same defense-in-depth approach to the controller job.

Relates to: PR #217 (modular test flags), EPIC-019 Story 2 (automated cattle upgrades)