### PR TITLE
fix(cattle): use always() to force controller job evaluation when template is skipped

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -576,8 +576,10 @@ jobs:
     runs-on: cattle-runner
     timeout-minutes: 30
     # Run when: test_controllers=true OR production mode (all test flags false)
+    # Use always() to force evaluation even when rebuild-templates is skipped
     # Also require rebuild-templates to have succeeded OR been skipped (not failed)
     if: |
+      always() &&
       (inputs.test_controllers == true || (inputs.test_templates == false && inputs.test_controllers == false && inputs.test_workers == false)) &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped')
     strategy:


### PR DESCRIPTION
## Summary

Fixes controller job being skipped when `test_controllers=true` by using `always()` to force GitHub Actions to evaluate the job condition even when the `rebuild-templates` dependency is skipped.

## Problem

**Previous attempts**:
- PR #219: Added `needs.rebuild-templates.result` check ❌ (still skipped)
- PR #218: Fixed validation arithmetic ✅ (merged)

**Current issue**:
When `test_controllers=true`:
- ✅ Template rebuild job correctly skipped
- ❌ Controller job also skipped (WRONG - should run!)
- ❌ Workflow failed validation (no nodes upgraded)

**Root cause** (discovered after PR #219 merged):
GitHub Actions evaluates job dependencies **BEFORE** evaluating the `if` condition. Even with the result check, if a dependency is skipped, GitHub auto-skips the dependent job without evaluating the condition.

## Solution

Use `always()` to force GitHub to evaluate the condition even when dependencies are skipped:

```yaml
if: |
  always() &&
  (inputs.test_controllers == true || (...)) &&
  (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped')
```

This pattern is already used 4 times in this workflow (lines 1384, 1960, 1995, 2108) for summary and cleanup jobs.

## How It Works

**Without `always()`** (PR #219 behavior):
1. GitHub sees `rebuild-templates` is skipped
2. GitHub auto-skips `upgrade-control-plane` (doesn't evaluate condition)
3. Controller job never runs

**With `always()`** (this PR):
1. GitHub sees `always()` in condition
2. GitHub evaluates the full condition regardless of dependencies
3. Condition checks `rebuild-templates.result == 'skipped'` ✅
4. Condition checks `test_controllers == true` ✅
5. Controller job runs!

## Testing Plan

After merge:
```bash
gh workflow run upgrade-cattle.yaml \
  -f old_version=1.11.5 \
  -f new_version=1.11.5 \
  -f test_controllers=true
```

**Expected behavior**:
- ✅ Validate Input Flags - PASSED
- ⏭️ Rebuild Templates - SKIPPED (correct)
- ✅ Upgrade Control k8s-ctrl-1 - **RUNS** (fixed!)
- ⏭️ Upgrade Workers - SKIPPED (correct)
- ✅ Validate Cluster Health - PASSED

**This will test**:
- All 7 phases of controller safety improvements (PR #214)
- Same-version "upgrade" (1.11.5 → 1.11.5) for safety
- Only k8s-ctrl-1 affected (1 of 3 controllers)
- etcd quorum protected (ctrl-2 and ctrl-3 remain available)

## Security Review

- [x] security-guardian approval received
- [x] No secrets or credentials
- [x] YAML syntax validated
- [x] Follows established pattern (`always()` already used 4x in workflow)
- [x] No security regressions

## GitHub Actions Documentation

From [GitHub Actions docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution):

> By default, a job will only run when the jobs it depends on have succeeded. Use `always()` to run a job regardless of the status of jobs it depends on.

## Notes

This is the **third attempt** to fix controller job skipping:
1. PR #218: Fixed validation arithmetic ✅ (merged)
2. PR #219: Added dependency result check ❌ (merged, but insufficient)
3. **PR #220** (this PR): Add `always()` to force evaluation ✅ (should work)

Relates to:
- PR #217: Modular test flags (merged)
- PR #214: Controller safety improvements (merged)
- EPIC-019 Story 2: Automated cattle upgrades