### PR TITLE
fix(terraform): improve template batching to prevent schematic race conditions

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -444,52 +444,52 @@ jobs:
           echo "Batching strategy: 2 templates per batch across different nodes"
           echo ""
 
-          # Batch 1: Baldar controller + Heimdall controller (different nodes)
+          # Batch 1: Baldar base + Heimdall GPU (different nodes, different schematics)
           echo "================================================================"
-          echo "Batch 1/4: Creating controller templates on Baldar + Heimdall"
+          echo "Batch 1/4: Creating templates on Baldar (base) + Heimdall (GPU)"
           echo "================================================================"
           terraform apply -input=false -auto-approve \
             -target=module.template_baldar_base \
-            -target=module.template_heimdall_base
+            -target=module.template_heimdall_gpu
 
           echo ""
           echo "✓ Batch 1 complete. Waiting 30 seconds for Ceph to settle..."
           sleep 30
 
-          # Batch 2: Odin controller + Thor controller (different nodes)
+          # Batch 2: Baldar GPU + Heimdall base (different nodes, different schematics)
           echo ""
           echo "================================================================"
-          echo "Batch 2/4: Creating controller templates on Odin + Thor"
+          echo "Batch 2/4: Creating templates on Baldar (GPU) + Heimdall (base)"
           echo "================================================================"
           terraform apply -input=false -auto-approve \
-            -target=module.template_odin_base \
-            -target=module.template_thor_base
+            -target=module.template_baldar_gpu \
+            -target=module.template_heimdall_base
 
           echo ""
           echo "✓ Batch 2 complete. Waiting 30 seconds for Ceph to settle..."
           sleep 30
 
-          # Batch 3: Baldar worker + Heimdall worker (different nodes)
+          # Batch 3: Odin base + Thor GPU (different nodes, different schematics)
           echo ""
           echo "================================================================"
-          echo "Batch 3/4: Creating worker templates on Baldar + Heimdall"
+          echo "Batch 3/4: Creating templates on Odin (base) + Thor (GPU)"
           echo "================================================================"
           terraform apply -input=false -auto-approve \
-            -target=module.template_baldar_gpu \
-            -target=module.template_heimdall_gpu
+            -target=module.template_odin_base \
+            -target=module.template_thor_gpu
 
           echo ""
           echo "✓ Batch 3 complete. Waiting 30 seconds for Ceph to settle..."
           sleep 30
 
-          # Batch 4: Odin worker + Thor worker (different nodes)
+          # Batch 4: Odin GPU + Thor base (different nodes, different schematics)
           echo ""
           echo "================================================================"
-          echo "Batch 4/4: Creating worker templates on Odin + Thor"
+          echo "Batch 4/4: Creating templates on Odin (GPU) + Thor (base)"
           echo "================================================================"
           terraform apply -input=false -auto-approve \
             -target=module.template_odin_gpu \
-            -target=module.template_thor_gpu
+            -target=module.template_thor_base
 
           echo ""
           echo "================================================================"

--- a/terraform/modules/talos-template/main.tf
+++ b/terraform/modules/talos-template/main.tf
@@ -45,9 +45,10 @@ resource "null_resource" "download_talos_image" {
 
       # Always decompress (overwrites existing .raw file for idempotency)
       # Multiple templates may share the same schematic (e.g., all GPU templates)
-      # so we force decompression to handle parallel builds safely
+      # Explicitly remove .raw file first, then decompress
       echo "[2/2] Decompressing image (overwrites if exists)..."
-      xz -d -k -f "${local.image_path}"
+      rm -f "${local.raw_image_path}"
+      xz -d -k "${local.image_path}"
 
       echo "Image ready: ${local.raw_image_path}"
       ls -lh "${local.raw_image_path}"


### PR DESCRIPTION
## Summary

Fixes template rebuild failures by addressing root cause: multiple templates sharing the same schematic running in parallel, causing xz decompression race conditions.

## Problem Analysis

**Current batching strategy** groups templates by type:
- Batch 1: baldar_base + heimdall_base ✅ (different nodes, different schematics)
- Batch 2: odin_base + thor_base ✅ (different nodes, different schematics)
- Batch 3: baldar_gpu + heimdall_gpu ❌ (different nodes, **SAME GPU schematic**)
- Batch 4: odin_gpu + thor_gpu ❌ (different nodes, **SAME GPU schematic**)

**The race condition**: In batches 3 and 4, two templates try to decompress the same GPU schematic file (`990731...raw.xz`) simultaneously, causing:
```
xz: /tmp/talos-images/990731763242a6b3cf735e49d0f550ce4068b4d0e7f4dfbb49a31799b698877e.raw: File exists
Exit status 1
```

## Changes

### Fix 1: Workflow Batching Strategy

**New batching** mixes base and GPU templates to ensure no batch shares a schematic:

- Batch 1: baldar_base + heimdall_gpu (different nodes, different schematics) ✅
- Batch 2: baldar_gpu + heimdall_base (different nodes, different schematics) ✅
- Batch 3: odin_base + thor_gpu (different nodes, different schematics) ✅
- Batch 4: odin_gpu + thor_base (different nodes, different schematics) ✅

**Benefits**:
- Eliminates schematic race condition entirely
- Maintains Proxmox node distribution (no resource contention)
- No shared schematics in any batch

### Fix 2: Defense-in-Depth File Removal

Added explicit `rm -f` before xz decompression:

```bash
# Before:
xz -d -k -f "${local.image_path}"

# After:
rm -f "${local.raw_image_path}"
xz -d -k "${local.image_path}"
```

**Benefits**:
- Ensures clean state before decompression
- Handles edge cases where -f flag may not work as expected
- Provides additional protection layer

## Testing Plan

After merge:
1. Trigger workflow run with test_templates=true
2. Verify all 4 batches complete successfully
3. Confirm all 8 templates created (IDs 9000-9007)
4. Verify correct schematic IDs in template descriptions

## Security Review

✅ **Approved by security-guardian**
- No credential exposure or information leakage
- Proper variable validation in Terraform
- Race condition fixes improve reliability and security posture
- Defense-in-depth approach

## Related Work

- Addresses user feedback: "Why are we doing two jobs on the same node?"
- Implements suggested fix: stagger batches across different nodes with mixed types
- Relates to: Cattle Testing Roadmap Phase 1
- Supersedes PR #225 (which only addressed xz flag, not batching)