### PR TITLE
fix(cattle): deduplicate etcd member count for accurate quorum validation

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -684,8 +684,9 @@ jobs:
           for i in {1..12}; do
             # Count healthy etcd voting members using talosctl
             # In Talos, etcd runs as a system service, not a Kubernetes pod
+            # Query all control plane nodes for connectivity, then deduplicate by member ID
             HEALTHY_MEMBERS=$(talosctl --nodes "$CTRL_NODES" etcd members 2>/dev/null | \
-              grep -c "false$" || echo "0")  # Count lines ending with "false" (non-learner members)
+              awk '/false$/ {print $2}' | sort -u | wc -l || echo "0")  # Extract IDs (col 2), deduplicate, count unique
 
             echo "Attempt $i/12: $HEALTHY_MEMBERS healthy etcd voting members"
 
@@ -1320,8 +1321,9 @@ jobs:
           for i in {1..30}; do
             # Count healthy etcd voting members using talosctl
             # In Talos, etcd runs as a system service, not a Kubernetes pod
+            # Query all control plane nodes for connectivity, then deduplicate by member ID
             HEALTHY_MEMBERS=$(talosctl --nodes "$CTRL_NODES" etcd members 2>/dev/null | \
-              grep -c "false$" || echo "0")  # Count lines ending with "false" (non-learner members)
+              awk '/false$/ {print $2}' | sort -u | wc -l || echo "0")  # Extract IDs (col 2), deduplicate, count unique
 
             echo "Attempt $i/30: $HEALTHY_MEMBERS healthy etcd voting members"
 


### PR DESCRIPTION
## Summary

Fixes critical bug where etcd quorum validation counted duplicate members when querying multiple control plane nodes, causing the post-rebuild validation step to fail with "9/3 voting members" error.

## Root Cause

The workflow uses `talosctl --nodes 10.20.67.1,10.20.67.2,10.20.67.3 etcd members` to check quorum health. This queries all 3 control plane nodes, and each node returns the full member list (3 members). The old code counted lines with `grep -c "false$"`, resulting in:

- 3 members × 3 nodes queried = **9 lines counted** (incorrect)
- Expected count: **3 unique members**

## Impact on Workflow

### Pre-Destruction Check (Line 694)
Requires `>= 2` members before destroying any controller:
- ✅ Old: 9 >= 2 (passes)
- ✅ New: 3 >= 2 (still passes)
- No change in safety behavior

### Post-Rebuild Check (Line 1331) 
Requires `== 3` members after controller rejoins cluster:
- ❌ Old: 9 == 3 (FAILS - workflow timed out)
- ✅ New: 3 == 3 (PASSES - correctly detects restored quorum)
- **This is what broke workflow run 19628935528**

## Actual Failure (Run 19628935528)

```
✓ Destroy VM
✓ Recreate VM 
✓ Apply machine configuration
✓ Wait for node to be Ready
✓ Verify Talos version
X Verify etcd quorum restored (timed out after 5 minutes)

Error: "Only 9/3 voting members healthy"
```

The controller successfully rejoined the cluster with healthy etcd, but the validation step counted 9 duplicate members instead of 3 unique members, causing it to fail the `== 3` check and timeout.

## Fix Implementation

Changed member counting logic in **both** pre-destruction and post-rebuild validation:

```bash
# Old (broken)
HEALTHY_MEMBERS=$(talosctl --nodes "$CTRL_NODES" etcd members 2>/dev/null | \
  grep -c "false$" || echo "0")

# New (fixed)
HEALTHY_MEMBERS=$(talosctl --nodes "$CTRL_NODES" etcd members 2>/dev/null | \
  awk '/false$/ {print $2}' | sort -u | wc -l || echo "0")
```

**How it works**:
1. Query all control plane nodes (connectivity verification preserved)
2. Extract member IDs: `awk '/false$/ {print $2}'` (column 2 from matching lines)
3. Deduplicate: `sort -u` (unique member IDs only)
4. Count: `wc -l` (accurate count of unique voting members)

## Changes

- `.github/workflows/upgrade-cattle.yaml` (Line 687-688): Controller upgrade pre-destruction check
- `.github/workflows/upgrade-cattle.yaml` (Line 1325-1326): Controller upgrade post-rebuild check

Both occurrences fixed (controller and worker upgrade paths use same logic).

## Testing Plan

- [ ] Merge PR #228
- [ ] Re-run `test_controllers` workflow targeting k8s-ctrl-1
- [ ] Verify "Verify etcd quorum restored" step passes with "3/3 voting members"
- [ ] Confirm workflow completes successfully end-to-end

## Related Work

- Relates to: EPIC-019 Story 2 - Automated Cattle Upgrades
- Previous test run: 19628935528 (failed at etcd quorum validation)
- Fix for PR #227 issues (version checks)