### PR TITLE
fix(workflow): add always() to workers job to fix test mode execution

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -1407,8 +1407,10 @@ jobs:
     name: Upgrade Worker ${{ matrix.node }}
     needs: [validate-inputs, rebuild-templates, upgrade-control-plane]
     # Run when: test_workers=true OR production mode (all test flags false)
-    # Also require dependencies to have succeeded or been skipped
+    # Use always() to force evaluation even when dependencies are skipped
+    # Also require dependencies to have succeeded or been skipped (not failed)
     if: |
+      always() &&
       (inputs.test_workers == true || (inputs.test_templates == false && inputs.test_controllers == false && inputs.test_workers == false)) &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped')


### PR DESCRIPTION
## Summary
Fix upgrade-workers job being auto-skipped when test_workers=true by adding `always()` to the if condition.

## Problem
When test_workers=true was set, the workers test didn't run at all. The upgrade-workers job was being automatically skipped by GitHub Actions because its dependencies (rebuild-templates and upgrade-control-plane) were skipped in test mode.

Without `always()`, GitHub Actions automatically skips a job when its dependencies are skipped, even if the job's if condition would evaluate to true.

## Root Cause
```yaml
# Before (line 1411):
if: |
  (inputs.test_workers == true || ...) &&
  (needs.rebuild-templates.result == 'skipped') &&
  (needs.upgrade-control-plane.result == 'skipped')
```

The condition checks for 'skipped' status, but GitHub Actions never evaluates the condition at all because dependencies were skipped.

## Solution
Added `always()` at the start of the if condition:

```yaml
# After (line 1413):
if: |
  always() &&
  (inputs.test_workers == true || ...) &&
  (needs.rebuild-templates.result == 'skipped') &&
  (needs.upgrade-control-plane.result == 'skipped')
```

This forces GitHub Actions to evaluate the condition regardless of dependency status, while still respecting the result checks (job won't run if dependencies failed).

## Pattern Consistency
This matches the existing pattern used in:
- upgrade-control-plane job (line 582)
- validate-cluster job (line 1990)

Both use `always()` for the same reason.

## Expected Behavior After Fix
- ✅ test_workers=true → workers job evaluates and runs
- ✅ test_workers=true → targets k8s-work-1 and k8s-work-2 only
- ✅ Production mode → all 12 workers upgraded sequentially
- ✅ Job still blocked if dependencies failed (safety preserved)

## Testing Plan
After merge:
- [ ] Trigger workflow with test_workers=true
- [ ] Verify upgrade-workers job runs (not skipped)
- [ ] Verify k8s-work-1 is recreated and rejoins cluster
- [ ] Verify k8s-work-2 is recreated and rejoins cluster
- [ ] Verify sequential execution (max-parallel: 1)

## Security Review
- [x] security-guardian review passed
- [x] No secrets or credentials exposed
- [x] YAML syntax validated
- [x] No security regressions
- [x] Follows established secure patterns

## References
- Previous test run: 19632182143 (all upgrade jobs skipped)
- GitHub Actions docs: [Using conditions to control job execution](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif)