### PR TITLE
fix(cattle): correct Talos version verification in worker upgrade

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2109,17 +2109,31 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: Verify version
+      - name: Verify Talos version
+        timeout-minutes: 2
         run: |
-          NODE_VERSION=$(kubectl get node "${{ matrix.node }}" -o jsonpath='{.status.nodeInfo.kubeletVersion}')
-          echo "Node version: $NODE_VERSION"
+          echo "Verifying Talos version on ${{ matrix.node }}..."
 
-          if [[ "$NODE_VERSION" != *"${{ inputs.new_version }}"* ]]; then
-            echo "::error::Version mismatch: expected v${{ inputs.new_version }}, got $NODE_VERSION"
+          # Get node IP from kubectl
+          NODE_IP=$(kubectl get node "${{ matrix.node }}" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+          EXPECTED_VERSION="v${{ inputs.new_version }}"
+
+          echo "Node IP: $NODE_IP"
+          echo "Expected Talos version: $EXPECTED_VERSION"
+
+          # Extract version from talosctl using JSON parsing for reliability
+          VERSION=$(talosctl version --nodes "$NODE_IP" --json 2>/dev/null | jq -r '.version.tag // empty')
+
+          echo "Node Talos version: $VERSION"
+
+          if [[ "$VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::Version mismatch on ${{ matrix.node }}"
+            echo "::error::Expected: $EXPECTED_VERSION"
+            echo "::error::Got: $VERSION"
             exit 1
           fi
 
-          echo "✅ Node running correct version: $NODE_VERSION"
+          echo "✅ Node running correct Talos version: $VERSION"
 
       - name: Apply global patches
         timeout-minutes: 5


### PR DESCRIPTION
## Summary
Fixes worker node upgrade version check to correctly verify Talos OS version instead of Kubernetes version.

## Problem
The worker upgrade workflow was checking `kubeletVersion` which returns the Kubernetes version (v1.34.1), causing false failures when we expected to see the Talos version (v1.11.5).

## Solution
- Changed to use `talosctl version --nodes <IP>` (same as controller upgrade)
- Dynamically retrieves node IP from kubectl
- Uses JSON parsing with jq for reliable version extraction
- Added 2-minute timeout
- Improved error messages

## Changes
- `.github/workflows/upgrade-cattle.yaml` line 2112-2136
  - Renamed step: "Verify version" → "Verify Talos version"
  - Query method: `kubectl get node` → `talosctl version`
  - Version field: `kubeletVersion` → Talos OS version tag
  - Added timeout and better error diagnostics

## Testing Plan
- [x] Security review completed (security-guardian approved)
- [ ] Run workflow with `test_workers=true`
- [ ] Verify k8s-work-1 and k8s-work-2 version checks pass
- [ ] Confirm workflow proceeds past version verification step

## Security Review
✅ Approved by security-guardian agent
- No secrets or credentials exposed
- No command injection risks
- Proper parameter quoting and safe JSON parsing
- Read-only cluster operations
- Appropriate error handling and timeouts

## Related Issues
Fixes version check failure in cattle upgrade workflow run #19635020565

## Notes
- k8s-work-1 has been imported back into Terraform state (was missing)
- Both test nodes (work-1 and work-2) are uncordoned and ready
- This matches the proven controller upgrade version check logic