### PR TITLE
fix(cattle): use pre-installed talosctl in worker upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2141,25 +2141,10 @@ jobs:
           echo "::group::Applying global patches to ${{ matrix.node }}"
           echo "These patches ensure consistent sysctls, kubelet config, network, and time settings"
 
-          # Download talosctl for the new version
-          echo "Installing talosctl v${{ inputs.new_version }}..."
-
-          # Download binary
-          curl -sL "https://github.com/siderolabs/talos/releases/download/v${{ inputs.new_version }}/talosctl-linux-amd64" \
-            -o talosctl
-
-          # Download checksums
-          curl -sL "https://github.com/siderolabs/talos/releases/download/v${{ inputs.new_version }}/sha512sum.txt" \
-            -o sha512sum.txt
-
-          # SECURITY: Verify checksum
-          if ! sha512sum -c --ignore-missing sha512sum.txt 2>&1 | grep -q "talosctl-linux-amd64: OK"; then
-            echo "::error::Checksum verification failed for talosctl v${{ inputs.new_version }}"
-            exit 1
-          fi
-
-          chmod +x talosctl
-          ./talosctl version --client
+          # Use pre-installed talosctl from setup-cluster-tools
+          echo "Using pre-installed talosctl..."
+          which talosctl
+          talosctl version --client
 
           # Determine node IP
           NODE_IP=$(kubectl get node "${{ matrix.node }}" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
@@ -2172,7 +2157,7 @@ jobs:
 
           for patch in "${GLOBAL_PATCHES[@]}"; do
             echo "  → Applying talos/patches/global/${patch}.yaml..."
-            ./talosctl patch machineconfig \
+            talosctl patch machineconfig \
               --nodes $NODE_IP \
               --patch-file talos/patches/global/${patch}.yaml
           done
@@ -2197,25 +2182,10 @@ jobs:
           echo "::group::Applying GPU patches for ${{ matrix.node }}"
           echo "Detected GPU node: ${{ matrix.node }}"
 
-          # Download talosctl for the new version
-          echo "Installing talosctl v${{ inputs.new_version }}..."
-
-          # Download binary
-          curl -sL "https://github.com/siderolabs/talos/releases/download/v${{ inputs.new_version }}/talosctl-linux-amd64" \
-            -o talosctl
-
-          # Download checksums
-          curl -sL "https://github.com/siderolabs/talos/releases/download/v${{ inputs.new_version }}/sha512sum.txt" \
-            -o sha512sum.txt
-
-          # SECURITY: Verify checksum
-          if ! sha512sum -c --ignore-missing sha512sum.txt 2>&1 | grep -q "talosctl-linux-amd64: OK"; then
-            echo "::error::Checksum verification failed for talosctl v${{ inputs.new_version }}"
-            exit 1
-          fi
-
-          chmod +x talosctl
-          ./talosctl version --client
+          # Use pre-installed talosctl from setup-cluster-tools
+          echo "Using pre-installed talosctl..."
+          which talosctl
+          talosctl version --client
 
           # Determine node IP
           NODE_IP=$(kubectl get node "${{ matrix.node }}" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
@@ -2223,7 +2193,7 @@ jobs:
 
           # Apply GPU-specific patches
           echo "Applying GPU patch from talos/patches/${{ matrix.node }}/nvidia-gpu.yaml..."
-          ./talosctl patch machineconfig \
+          talosctl patch machineconfig \
             --nodes $NODE_IP \
             --patch-file talos/patches/${{ matrix.node }}/nvidia-gpu.yaml
 


### PR DESCRIPTION
## Summary
Fixes worker upgrade checksum failure by removing redundant talosctl downloads and using the pre-installed version from setup-cluster-tools, matching the proven controller upgrade pattern.

## Problem
Worker upgrades were failing with "Checksum verification failed for talosctl v1.11.5" during patch application:
- Downloaded binary as `talosctl` but checksum file expected `talosctl-linux-amd64` (filename mismatch)
- **Controllers don't have this issue** - they use pre-installed talosctl, never download during upgrade
- Unnecessary complexity causing failures

## Root Cause Analysis
Opus investigation identified:
1. Workers download talosctl during "Apply global patches" and "Apply GPU patches" steps
2. Controllers skip this entirely and use pre-installed version from `setup-cluster-tools`
3. Download logic had filename mismatch bug (saved as wrong name for checksum verification)
4. **Core issue: unnecessary complexity** - workers downloading tools they already have

## Solution
**Do what controllers do** - use pre-installed talosctl

### Changes Made
- Removed talosctl download from "Apply global patches" step
- Removed talosctl download from "Apply GPU patches" step  
- Use pre-installed talosctl via $PATH
- Add runtime validation with which/version checks
- Update command references from ./talosctl to talosctl

## Benefits
- Eliminates checksum failures - No more download/verification bugs  
- Aligns with controllers - Both workflows now follow same pattern  
- Reduces complexity - Fewer HTTP requests, simpler workflow  
- Improves security - Centralized verification in setup-cluster-tools  
- Faster execution - No repeated downloads per worker

## Testing Plan
- [x] Security review completed (security-guardian approved)
- [x] Verified controllers use this same pattern successfully
- [ ] Run workflow with test_workers=true
- [ ] Verify k8s-work-2 passes "Apply global patches" step
- [ ] Confirm workflow completes without checksum errors

## Security Review
Approved by security-guardian agent:
- Binary integrity maintained via setup-cluster-tools action
- No new command injection risks
- Reduces attack surface (fewer HTTP requests)
- Centralizes verification (better practice)
- Safe for public repository

## Related Issues
Fixes checksum verification failure in cattle upgrade workflow runs:
- Run #19645235915 (failed at Apply global patches)
- Run #19645712028 (failed at Apply global patches)

## Additional Context
- **Insight from Opus investigation:** "The core issue is unnecessary complexity in the worker workflow. Controllers prove the workflow works when kept simple."
- setup-cluster-tools already installs correct talosctl version with verification
- This eliminates entire class of download/checksum failures
- Pattern proven to work in controller upgrades
