### PR TITLE
feat(renovate): add automated Terraform version management

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -34,6 +34,17 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "siderolabs/talos",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Monitor Terraform version in GitHub Actions workflows",
+      "fileMatch": ["^\\.github/workflows/.+\\.ya?ml$"],
+      "matchStrings": [
+        "TERRAFORM_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "hashicorp/terraform",
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -56,7 +56,7 @@ concurrency:
 env:
   AWS_REGION: us-east-2
   TERRAFORM_STATE_BUCKET: prox-ops-terraform-state
-  TERRAFORM_VERSION: "latest"
+  TERRAFORM_VERSION: "1.14.0"  # Managed by Renovate
 
 jobs:
   # ==========================================================================


### PR DESCRIPTION
## Summary

Configures Renovate to automatically manage Terraform version updates via PRs, replacing the unstable "latest" tag with version pinning for improved supply chain security.

## Problem

Current configuration uses `TERRAFORM_VERSION: "latest"` in workflows, which:
- ❌ Introduces instability (unexpected version changes)
- ❌ Creates supply chain risk (no review before version bumps)
- ❌ Breaks reproducibility (same workflow, different Terraform versions)
- ❌ No tracking of when/why Terraform version changed

## Solution

### Renovate Custom Regex Manager

Add custom manager to track Terraform versions in GitHub Actions workflows:

```json5
{
  "customType": "regex",
  "description": "Monitor Terraform version in GitHub Actions workflows",
  "fileMatch": ["^\\.github/workflows/.+\\.ya?ml$"],
  "matchStrings": [
    "TERRAFORM_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
  ],
  "datasourceTemplate": "github-releases",
  "depNameTemplate": "hashicorp/terraform",
  "versioningTemplate": "semver"
}
```

### Version Pinning

Replace `TERRAFORM_VERSION: "latest"` with pinned version:
```yaml
TERRAFORM_VERSION: "1.14.0"  # Managed by Renovate
```

### Automated Update Workflow

When HashiCorp releases new Terraform versions:
1. Renovate detects new release via GitHub API
2. Creates PR with version update
3. User reviews PR and merges when ready
4. Controlled, auditable version upgrades

## Changes

**File 1**: `.github/renovate/customManagers.json5`
- Added Terraform version regex manager
- Matches pattern: `TERRAFORM_VERSION: "X.Y.Z"`
- Scoped to workflow files only

**File 2**: `.github/workflows/upgrade-cattle.yaml`
- Changed `TERRAFORM_VERSION: "latest"` → `"1.14.0"`
- Added comment: `# Managed by Renovate`

## Benefits

✅ **Supply chain security** - Version changes require review before merge  
✅ **Reproducibility** - Same workflow always uses same Terraform version  
✅ **Stability** - No unexpected breaking changes from "latest"  
✅ **Automated tracking** - Renovate creates PRs when updates available  
✅ **Audit trail** - Git history shows when/why Terraform version changed  
✅ **Consistent pattern** - Matches existing Talos version management  

## Testing

**Regex pattern validation:**
- ✅ Matches: `TERRAFORM_VERSION: "1.14.0"`
- ✅ Handles spacing variations correctly
- ❌ Rejects invalid formats (v1.2.3, 1.2, latest)
- ❌ No ReDoS vulnerability

**Version verification:**
- ✅ Terraform 1.14.0 is official HashiCorp release (Nov 19, 2025)
- ✅ Compatible with S3 native locking (requires >= 1.10.0)
- ✅ Currently used in GitHub Actions workflows

**Security review:**
- ✅ security-guardian approval received
- ✅ No secrets exposed
- ✅ No security regressions
- ✅ Improves supply chain security posture

## Expected Behavior After Merge

**Immediate:**
- Workflows will use Terraform 1.14.0 (no change from current)
- No workflow behavior changes

**Future:**
- When Terraform 1.14.1+ released → Renovate creates PR
- User reviews PR → Merges when ready
- Workflow uses new version after merge

## Comparison to Existing Pattern

**Already using Renovate for Talos versions:**
```json5
{
  "description": "Monitor Talos version in Terraform variables",
  "matchStrings": [
    "talos_version\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
  ]
}
```

**New Terraform pattern follows same structure:**
```json5
{
  "description": "Monitor Terraform version in GitHub Actions workflows",
  "matchStrings": [
    "TERRAFORM_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
  ]
}
```

Proven pattern, consistent approach.

## References

- [Renovate Custom Managers](https://docs.renovatebot.com/modules/manager/regex/)
- [Terraform Releases](https://github.com/hashicorp/terraform/releases)
- [Terraform 1.14.0 Release](https://discuss.hashicorp.com/t/terraform-v1-14-0-released/76808)

## Notes

- **No breaking changes** - Current version pinned to what workflows already use
- **Manual merge required** - Renovate PRs need user review
- **Scope**: Only affects `upgrade-cattle.yaml` workflow (other workflows can be added later)
- **Future**: Consider adding Terraform version tracking to other workflows using custom install scripts