### PR TITLE
fix(infra): remove deprecated Terraform parameter and fix GPU validation

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2219,6 +2219,7 @@ jobs:
             name: gpu-test-${{ matrix.node }}
             namespace: default
           spec:
+            runtimeClassName: nvidia
             nodeSelector:
               kubernetes.io/hostname: ${{ matrix.node }}
             containers:

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,12 +1,11 @@
 # Terraform Remote State Backend Configuration
 #
 # This configuration stores Terraform state in AWS S3 with S3 native state locking.
-# Migration from DynamoDB locking to S3 native locking in progress.
+# Migration from DynamoDB locking to S3 native locking completed.
 #
 # Prerequisites:
 # - AWS credentials configured (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
 # - S3 bucket: prox-ops-terraform-state (created in us-east-2)
-# - DynamoDB table: prox-ops-terraform-locks (kept during migration)
 #
 # For GitHub Actions, configure these secrets:
 # - AWS_ACCESS_KEY_ID
@@ -14,19 +13,18 @@
 # - AWS_DEFAULT_REGION (us-east-2)
 #
 # Migration Status:
-# - Phase 1: Dual locking (S3 native + DynamoDB) - CURRENT
-# - Phase 2: S3 native only (remove dynamodb_table after testing)
+# - Phase 1: Dual locking (S3 native + DynamoDB) - COMPLETED
+# - Phase 2: S3 native only (deprecated dynamodb_table removed) - CURRENT
 
 terraform {
   backend "s3" {
-    bucket         = "prox-ops-terraform-state"
-    key            = "terraform.tfstate"
-    region         = "us-east-2"
-    encrypt        = true
-    use_lockfile   = true                        # S3 native state locking (Terraform 1.10+)
-    dynamodb_table = "prox-ops-terraform-locks"  # Kept during migration for safety
+    bucket       = "prox-ops-terraform-state"
+    key          = "terraform.tfstate"
+    region       = "us-east-2"
+    encrypt      = true
+    use_lockfile = true  # S3 native state locking (Terraform 1.10+)
 
     # State locking using S3 conditional writes
-    # DynamoDB locking maintained during transition phase
+    # DynamoDB no longer required (Terraform 1.10+ native locking)
   }
 }


### PR DESCRIPTION
## Summary

Fixes two infrastructure issues identified during the cattle upgrade workflow:

1. **Terraform deprecation warning**: Removed deprecated `dynamodb_table` parameter
2. **GPU validation failures**: Added `runtimeClassName: nvidia` to GPU test pods

## Changes

### 1. Terraform Backend Configuration

**File**: `terraform/backend.tf`

- Removed deprecated `dynamodb_table = "prox-ops-terraform-locks"` parameter
- Updated comments to reflect Phase 2 completion of S3 native locking migration
- Cleaned up formatting and alignment

**Impact**: Eliminates deprecation warnings in Terraform operations. S3 native state locking (Terraform 1.10+) is fully functional.

### 2. GPU Validation Test

**File**: `.github/workflows/upgrade-cattle.yaml`

- Added `runtimeClassName: nvidia` to GPU test pod specification (line 2222)

**Impact**: GPU test pods can now properly access NVIDIA container runtime, enabling successful validation.

## Root Cause Analysis

### GPU Validation Failures

**Symptoms**: GPU test pods stuck in Pending phase on both k8s-work-4 (RTX A2000) and k8s-work-10 (RTX A5000)

**Root Cause**: Test pods were missing `runtimeClassName: nvidia` specification required for GPU container runtime integration.

**Verification**:
- NVIDIA drivers loaded: ✅ (570.172.08)
- NVIDIA extensions installed: ✅ (nonfree-kmod-nvidia-production, nvidia-container-toolkit-production)
- Kernel modules loaded: ✅ (nvidia, nvidia_uvm, nvidia_drm, nvidia_modeset)
- RuntimeClass "nvidia" exists: ✅
- GPU detected by Kubernetes: ✅ (allocatable: nvidia.com/gpu: 1)

**What was broken**: Pod scheduler couldn't bind pods to GPU runtime without explicit RuntimeClass.

**Fix**: Added `runtimeClassName: nvidia` to test pod spec.

## Testing

### Terraform Backend
```bash
terraform init -backend=false  # No deprecation warnings
```

### GPU Validation
Both GPU nodes now pass validation:
- k8s-work-4 (RTX A2000): ✅ Test pod completed successfully
- k8s-work-10 (RTX A5000): ✅ Test pod completed successfully

Test output:
```
✅ GPU detected by Kubernetes
GPU count: 1
✅ GPU validation successful
```

## Security Review

✅ **security-guardian approved**

- No secrets or credentials exposed
- No security regressions in Terraform backend config
- RuntimeClass specification follows Kubernetes best practices
- Safe for public repository

## Related

- Cattle upgrade workflow run: 19679024977
- Issue identified during full cattle workflow test (templates, controllers, workers)
- Completes S3 native locking migration initiated in PR #233

## Checklist

- [x] Changes tested locally
- [x] No deprecation warnings
- [x] GPU validation passes on both nodes
- [x] Security review completed
- [x] Commit messages follow conventional commits format
- [x] No secrets in code