### PR TITLE
feat(cattle): change default worker rollout mode to standard

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -27,7 +27,7 @@ on:
       worker_rollout_mode:
         description: 'Worker rollout strategy (safe: 1 pair at a time, standard: both in pair parallel, aggressive: multiple pairs parallel)'
         type: string
-        default: safe
+        default: standard
   workflow_dispatch:
     inputs:
       old_version:
@@ -57,7 +57,7 @@ on:
           - safe
           - standard
           - aggressive
-        default: safe
+        default: standard
 
 # Prevent concurrent cattle upgrades (Terraform state lock protection)
 # Cancel old queued runs when new run starts (prevents zombie workflow blocking)


### PR DESCRIPTION
## Summary
Changes default `worker_rollout_mode` from 'safe' to 'standard' for faster automated cattle upgrades.

## Changes
- Updated `.github/workflows/upgrade-cattle.yaml`:
  - `workflow_call` input default: `safe` → `standard` (line 30)
  - `workflow_dispatch` input default: `safe` → `standard` (line 60)

## Rationale
- **Performance**: Reduces total upgrade time from ~3-4 hours to ~2 hours
- **Fault Tolerance**: Maintains cross-host fault tolerance through worker pairing
- **Parallel Execution**: Upgrades both workers in a pair simultaneously on different Proxmox hosts
- **Router-Triggered**: Ensures automated cattle upgrades from router use optimal strategy

## Worker Pairing Strategy
Workers are paired cross-diagonally across Proxmox hosts:
- Pair 1: work-1 (Baldar) + work-2 (Odin)
- Pair 2: work-3 (Heimdall) + work-4 (Thor)
- Pair 3: work-5 (Baldar) + work-6 (Odin)
- Pair 4: work-7 (Heimdall) + work-8 (Thor)
- Pair 5: work-9 (Baldar) + work-10 (Odin)
- Pair 6: work-11 (Heimdall) + work-12 (Thor)

Standard mode upgrades both workers in each pair simultaneously while maintaining host diversity for resilience.

## Testing
- Current workflow run #19685208099 is validating GPU functionality with 'safe' mode
- Future automated runs will use 'standard' mode by default
- Manual runs still allow selecting 'safe' or 'aggressive' modes via workflow_dispatch