### PR TITLE
fix(flux): add explicit namespace to cross-namespace dependsOn refs

### DIFF
--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/default/echo/app
   postBuild:

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
   postBuild:

--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-dns/app
   postBuild:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
   prune: true

--- a/kubernetes/apps/observability/loki/ks.yaml
+++ b/kubernetes/apps/observability/loki/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+      namespace: kube-system
   interval: 10m
   path: ./kubernetes/apps/observability/loki/app
   prune: true


### PR DESCRIPTION
## Summary

Fix cross-namespace dependency resolution for prometheus-operator-crds Kustomization.

## Problem

After merging PR #246 (prometheus-operator-crds deployment), dependent Kustomizations were failing with errors like:
- `dependency 'flux-system/prometheus-operator-crds' not found`
- `dependency 'network/prometheus-operator-crds' not found`
- `dependency 'default/prometheus-operator-crds' not found`

The prometheus-operator-crds Kustomization lives in `kube-system` namespace, but dependent Kustomizations in other namespaces were looking for it in their own namespace (Flux default behavior).

## Changes

Added explicit `namespace: kube-system` to dependsOn references in:
- kubernetes/apps/default/echo/ks.yaml
- kubernetes/apps/flux-system/flux-operator/ks.yaml
- kubernetes/apps/network/cloudflare-dns/ks.yaml
- kubernetes/apps/network/cloudflare-tunnel/ks.yaml
- kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
- kubernetes/apps/observability/loki/ks.yaml

Note: kube-system apps (cilium, tetragon, etc.) don't need this fix because they're already in the same namespace as prometheus-operator-crds.

## Testing

After merge, verify with:
```bash
flux get kustomizations -A | grep -E "(echo|flux-operator|cloudflare|prometheus-stack|loki)"
```

All Kustomizations should show `Ready=True` after Flux reconciliation.