### PR TITLE
fix(loki): add self-healing remediation strategy

### DIFF
--- a/kubernetes/apps/observability/loki/app/loki-helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/loki-helmrelease.yaml
@@ -14,16 +14,18 @@ spec:
         name: grafana
         namespace: observability
   interval: 1h
-  timeout: 15m
+  timeout: 20m
   install:
+    crds: CreateReplace
     remediation:
       retries: 3
-    crds: CreateReplace
   upgrade:
+    crds: CreateReplace
     cleanupOnFail: true
     remediation:
       retries: 3
-    crds: CreateReplace
+      # Use uninstall strategy when rollback target is missing
+      strategy: uninstall
   values:
     # Deployment mode - single binary for homelab simplicity
     deploymentMode: SingleBinary


### PR DESCRIPTION
## Summary

Fix loki HelmRelease stuck in failed state with `MissingRollbackTarget` error.

## Problem

Both Helm releases (v1 and v2) have `status: failed` in history. Flux tries to remediate by rolling back, but there's no successful release to roll back to - resulting in a permanent `MissingRollbackTarget` stall.

Note: Loki pods are actually running fine - this is purely a Helm/Flux state issue.

## Changes

1. **Increased timeout**: 15m → 20m (buffer for slow loki initialization)
2. **Added `strategy: uninstall`**: When remediation is needed and rollback fails, Flux will uninstall and reinstall instead of getting stuck

## Post-Merge Steps

After merge, need to delete failed Helm release secrets to allow fresh reconciliation:
```bash
kubectl delete secret -n observability sh.helm.release.v1.loki.v1 sh.helm.release.v1.loki.v2
```

## Testing

Verify after merge:
```bash
kubectl get helmrelease loki -n observability
# Should show Ready=True after reconciliation
```