### PR TITLE
fix(cloudflare-tunnel): add noTLSVerify for internal origin connections

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -75,6 +75,7 @@ spec:
                 originRequest:
                   http2Origin: true
                   originServerName: grafana.${SECRET_DOMAIN}
+                  noTLSVerify: true
 
               # Echo test application
               - hostname: "echo.${SECRET_DOMAIN}"
@@ -82,6 +83,7 @@ spec:
                 originRequest:
                   http2Origin: true
                   originServerName: echo.${SECRET_DOMAIN}
+                  noTLSVerify: true
 
               # Flux webhook
               - hostname: "flux-webhook.${SECRET_DOMAIN}"
@@ -89,6 +91,7 @@ spec:
                 originRequest:
                   http2Origin: true
                   originServerName: flux-webhook.${SECRET_DOMAIN}
+                  noTLSVerify: true
 
               # NOTE: Apps NOT routed through Cloudflare tunnel:
               # - Plex (DMZ): UDM SE port forward for high bandwidth streaming


### PR DESCRIPTION
## Summary

Fix Cloudflare tunnel failing to connect to internal envoy-external gateway.

## Problem

cloudflared was logging:
```
ERR Cannot determine default origin certificate path. No file cert.pem
```

This caused external access via IPv6/Cloudflare to fail completely while IPv4 (direct internal) worked.

## Root Cause

The tunnel connects to `https://envoy-external.network.svc.cluster.local:443` but cloudflared couldn't verify the origin certificate (Let's Encrypt cert) without the CA bundle.

## Fix

Added `noTLSVerify: true` to originRequest for:
- grafana.homelab0.org
- echo.homelab0.org
- flux-webhook.homelab0.org

## Security Analysis

This is **safe** because:
- Only affects internal cluster connection (cloudflared pod → envoy-external service)
- External TLS (client → Cloudflare edge) remains fully verified
- Internal traffic is within trusted Kubernetes network
- Pod security context follows best practices (non-root, read-only fs, dropped caps)

## Testing

After merge:
```bash
# Verify tunnel logs show no cert errors
kubectl logs -n network deploy/cloudflare-tunnel

# Test external access via IPv6
curl -6 https://grafana.homelab0.org
```