### PR TITLE
fix(dns): remove gateway hostname annotation conflicting with tunnel

### DIFF
--- a/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
@@ -50,7 +50,8 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: external.${SECRET_DOMAIN}
+      # NOTE: external.${SECRET_DOMAIN} DNS is managed by DNSEndpoint (CNAME to tunnel)
+      # Do NOT add external-dns hostname annotation here - it conflicts with tunnel routing
       lbipam.cilium.io/ips: "10.20.67.23"
   listeners:
     - name: http


### PR DESCRIPTION
## Summary

Fix external access via Cloudflare tunnel by removing conflicting DNS annotation.

## Problem

Two DNS systems were fighting over `external.homelab0.org`:

| Source | Record Type | Target |
|--------|-------------|--------|
| Gateway annotation | A record | `10.20.67.23` (internal IP) |
| DNSEndpoint CRD | CNAME | `88d7cb55-...cfargotunnel.com` |

The **A record won**, so external clients (IPv6) tried to connect to the internal IP (unreachable), causing "secure connection failed" errors.

## Root Cause Analysis

```bash
# External DNS returns internal IP (wrong!)
$ dig external.homelab0.org @1.1.1.1 +short
10.20.67.23

# Should return tunnel CNAME for external access
```

## Fix

Remove `external-dns.alpha.kubernetes.io/hostname` from envoy-external gateway's infrastructure annotations. This stops the A record creation and allows the DNSEndpoint CNAME to take effect.

**Kept:** `external-dns.alpha.kubernetes.io/target` on gateway metadata (used by HTTPRoutes)

## DNS Flow After Fix

```
External: grafana.homelab0.org → external.homelab0.org → tunnel → Cloudflare → origin
Internal: grafana.homelab0.org → (k8s-gateway) → 10.20.67.23 (direct)
```

## Testing

After merge and DNS propagation (~5 min):
```bash
# Should now return tunnel CNAME
dig external.homelab0.org @1.1.1.1

# IPv6 should work
curl -6 https://grafana.homelab0.org
```