### PR TITLE
fix(observability): disable kube-proxy alerts for Cilium-based cluster

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -308,7 +308,7 @@ spec:
         kubeApiserverSlos: true
         kubeControllerManager: true
         kubelet: true
-        kubeProxy: true
+        kubeProxy: false  # Disabled - Talos uses Cilium which replaces kube-proxy
         kubePrometheusGeneral: true
         kubePrometheusNodeRecording: true
         kubernetesApps: true


### PR DESCRIPTION
## Summary
Disables kube-proxy alert rules since Talos Linux uses Cilium CNI which replaces kube-proxy.

## Changes
- Set `kubeProxy: false` in `defaultRules` to disable kube-proxy alerts
- The `KubeProxyDown` alert was firing as a false positive since kube-proxy is not present

## Context
- Talos Linux clusters use Cilium in kube-proxy replacement mode
- kube-proxy pods are not deployed in this architecture
- This eliminates false positive alerts while keeping all relevant monitoring

## Testing
- [x] Verified no kube-proxy pods exist in cluster
- [x] Alert is currently firing as false positive
- [ ] After merge, verify alert resolves