### PR TITLE
fix(plex): remove unnecessary decryption config from storage ks

### DIFF
--- a/kubernetes/apps/media/plex/storage/ks.yaml
+++ b/kubernetes/apps/media/plex/storage/ks.yaml
@@ -20,7 +20,3 @@ spec:
     namespace: flux-system
   targetNamespace: media
   wait: true
-  decryption:
-    provider: sops
-    secretRef:
-      name: sops-age


### PR DESCRIPTION
## Summary
Removes the unnecessary `decryption` section from plex-storage Kustomization that was causing it to fail with `secrets "sops-age" not found`.

## Problem
The plex-storage Kustomization was being applied to the `media` namespace (via parent kustomization), but it referenced the `sops-age` secret which only exists in `flux-system`. Since the storage manifests don't contain any encrypted secrets, the decryption section was unnecessary.

## Changes
- Removed `decryption` section from `kubernetes/apps/media/plex/storage/ks.yaml`

## Testing
- Kustomization should reconcile successfully
- PVCs will be created with `prune: false` protection