### PR TITLE
fix(plex): add prune protection to NFS PVC

### DIFF
--- a/kubernetes/apps/media/plex/storage/nfs-pvc.yaml
+++ b/kubernetes/apps/media/plex/storage/nfs-pvc.yaml
@@ -4,6 +4,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: plex-media
   namespace: media
+  labels:
+    app.kubernetes.io/name: plex
+    app.kubernetes.io/component: storage
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
## Summary
Adds `kustomize.toolkit.fluxcd.io/prune: disabled` annotation to the NFS PVC for consistency with the Ceph-block PVCs.

## Changes
- Added prune disabled annotation to `plex-media` NFS PVC
- Added standard labels for consistency

## Why
While the NFS PV already has `persistentVolumeReclaimPolicy: Retain`, adding the prune annotation provides defense-in-depth and ensures all Plex storage resources are consistently protected from accidental Flux pruning.