### PR TITLE
fix(wireguard-gateway): correct 1Password item name

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/externalsecret.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/externalsecret.yaml
@@ -15,5 +15,5 @@ spec:
   data:
     - secretKey: wg0.conf
       remoteRef:
-        key: WireGuard Gateway K8s
+        key: WireGaurd Gateway K8s
         property: notesPlain


### PR DESCRIPTION
## Summary
Fix ExternalSecret to match actual 1Password item name.

## Changes
- Update `key` from `WireGuard Gateway K8s` to `WireGaurd Gateway K8s` (matches user's 1Password item)

## Testing
- ExternalSecret should sync successfully after merge