### PR TITLE
fix(wireguard-gateway): use privileged mode for Talos

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/helmrelease.yaml
@@ -116,6 +116,7 @@ spec:
             subPath: wg0.conf
             readOnly: true
 
-    # Pod options - sysctls handled by privileged container
+    # Pod options - sysctls (net.ipv4.ip_forward, net.ipv4.conf.all.src_valid_mark) set by
+    # linuxserver/wireguard entrypoint; privileged mode required on Talos to allow runtime sysctl changes
     defaultPodOptions:
       securityContext: {}

--- a/kubernetes/apps/network/wireguard-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ocirepository.yaml
   - helmrelease.yaml
   - externalsecret.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wireguard-gateway
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wireguard-gateway
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow WireGuard traffic from Oracle VPS only
+    - from:
+        - ipBlock:
+            cidr: 129.159.81.167/32  # Oracle VPS public IP
+      ports:
+        - protocol: UDP
+          port: 51820
+  egress:
+    # Allow traffic to Plex LoadBalancer only
+    - to:
+        - ipBlock:
+            cidr: 10.20.81.100/32  # Plex LoadBalancer IP
+      ports:
+        - protocol: TCP
+          port: 32400
+    # Allow DNS for container startup (required)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow WireGuard handshake responses to Oracle VPS
+    - to:
+        - ipBlock:
+            cidr: 129.159.81.167/32
+      ports:
+        - protocol: UDP
+          port: 51820


### PR DESCRIPTION
## Summary
Fix SysctlForbidden error on Talos by using privileged mode instead of pod-level sysctls.

## Changes
- Set `privileged: true` in container securityContext
- Remove sysctls from defaultPodOptions (handled internally by privileged container)

## Context
Talos restricts pod sysctls for security. The WireGuard container needs to set `net.ipv4.ip_forward` which requires privileged mode.