### PR TITLE
fix(wireguard): remove empty securityContext causing schema error

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/helmrelease.yaml
@@ -118,5 +118,4 @@ spec:
 
     # Pod options - sysctls (net.ipv4.ip_forward, net.ipv4.conf.all.src_valid_mark) set by
     # linuxserver/wireguard entrypoint; privileged mode required on Talos to allow runtime sysctl changes
-    defaultPodOptions:
-      securityContext: {}
+    defaultPodOptions: {}


### PR DESCRIPTION
## Summary
Fixes Helm schema validation error where `securityContext: {}` was being interpreted as null by the app-template chart.

## Changes
- Changed `defaultPodOptions: { securityContext: {} }` to `defaultPodOptions: {}`
- Pod-level security context is not needed when using container-level privileged mode

## Error Fixed
```
Helm upgrade failed: values don't meet the specifications of the schema(s):
- at '/defaultPodOptions/securityContext': got null, want object
```

## Testing
- [ ] HelmRelease reconciles successfully
- [ ] Pod starts without schema errors