### PR TITLE
fix(network): allow WireGuard to Plex via pod selector

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
@@ -19,10 +19,14 @@ spec:
         - protocol: UDP
           port: 51820
   egress:
-    # Allow traffic to Plex LoadBalancer only
+    # Allow traffic to Plex pod (via namespace+pod selector for reliability)
     - to:
-        - ipBlock:
-            cidr: 10.20.81.100/32  # Plex LoadBalancer IP
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: plex
       ports:
         - protocol: TCP
           port: 32400


### PR DESCRIPTION
## Summary
Fix WireGuard gateway NetworkPolicy to allow traffic to Plex pod using namespace+pod selector instead of LoadBalancer IP.

## Problem
- WireGuard pod couldn't reach Plex via LoadBalancer IP (`10.20.81.100`)
- LoadBalancer IPs aren't directly routable from pod network
- Connection timeout when testing from WireGuard pod

## Solution
Changed egress rule from:
```yaml
- ipBlock:
    cidr: 10.20.81.100/32
```
to:
```yaml
- namespaceSelector:
    matchLabels:
      kubernetes.io/metadata.name: media
  podSelector:
    matchLabels:
      app.kubernetes.io/name: plex
```

## Testing
After merge, verify WireGuard pod can reach Plex:
```bash
kubectl exec -n network deploy/wireguard-gateway -- nc -zv 10.42.10.60 32400
```

## Related
- STORY-054: Plex VPN Proxy Implementation
- PR #266: NetworkPolicy IP update (merged)