### PR TITLE
fix(media): allow WireGuard gateway ingress to Plex

### DIFF
--- a/kubernetes/apps/media/plex/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/plex/app/networkpolicy.yaml
@@ -21,6 +21,15 @@ spec:
         - ports:
             - port: "32400"
               protocol: TCP
+    # Allow ingress from WireGuard gateway for OCI VPN proxy
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: wireguard-gateway
+      toPorts:
+        - ports:
+            - port: "32400"
+              protocol: TCP
     # Allow DNS queries
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary
Allow WireGuard gateway pod to access Plex by adding an ingress rule to the CiliumNetworkPolicy.

## Root Cause
The `plex-dmz-isolation` CiliumNetworkPolicy only allowed ingress from:
- `world` entity (external traffic)
- `envoy-internal` gateway
- `kube-dns`
- `prometheus`

The `wireguard-gateway` pod was blocked from reaching Plex.

## Changes
Added ingress rule:
```yaml
- fromEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: network
        app.kubernetes.io/name: wireguard-gateway
  toPorts:
    - ports:
        - port: "32400"
          protocol: TCP
```

## Testing
After merge, verify WireGuard can reach Plex:
```bash
kubectl exec -n network deploy/wireguard-gateway -- wget -q -O /dev/null http://plex.media.svc.cluster.local:32400/web/index.html
```

## Related
- STORY-054: Plex VPN Proxy Implementation
- PR #266: VPS IP fix (merged)
- PR #267: WireGuard egress fix (merged)