### PR TITLE
fix(media): allow WireGuard tunnel CIDR in Plex ingress

### DIFF
--- a/kubernetes/apps/media/plex/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/plex/app/networkpolicy.yaml
@@ -30,6 +30,13 @@ spec:
         - ports:
             - port: "32400"
               protocol: TCP
+    # Allow ingress from WireGuard tunnel network (forwarded VPS traffic)
+    - fromCIDR:
+        - 10.200.200.0/24
+      toPorts:
+        - ports:
+            - port: "32400"
+              protocol: TCP
     # Allow DNS queries
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary
Allow forwarded traffic from WireGuard tunnel to reach Plex.

## Problem
Traffic from VPS forwarded through K8s WireGuard pod arrives with source IP from tunnel network (10.200.200.x), not the pod's IP. Cilium's `fromEndpoints` rule doesn't match forwarded traffic.

## Solution
Add `fromCIDR: [10.200.200.0/24]` to allow traffic from the WireGuard tunnel network.

## Testing
After merge, test VPS to Plex via tunnel:
```bash
ssh ubuntu@129.80.152.215 "curl -s http://10.20.81.100:32400/web/index.html | head -5"
```

## Related
- PR #268: WireGuard endpoint ingress (merged)
- STORY-054: Plex VPN Proxy