### PR TITLE
fix(oci): enable UFW routing for WireGuard port forwarding

### DIFF
--- a/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
+++ b/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
@@ -148,6 +148,8 @@ runcmd:
       ufw allow 22/tcp
 %{ if enable_wireguard ~}
       ufw allow ${wg_listen_port}/udp
+      # Enable routing for forwarded traffic (required for NAT/DNAT to work)
+      ufw default allow routed
 %{ endif ~}
 %{ for port in [for p in try(jsondecode("[{\"port\":${wg_forward_port}}]"), []) : p if p.port > 0] ~}
       ufw allow ${port.port}/tcp


### PR DESCRIPTION
## Summary

Enable UFW routing policy on OCI VPS to allow DNAT port forwarding for Plex access.

## Problem

UFW's default `deny (routed)` policy blocks DNAT forwarding even when explicit iptables FORWARD rules exist. External clients cannot reach Plex via the VPS public IP because forwarded traffic is dropped.

## Solution

Add `ufw default allow routed` when WireGuard is enabled. The WireGuard PostUp FORWARD rules still provide explicit port restrictions (only port 32400 allowed eth0→wg0).

## Security

- Security review: APPROVED
- Oracle Cloud Security List (network-level filtering) still in place
- UFW INPUT chain (inbound protection) unchanged
- WireGuard PostUp FORWARD rules (port-specific restrictions) unchanged
- K8s NetworkPolicy + Cilium (cluster-level isolation) unchanged

## Testing

After merge, VPS must be recreated via GitHub Actions workflow to apply cloud-init changes:
1. Run `oci-plex-proxy` workflow with action: `recreate`
2. Verify UFW status shows `allow (routed)`
3. Test external access to VPS:32400

## Notes

Relates to STORY-054