### PR TITLE
fix(network): update NetworkPolicy for new VPS IP

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
     # Allow WireGuard traffic from Oracle VPS only
     - from:
         - ipBlock:
-            cidr: 129.80.152.215/32  # Oracle VPS public IP
+            cidr: 129.213.56.187/32  # Oracle VPS public IP
       ports:
         - protocol: UDP
           port: 51820
@@ -46,7 +46,7 @@ spec:
     # Allow WireGuard handshake responses to Oracle VPS
     - to:
         - ipBlock:
-            cidr: 129.80.152.215/32  # Oracle VPS public IP
+            cidr: 129.213.56.187/32  # Oracle VPS public IP
       ports:
         - protocol: UDP
           port: 51820


### PR DESCRIPTION
## Summary

Update NetworkPolicy with new VPS IP after VPS recreation with UFW routing fix.

## Changes

- Updated VPS IP in both ingress and egress rules: 129.80.152.215 → 129.213.56.187

## Required Manual Action

**You must also update the 1Password secret** with the new VPS configuration:

| Field | New Value |
|-------|-----------|
| Endpoint | `129.213.56.187:51820` |
| PublicKey | `V57mxRMF+AygEulhG/q7Zxl1X0dX5R6psvF0hRQhI24=` |

After merging this PR:
1. Update the 1Password item "WireGaurd Gateway K8s" with the new Endpoint and PublicKey
2. Restart the WireGuard pod to pick up the new secret: `kubectl rollout restart deploy/wireguard-gateway -n network`

## Testing

After both changes are applied:
1. Verify WireGuard tunnel establishes
2. Test external access to VPS:32400

Relates to STORY-054