### PR TITLE
fix(wireguard): update NetworkPolicy for new VPS IP (129.213.14.137)

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
     # Allow WireGuard traffic from Oracle VPS only
     - from:
         - ipBlock:
-            cidr: 129.213.56.187/32  # Oracle VPS public IP
+            cidr: 129.213.14.137/32  # Oracle VPS public IP
       ports:
         - protocol: UDP
           port: 51820
@@ -46,7 +46,7 @@ spec:
     # Allow WireGuard handshake responses to Oracle VPS
     - to:
         - ipBlock:
-            cidr: 129.213.56.187/32  # Oracle VPS public IP
+            cidr: 129.213.14.137/32  # Oracle VPS public IP
       ports:
         - protocol: UDP
           port: 51820


### PR DESCRIPTION
## Summary
Update WireGuard NetworkPolicy to allow traffic from/to the new Oracle VPS IP address.

## Changes
- Updated ingress rule to allow WireGuard traffic from 129.213.14.137/32
- Updated egress rule to allow WireGuard responses to 129.213.14.137/32

## Background
The previous VPS (129.213.56.187) was reclaimed by Oracle. A new VPS was created via terraform with IP 129.213.14.137.

## Testing
- [ ] NetworkPolicy applied via Flux
- [ ] WireGuard tunnel establishes
- [ ] External Plex access works

## Security
- Security-guardian review passed
- No secrets or credentials in change
- Valid Oracle Cloud public IP