### PR TITLE
feat(oci): implement reserved public IP for VPS persistence

### DIFF
--- a/terraform/oci/main.tf
+++ b/terraform/oci/main.tf
@@ -39,6 +39,11 @@ module "plex_proxy" {
   ssh_public_key    = var.ssh_public_key
   ssh_allowed_cidrs = var.ssh_allowed_cidrs
 
+  # Use reserved public IP - persists across instance recreation
+  # This eliminates the need to update NetworkPolicy and 1Password
+  # every time the VPS is recreated
+  use_reserved_public_ip = true
+
   # WireGuard configuration for Plex proxy
   enable_wireguard       = true
   wg_peer_allowed_cidrs  = var.wg_peer_allowed_cidrs

--- a/terraform/oci/modules/compute/outputs.tf
+++ b/terraform/oci/modules/compute/outputs.tf
@@ -13,8 +13,13 @@ output "instance_name" {
 }
 
 output "public_ip" {
-  description = "Public IP address of the instance"
-  value       = oci_core_instance.main.public_ip
+  description = "Public IP address of the instance (reserved or ephemeral)"
+  value       = var.use_reserved_public_ip ? oci_core_public_ip.reserved[0].ip_address : oci_core_instance.main.public_ip
+}
+
+output "reserved_public_ip_id" {
+  description = "OCID of the reserved public IP (if using reserved IP)"
+  value       = var.use_reserved_public_ip ? oci_core_public_ip.reserved[0].id : null
 }
 
 output "private_ip" {

--- a/terraform/oci/modules/compute/variables.tf
+++ b/terraform/oci/modules/compute/variables.tf
@@ -146,6 +146,16 @@ variable "wg_forward_target_ip" {
 }
 
 # =============================================================================
+# Reserved Public IP
+# =============================================================================
+
+variable "use_reserved_public_ip" {
+  description = "Use a reserved public IP that persists across instance recreation"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
 # Tags
 # =============================================================================
 


### PR DESCRIPTION
## Summary
Implement OCI Reserved Public IP to eliminate the need for NetworkPolicy and 1Password updates every time the VPS is recreated.

## Problem
Every VPS recreation (manual or due to Oracle reclaiming) assigns a new ephemeral public IP, requiring:
1. PR to update NetworkPolicy with new IP
2. Manual 1Password secret update with new endpoint
3. Pod restart to pick up new config

This defeats the "one-click deploy" goal and has resulted in 5+ PRs just for IP changes.

## Solution
Use OCI Reserved Public IP which persists across instance recreation.

## Changes
- Add `use_reserved_public_ip` variable to compute module (default: false)
- Create Reserved Public IP resource with `lifetime = RESERVED`
- Update VNIC to not auto-assign ephemeral IP when using reserved IP
- Update outputs to return reserved IP when available
- Enable reserved IP for plex_proxy module

## How It Works
```
Before: Instance recreation → New ephemeral IP → Manual updates
After:  Instance recreation → Same reserved IP → No updates needed
```

## Testing
After merge:
1. Run `terraform apply` to create reserved IP and attach to existing VPS
2. Note the new reserved IP from terraform output
3. Update NetworkPolicy and 1Password ONE FINAL TIME with reserved IP
4. Test VPS recreation: `terraform taint module.plex_proxy[0].oci_core_instance.main && terraform apply`
5. Verify IP stays the same

## Cost
Reserved Public IPs are included in OCI Always Free tier (1 per account). No additional cost.

## Security
- Security-guardian review passed
- No secrets or credentials exposed
- No sensitive information in changes