### PR TITLE
fix(wireguard): update NetworkPolicy with permanent reserved IP (157.151.218.201)

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/app/networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
     # Allow WireGuard traffic from Oracle VPS only
     - from:
         - ipBlock:
-            cidr: 129.213.14.137/32  # Oracle VPS public IP
+            cidr: 157.151.218.201/32  # Oracle VPS reserved public IP (permanent)
       ports:
         - protocol: UDP
           port: 51820
@@ -46,7 +46,7 @@ spec:
     # Allow WireGuard handshake responses to Oracle VPS
     - to:
         - ipBlock:
-            cidr: 129.213.14.137/32  # Oracle VPS public IP
+            cidr: 157.151.218.201/32  # Oracle VPS reserved public IP (permanent)
       ports:
         - protocol: UDP
           port: 51820


### PR DESCRIPTION
## Summary
Update NetworkPolicy to use the permanent reserved public IP for Oracle VPS.

## This is the FINAL IP update

The reserved IP **157.151.218.201** is permanent and will persist across all future VPS recreations.

**No more NetworkPolicy updates will be needed for IP changes.**

## Changes
- Updated ingress/egress rules from 129.213.14.137/32 to 157.151.218.201/32
- Added "(permanent)" note to comments for clarity

## What Changed Architecturally
PR #273 implemented OCI Reserved Public IP:
- Before: Ephemeral IP changed every VPS recreation
- After: Reserved IP persists across instance recreation

## Testing
- [ ] Flux deploys updated NetworkPolicy
- [ ] WireGuard tunnel establishes with new endpoint
- [ ] External Plex access works via VPS

## Next Steps After Merge
1. Update 1Password "WireGaurd Gateway K8s" with new endpoint: `157.151.218.201:51820`
2. Restart WireGuard pod to pick up new config
3. Test end-to-end connectivity