### PR TITLE
security(plex): restrict egress to explicit FQDN allowlist

### DIFF
--- a/kubernetes/apps/media/plex/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/plex/app/networkpolicy.yaml
@@ -48,10 +48,7 @@ spec:
             io.kubernetes.pod.namespace: monitoring
             app.kubernetes.io/name: prometheus
   egress:
-    # Allow internet access for Plex.tv metadata and updates
-    - toEntities:
-        - world
-    # Allow DNS queries
+    # Allow DNS queries (required for FQDN resolution)
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -62,12 +59,29 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-    # Allow Plex.tv services
+    # Allow Plex.tv services (authentication, metadata, updates)
     - toFQDNs:
         - matchName: "plex.tv"
         - matchPattern: "*.plex.tv"
         - matchPattern: "*.plex.direct"
-    # Allow NFS server access (read-write media library for management)
+        - matchName: "download.plex.tv"
+    # Allow metadata providers (posters, artwork, episode info)
+    - toFQDNs:
+        - matchName: "thetvdb.com"
+        - matchPattern: "*.thetvdb.com"
+        - matchName: "themoviedb.org"
+        - matchPattern: "*.themoviedb.org"
+        - matchName: "fanart.tv"
+        - matchPattern: "*.fanart.tv"
+        - matchName: "musicbrainz.org"
+        - matchPattern: "*.musicbrainz.org"
+        - matchName: "last.fm"
+        - matchPattern: "*.last.fm"
+    # Allow subtitle providers
+    - toFQDNs:
+        - matchName: "opensubtitles.org"
+        - matchPattern: "*.opensubtitles.org"
+    # Allow NFS server access (read-write media library)
     - toCIDR:
         - 10.20.66.11/32
       toPorts:


### PR DESCRIPTION
## Summary
Removes overly permissive `toEntities: world` egress rule from Plex CiliumNetworkPolicy and replaces it with an explicit FQDN allowlist following least privilege principle.

## Security Impact
- **Before**: Plex could reach ANY internet destination
- **After**: Plex can ONLY reach explicitly allowed domains

## Allowed Egress Destinations

| Category | Domains |
|----------|---------|
| Plex Services | plex.tv, *.plex.tv, *.plex.direct, download.plex.tv |
| Metadata (TV/Movies) | thetvdb.com, themoviedb.org |
| Artwork | fanart.tv |
| Music Metadata | musicbrainz.org, last.fm |
| Subtitles | opensubtitles.org |
| Internal | NFS server (10.20.66.11), kube-dns |

## Risk Mitigation
This change reduces blast radius if Plex is compromised:
- Prevents data exfiltration to arbitrary servers
- Blocks C2 communication to attacker infrastructure
- Limits lateral movement capability

## Testing
After merging, verify Plex can still:
- [ ] Fetch metadata for new content
- [ ] Download artwork/posters
- [ ] Authenticate with plex.tv
- [ ] Stream to external clients

If any functionality breaks, domains can be added to the allowlist.