### PR TITLE
fix(workflow): correct terraform output name

### DIFF
--- a/.github/workflows/oci-plex-proxy.yaml
+++ b/.github/workflows/oci-plex-proxy.yaml
@@ -340,7 +340,7 @@ jobs:
         run: |
           # Get outputs (suppress from logs)
           PUBLIC_IP=$(terraform output -raw plex_proxy_public_ip 2>/dev/null || echo "N/A")
-          VPS_WG_PUB=$(terraform output -raw vps_wireguard_public_key 2>/dev/null || echo "N/A")
+          VPS_WG_PUB=$(terraform output -raw plex_proxy_wireguard_public_key 2>/dev/null || echo "N/A")
 
           # SECURITY: Mask sensitive values to prevent log exposure
           # GitHub Actions will replace these values with *** in all subsequent log output


### PR DESCRIPTION
## Summary
Fixes the OCI Plex Proxy workflow failing at the "Get Outputs" step.

## Problem
The workflow was using `vps_wireguard_public_key` but the actual terraform output is named `plex_proxy_wireguard_public_key`. This caused the `terraform output -raw` command to fail, which then caused `::add-mask::N/A` to error with "Invalid format 'N/A'".

## Changes
- Line 343: Changed `vps_wireguard_public_key` to `plex_proxy_wireguard_public_key`

## Testing
After merge, trigger the workflow and verify:
- [ ] Get Outputs step succeeds
- [ ] Sensitive values are masked in logs
- [ ] Deployment summary shows status only