### PR TITLE
fix(terraform/oci): use absolute path for wg binary in GitHub Actions

### DIFF
--- a/terraform/oci/modules/compute/main.tf
+++ b/terraform/oci/modules/compute/main.tf
@@ -65,9 +65,10 @@ data "local_file" "wg_public_key" {
 
 # Derive public key from static private key (when static key provided)
 # Uses query parameter to pass key via stdin instead of shell interpolation (security best practice)
+# Note: Uses full path /usr/bin/wg for GitHub Actions compatibility (PATH may not include it)
 data "external" "wg_public_key_from_static" {
   count   = local.use_static_wg_key ? 1 : 0
-  program = ["bash", "-c", "jq -r .private_key | wg pubkey | jq -R '{public_key: .}'"]
+  program = ["bash", "-c", "jq -r .private_key | /usr/bin/wg pubkey | jq -R '{public_key: .}'"]
   query = {
     private_key = var.wg_private_key
   }


### PR DESCRIPTION
## Summary
Fix `wg: command not found` error in GitHub Actions workflows.

## Problem
The external data source for deriving WireGuard public keys from static private keys was using `wg` without an absolute path. GitHub Actions runners may not have `/usr/bin` in PATH after `apt-get install wireguard-tools`, causing terraform destroy/plan operations to fail.

## Solution
Use absolute path `/usr/bin/wg` instead of just `wg` in the external program command.

## Testing
- Verified `wireguard-tools` package installs to `/usr/bin/wg` on Ubuntu
- No changes to security or secret handling (uses stdin query parameter)

## Security Review
- security-guardian approved
- No secrets or credentials exposed
- No change to sensitive data handling