### PR TITLE
fix(oci): resolve WireGuard public key sensitivity propagation

### DIFF
--- a/terraform/oci/modules/compute/outputs.tf
+++ b/terraform/oci/modules/compute/outputs.tf
@@ -44,5 +44,8 @@ output "subnet_id" {
 
 output "wireguard_public_key" {
   description = "WireGuard public key for this instance (static if wg_private_key provided)"
-  value       = var.enable_wireguard ? local.wg_public_key : null
+  # Use nonsensitive() because while local.wg_public_key inherits sensitivity from
+  # local.use_static_wg_key (which checks wg_private_key != ""), the public key itself
+  # is NOT sensitive - it's meant to be shared with peers.
+  value = var.enable_wireguard ? nonsensitive(local.wg_public_key) : null
 }


### PR DESCRIPTION
## Summary

Fixes persistent GitHub Actions workflow failures in the OCI Plex Proxy deployment. The workflow was failing with "Output refers to sensitive values" error during terraform destroy/plan operations.

## Root Cause

Terraform sensitivity propagation issue:
1. `local.use_static_wg_key` checks `var.wg_private_key != ""`
2. This makes the condition sensitive (because `wg_private_key` is marked `sensitive = true`)
3. `local.wg_public_key` uses this condition, inheriting the sensitivity
4. The `wireguard_public_key` output fails validation because it references a "sensitive" value

## Solution

Use `nonsensitive()` on the public key output:
- WireGuard public keys are NOT sensitive (designed to be shared with peers)
- The private key remains properly marked as sensitive
- Follows cryptographic best practices (public keys are non-confidential per RFC 4253, NIST SP 800-57)

## Changes

- terraform/oci/modules/compute/outputs.tf: Add `nonsensitive()` wrapper to wireguard_public_key output

## Testing

- [x] `terraform validate` passes
- [x] Security-guardian review approved
- [ ] OCI Plex Proxy workflow succeeds after merge

## Notes

This was the actual cause of 5+ consecutive workflow failures. The error was hidden due to the grep pattern in the workflow suppressing terraform error output (the `^Error:` anchor doesn't match terraform's `│ Error:` format).