### PR TITLE
fix(workflow): use targeted destroy to preserve static IP

### DIFF
--- a/.github/workflows/oci-plex-proxy.yaml
+++ b/.github/workflows/oci-plex-proxy.yaml
@@ -186,7 +186,7 @@ jobs:
           echo "::group::Destroying existing resources"
           # SECURITY: Suppress detailed destroy output (contains user_data with secrets)
           # Use targeted destroy to preserve static IP (which has prevent_destroy=true)
-          terraform destroy -target=module.plex_proxy -auto-approve -input=false > /tmp/tfdestroy.txt 2>&1
+          terraform destroy -target=module.plex_proxy[0] -auto-approve -input=false > /tmp/tfdestroy.txt 2>&1
           DESTROY_EXIT=$?
           # Show only resource status (exclude any lines with sensitive patterns)
           grep -E '^(Destroy complete|Error:|Warning:|module\.[^:]+: (Destroying|Destruction complete))' /tmp/tfdestroy.txt | grep -v -E '(user_data|base64|PRIVATE KEY)' | head -30 || true


### PR DESCRIPTION
## Summary
Fix recreate workflow failing due to `prevent_destroy = true` on the static IP resource.

## Problem
The terraform destroy command was attempting to destroy all resources including `oci_core_public_ip.plex_proxy_static`, which has `prevent_destroy = true` in its lifecycle block. This caused the recreate action to fail immediately.

## Solution
Use targeted destroy (`-target=module.plex_proxy`) to only destroy the compute module while preserving the static IP. The subsequent apply will create a new instance and attach it to the existing static IP.

## Testing
- Run workflow with `action: recreate`
- Verify instance is recreated with same static IP