### PR TITLE
fix(workflow): quote module target to prevent bash glob expansion

### DIFF
--- a/.github/workflows/oci-plex-proxy.yaml
+++ b/.github/workflows/oci-plex-proxy.yaml
@@ -186,7 +186,7 @@ jobs:
           echo "::group::Destroying existing resources"
           # SECURITY: Suppress detailed destroy output (contains user_data with secrets)
           # Use targeted destroy to preserve static IP (which has prevent_destroy=true)
-          terraform destroy -target=module.plex_proxy[0] -auto-approve -input=false > /tmp/tfdestroy.txt 2>&1
+          terraform destroy -target='module.plex_proxy[0]' -auto-approve -input=false > /tmp/tfdestroy.txt 2>&1
           DESTROY_EXIT=$?
           # Show only resource status (exclude any lines with sensitive patterns)
           grep -E '^(Destroy complete|Error:|Warning:|module\.[^:]+: (Destroying|Destruction complete))' /tmp/tfdestroy.txt | grep -v -E '(user_data|base64|PRIVATE KEY)' | head -30 || true


### PR DESCRIPTION
## Summary
Fix bash glob expansion issue in targeted destroy command.

## Problem
The `[0]` in `module.plex_proxy[0]` was being interpreted as a bash glob pattern, causing the terraform command to fail.

## Solution
Quote the target parameter: `-target='module.plex_proxy[0]'`