### PR TITLE
fix(network): remove unsupported secretRef from wireguard-gateway SOPS config

### DIFF
--- a/kubernetes/apps/network/wireguard-gateway/ks.yaml
+++ b/kubernetes/apps/network/wireguard-gateway/ks.yaml
@@ -22,9 +22,6 @@ spec:
   # SOPS decryption for WireGuard config secret
   decryption:
     provider: sops
-    secretRef:
-      name: sops-age
-      namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease


### PR DESCRIPTION
## Summary
Fixes the SOPS schema validation error by removing the unsupported `secretRef.namespace` field from the wireguard-gateway Kustomization.

## Problem
PR #295 added `namespace: flux-system` to the secretRef, but this field is not supported in Flux kustomize-controller v1.7.1:
```
.spec.decryption.secretRef.namespace: field not declared in schema
```

## Solution
Remove the `secretRef` entirely, matching the pattern used by other working network apps:
```yaml
# Before (schema error):
decryption:
  provider: sops
  secretRef:
    name: sops-age
    namespace: flux-system

# After (matches cloudflare-dns, cloudflare-tunnel):
decryption:
  provider: sops
```

Flux uses the default SOPS decryption configuration when no secretRef is specified.

## Testing
After merge, verify:
- [ ] cluster-apps Kustomization reconciles without errors
- [ ] wireguard-gateway Kustomization shows Ready=True
- [ ] WireGuard gateway pod starts successfully

## Security
- Security-guardian review passed
- No secrets exposed
- SOPS encryption properly configured