### PR TITLE
fix(oci): add proxy_redirect and WebSocket headers for Plex

### DIFF
--- a/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
+++ b/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
@@ -228,8 +228,8 @@ write_files:
           add_header X-Frame-Options "SAMEORIGIN" always;
           add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
-          # Send timeout for long-running streams
-          send_timeout 100m;
+          # Send timeout for long-running streams (matches proxy_send_timeout)
+          send_timeout 24h;
 
           # Plex client body size (for uploads)
           client_max_body_size 100M;
@@ -242,9 +242,6 @@ write_files:
               # WebSocket support (required for Plex)
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection $connection_upgrade;
-              proxy_set_header Sec-WebSocket-Extensions $http_sec_websocket_extensions;
-              proxy_set_header Sec-WebSocket-Key $http_sec_websocket_key;
-              proxy_set_header Sec-WebSocket-Version $http_sec_websocket_version;
 
               # Standard proxy headers
               proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

Fixes Plex web UI not loading when accessed via https://streaming.homelab0.org

## Problem

Plex was returning HTTP redirects (e.g., `location: http://streaming.homelab0.org/web/index.html`) which caused browsers to hang when trying to follow the redirect to an HTTP URL from an HTTPS page.

## Root Cause

Plex doesn't honor the `X-Forwarded-Proto` header and generates redirect URLs based on the incoming connection protocol (HTTP from NGINX backend).

## Solution

Based on [toomuchio/plex-nginx-reverseproxy](https://github.com/toomuchio/plex-nginx-reverseproxy):

- Add `proxy_redirect http:// https://;` to rewrite backend HTTP redirects to HTTPS
- Add `Sec-WebSocket-*` headers for full WebSocket support (required for Plex live features)
- Move `send_timeout` and `client_max_body_size` to server level per best practices

## Testing

After merge, run OCI workflow with `action=recreate` to deploy new NGINX config.