### PR TITLE
fix(oci): add nginx redirect from root URL to Plex web UI

### DIFF
--- a/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
+++ b/terraform/oci/modules/compute/templates/cloud-init.yaml.tpl
@@ -244,6 +244,12 @@ write_files:
           # Plex client body size (for uploads)
           client_max_body_size 100M;
 
+          # Redirect root URL to Plex web UI (hide API XML from browsers)
+          # This improves UX for users navigating directly to streaming.homelab0.org
+          location = / {
+              return 301 /web/;
+          }
+
           # Reverse proxy to Plex via WireGuard tunnel
           location / {
               # Handle CORS preflight requests


### PR DESCRIPTION
## Summary

Add nginx redirect from `/` to `/web/` in the OCI VPS cloud-init template to improve UX for users navigating directly to `streaming.homelab0.org`.

## Problem

When users navigate to `https://streaming.homelab0.org/`, they see the Plex API XML response instead of the web UI. This is confusing and exposes internal API structure.

## Solution

Add an exact-match nginx redirect that sends users from root URL to the Plex web UI:

```nginx
location = / {
    return 301 /web/;
}
```

## Changes

- Added `location = /` block before `location /` to catch exact root URL requests
- Uses HTTP 301 permanent redirect for browser caching
- Exact match prevents affecting other paths

## Testing

After VPS rebuild, verify:
```bash
# Should return 301 redirect to /web/
curl -I https://streaming.homelab0.org/

# Should return 200 with Plex web UI
curl -I https://streaming.homelab0.org/web/
```

## Notes

- Security review passed (no open redirect vulnerability - hardcoded path)
- Change improves security posture by hiding API XML response from casual browsers