### PR TITLE
fix(arr-storage): add namespace to sourceRef for GitRepository

### DIFF
--- a/kubernetes/apps/media/arr-storage/ks.yaml
+++ b/kubernetes/apps/media/arr-storage/ks.yaml
@@ -14,6 +14,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+    namespace: flux-system
   wait: true
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Summary
Fix Flux Kustomization sourceRef to explicitly reference flux-system namespace.

## Issue
The arr-storage Kustomization was failing with:
```
GitRepository.source.toolkit.fluxcd.io "flux-system" not found
```

## Fix
Added `namespace: flux-system` to sourceRef to match the plex-storage pattern.