### PR TITLE
fix(arr-storage): remove explicit decryption block

### DIFF
--- a/kubernetes/apps/media/arr-storage/ks.yaml
+++ b/kubernetes/apps/media/arr-storage/ks.yaml
@@ -19,7 +19,3 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-  decryption:
-    provider: sops
-    secretRef:
-      name: sops-age


### PR DESCRIPTION
## Summary
Remove explicit decryption block - cluster-apps parent patches it automatically.

## Issue
```
secrets "sops-age" not found
```

## Fix
Remove `decryption` block entirely - parent Kustomization patches all children with `decryption: provider: sops` automatically (same pattern as plex-storage).