### PR TITLE
fix(downloads): remove DNS_KEEP_NAMESERVER causing VPN DNS failure

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -79,9 +79,8 @@ spec:
               FIREWALL: "on"
               FIREWALL_VPN_INPUT_PORTS: "6881"  # BitTorrent port
               FIREWALL_INPUT_PORTS: "8080,8000"  # Web UI and control
-              # DNS
+              # DNS - use VPN provider DNS (Surfshark)
               DOT: "off"
-              DNS_KEEP_NAMESERVER: "on"
               # Logging
               LOG_LEVEL: info
               TZ: America/New_York

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -83,9 +83,8 @@ spec:
               # Firewall Kill Switch
               FIREWALL: "on"
               FIREWALL_INPUT_PORTS: "8080,8000"  # Web UI and control
-              # DNS
+              # DNS - use VPN provider DNS (Surfshark)
               DOT: "off"
-              DNS_KEEP_NAMESERVER: "on"
               # Logging
               LOG_LEVEL: info
               TZ: America/New_York


### PR DESCRIPTION
## Summary
Fix Gluetun VPN DNS resolution failure in download clients.

## Problem
Gluetun healthcheck failing with:
```
dialing: dial tcp4: lookup cloudflare.com: i/o timeout
```

The `DNS_KEEP_NAMESERVER: "on"` setting tells Gluetun to use the pod's original DNS (Kubernetes CoreDNS), but the firewall kill-switch blocks all non-VPN traffic before the tunnel is established.

## Solution
Remove `DNS_KEEP_NAMESERVER: "on"` to let Gluetun use Surfshark's DNS servers through the VPN tunnel.

## Changes
- Remove `DNS_KEEP_NAMESERVER` from qBittorrent Gluetun config
- Remove `DNS_KEEP_NAMESERVER` from SABnzbd Gluetun config

## Testing
- [ ] Pods restart and Gluetun connects successfully
- [ ] DNS resolves through VPN tunnel
- [ ] Public IP shows Surfshark VPN (not home IP)