### PR TITLE
fix(downloads): use TCP probe for qBittorrent

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -33,8 +33,7 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /api/v2/app/version
+                  tcpSocket:
                     port: *port
                   initialDelaySeconds: 60
                   periodSeconds: 30
@@ -44,8 +43,7 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /api/v2/app/version
+                  tcpSocket:
                     port: *port
                   initialDelaySeconds: 60
                   periodSeconds: 30


### PR DESCRIPTION
## Summary
Fix qBittorrent pod restarts due to failed health probes.

## Problem
qBittorrent API requires authentication, returning 403 for requests from non-localhost IPs.
Kubelet probes come from the node IP, not localhost, so HTTP probes fail with 403.

## Solution
Change from HTTP GET probe to TCP socket probe which checks port availability without authentication.

## Changes
- Change qBittorrent liveness probe: httpGet → tcpSocket
- Change qBittorrent readiness probe: httpGet → tcpSocket

## Testing
- [ ] Pod reaches 2/2 Ready state
- [ ] No probe-related restarts