### PR TITLE
fix(media): use valid Sonarr image tag

### DIFF
--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/onedr0p/sonarr-develop
-              tag: 4.0.11.2680
+              repository: ghcr.io/onedr0p/sonarr
+              tag: 4.0.13.2932
             env:
               TZ: America/New_York
               SONARR__PORT: &port 8989


### PR DESCRIPTION
## Summary

Fixes ImagePullBackOff error for Sonarr deployment.

## Problem

The image `ghcr.io/onedr0p/sonarr-develop:4.0.11.2680` doesn't exist.

## Solution

Changed to `ghcr.io/onedr0p/sonarr:4.0.13.2932` which is a valid stable release.

## Testing

- [ ] Sonarr pod starts successfully (1/1)