### PR TITLE
fix(media): correct image tag format (no v prefix)

### DIFF
--- a/kubernetes/apps/media/cleanuparr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cleanuparr/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cleanuparr/cleanuparr
-              tag: v2.4.7
+              tag: "2.4.7"
             env:
               TZ: America/New_York
             probes:

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/jorenn92/maintainerr
-              tag: v2.22.1
+              repository: docker.io/jorenn92/maintainerr
+              tag: "2.22.1"
             env:
               TZ: America/New_York
             probes:


### PR DESCRIPTION
## Summary
Fixes remaining ImagePullBackOff errors for cleanuparr and maintainerr.

## Issue
After PR #318, both apps still fail to pull images because of incorrect tag format:
- GHCR Cleanuparr uses tags like `2.4.7` not `v2.4.7`
- Maintainerr is on Docker Hub (`docker.io/jorenn92/maintainerr`), not GHCR

## Changes
- **cleanuparr**: `v2.4.7` → `2.4.7`
- **maintainerr**: 
  - Registry: `ghcr.io/jorenn92/maintainerr` → `docker.io/jorenn92/maintainerr`
  - Tag: `v2.22.1` → `2.22.1`

## Testing
- [ ] Verify cleanuparr pod pulls image successfully
- [ ] Verify maintainerr pod pulls image successfully
- [ ] Verify both apps start and are accessible