### PR TITLE
fix(media): remove container securityContext from cleanuparr

### DIFF
--- a/kubernetes/apps/media/cleanuparr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cleanuparr/app/helmrelease.yaml
@@ -55,12 +55,7 @@ spec:
               limits:
                 cpu: 500m
                 memory: 512Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                  - ALL
+            # No container securityContext - cleanuparr needs root capabilities for user creation
 
     defaultPodOptions:
       automountServiceAccountToken: false


### PR DESCRIPTION
## Summary
Removes container-level securityContext from cleanuparr to allow user/group creation at startup.

## Problem
Cleanuparr was failing with:
```
Creating group with GID 1000
groupadd: failure while writing changes to /etc/gshadow
```

## Root Cause
The container-level `capabilities: drop: [ALL]` blocks `groupadd` from writing to system files. The container needs CAP_SETGID and other capabilities to create users at startup.

## Solution
Remove container-level securityContext entirely, matching kubesearch.dev community configs which have no restrictions for this app.

## Testing
- [ ] Cleanuparr pod starts successfully
- [ ] User/group creation completes
- [ ] App accessible via HTTPRoute