### PR TITLE
fix(media): update maintainerr image to correct ghcr.io org

### DIFF
--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/jorenn92/maintainerr
-              tag: "2.22.1"
+              repository: ghcr.io/maintainerr/maintainerr
+              tag: "2.22.1@sha256:54390936bd6e3579f1a32e4d00fee9a61c8b373a37012789580e0778c8d11269"
             env:
               TZ: America/New_York
             probes:
@@ -65,10 +65,10 @@ spec:
     defaultPodOptions:
       automountServiceAccountToken: false
       securityContext:
-        runAsUser: 568
-        runAsGroup: 568
+        runAsUser: 1000
+        runAsGroup: 1000
         runAsNonRoot: true
-        fsGroup: 568
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
## Summary
Updates maintainerr to use the correct image from the `maintainerr` organization on ghcr.io, matching kubesearch.dev community configs.

## Problem
Maintainerr was failing with `ImagePullBackOff`:
```
ghcr.io/jorenn92/maintainerr:2.22.1: not found
```

## Root Cause
The maintainerr project moved from `jorenn92` to `maintainerr` organization on ghcr.io.

## Changes
- **Repository**: `ghcr.io/jorenn92/maintainerr` → `ghcr.io/maintainerr/maintainerr`
- **Tag**: Use digest-pinned `2.22.1@sha256:54390...` per community config
- **UID/GID**: Updated to 1000 per community standard

## Source
https://kubesearch.dev/hr/ghcr.io-bjw-s-labs-helm-app-template-maintainerr

## Testing
- [ ] Maintainerr pod starts successfully
- [ ] Image pulls from ghcr.io/maintainerr/maintainerr
- [ ] App accessible via HTTPRoute