### PR TITLE
fix(cloudflare-tunnel): revert unnecessary --config flag

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
             envFrom:
               - secretRef:
                   name: cloudflare-tunnel-secret
-            args: ["tunnel", "--config", "/etc/cloudflared/config.yaml", "run"]
+            args: ["tunnel", "run"]
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Summary
Reverts the unnecessary `--config` flag added in commit 884d833.

## Background
The `--config` flag was added during debugging of Cloudflare Error 1000 for overseerr/wizarr. However, the actual root cause was conflicting hostname configurations in a separate Cloudflare tunnel (pointing to old Traefik).

The tunnel works correctly with just `tunnel run` when using `TUNNEL_TOKEN` - Cloudflare manages the config via the dashboard/Zero Trust.

## Changes
- Reverts args from `["tunnel", "--config", "/etc/cloudflared/config.yaml", "run"]` back to `["tunnel", "run"]`