### PR TITLE
fix(media): allow Huntarr to Prowlarr network access

### DIFF
--- a/kubernetes/apps/media/huntarr/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/huntarr/app/networkpolicy.yaml
@@ -55,3 +55,12 @@ spec:
         - ports:
             - port: "7878"
               protocol: TCP
+    # Allow egress to Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP

--- a/kubernetes/apps/media/prowlarr/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/prowlarr/app/networkpolicy.yaml
@@ -38,6 +38,15 @@ spec:
         - ports:
             - port: "9696"
               protocol: TCP
+    # Allow from Huntarr (automated media hunting)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: huntarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
     # Allow Prometheus metrics scraping
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary
Add NetworkPolicy rules for Huntarr to communicate with Prowlarr.

## Changes
- **Huntarr**: Add egress rule to Prowlarr on port 9696
- **Prowlarr**: Add ingress rule from Huntarr on port 9696

## Why
Huntarr needs to connect to Prowlarr to search indexers via the Prowlarr API. Without these rules, Huntarr shows connection errors when trying to add Prowlarr.