### PR TITLE
fix(media): use linuxserver.io image for Tautulli

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -58,8 +58,15 @@ spec:
                 cpu: 500m
                 memory: 512Mi
             securityContext:
-              allowPrivilegeEscalation: true
+              allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETUID
+                  - SETGID
 
     defaultPodOptions:
       automountServiceAccountToken: false
@@ -70,6 +77,7 @@ spec:
           type: RuntimeDefault
       annotations:
         security.homelab/network: "Internal - Plex monitoring"
+        security.homelab/exception: "LinuxServer.io image requires root for s6-overlay init"
 
     persistence:
       config:


### PR DESCRIPTION
## Summary

Fixes Tautulli CrashLoopBackOff - the official `ghcr.io/tautulli/tautulli` image tries to switch users at runtime which fails with our security context.

## Changes

- Switch to `lscr.io/linuxserver/tautulli:2.14.6` which properly supports PUID/PGID
- Relax security context to allow linuxserver.io's initialization process

## Root Cause

```
usermod: Permission denied.
error: failed switching to "tautulli": operation not permitted
```

The official image expects to run as root and switch users, but our pod security context enforced `runAsNonRoot: true`.

## Testing

- [ ] Tautulli pod starts successfully
- [ ] Tautulli connects to Plex