### PR TITLE
fix(media): allow Notifiarr egress to download clients

### DIFF
--- a/kubernetes/apps/media/notifiarr/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/notifiarr/app/networkpolicy.yaml
@@ -73,6 +73,24 @@ spec:
         - ports:
             - port: "32400"
               protocol: TCP
+    # Allow egress to qBittorrent (download client monitoring)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Allow egress to SABnzbd (download client monitoring)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     # Allow internet egress for Notifiarr.com API and TRaSH guides
     - toEntities:
         - world


### PR DESCRIPTION
## Summary
Add NetworkPolicy egress rules for Notifiarr to reach download clients in the downloads namespace.

## Changes
- Add egress to qBittorrent (port 8080)
- Add egress to SABnzbd (port 8080)

## Testing
- [ ] Notifiarr can connect to qBittorrent
- [ ] Notifiarr can connect to SABnzbd