### PR TITLE
fix(media): use cat+exec instead of kubectl cp for ConfigMap copy

### DIFF
--- a/kubernetes/apps/media/tautulli/app/newsletter-sync.yaml
+++ b/kubernetes/apps/media/tautulli/app/newsletter-sync.yaml
@@ -219,7 +219,7 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  set -e
+                  set -eo pipefail
                   echo "Finding Tautulli pod..."
                   POD=$(kubectl get pod -n media -l app.kubernetes.io/name=tautulli -o jsonpath='{.items[0].metadata.name}')
                   echo "Copying sync script to pod..."


### PR DESCRIPTION
## Summary

Fixes the Tautulli newsletter sync CronJob which was failing with:
```
python3: can't open file '/tmp/sync-users.py': No such file or directory
```

## Problem

The init container was using `kubectl cp` to copy the sync script from a ConfigMap mount to the Tautulli pod. ConfigMap mounts are symlinks (e.g., `/scripts/sync-users.py -> ..data/sync-users.py`), and `kubectl cp` copies the symlink rather than the file content, resulting in a broken symlink in the target pod.

## Solution

Changed from:
```bash
kubectl cp /scripts/sync-users.py media/"$POD":/tmp/sync-users.py
```

To:
```bash
cat /scripts/sync-users.py | kubectl exec -i -n media "$POD" -- tee /tmp/sync-users.py > /dev/null
```

This reads the actual file content using `cat` and pipes it through `kubectl exec` with `tee` to write the content to the target pod.

## Testing

After merge, run:
```bash
kubectl create job --from=cronjob/tautulli-newsletter-sync test-sync -n media
kubectl logs -n media job/test-sync -f
kubectl delete job test-sync -n media
```

## Security Review

- [x] security-guardian approval received
- [x] No secrets in plaintext
- [x] Standard Kubernetes pattern for ConfigMap handling