### PR TITLE
fix(media): handle null email values in newsletter sync script

### DIFF
--- a/kubernetes/apps/media/tautulli/app/newsletter-sync.yaml
+++ b/kubernetes/apps/media/tautulli/app/newsletter-sync.yaml
@@ -72,7 +72,8 @@ data:
                 # Filter users with valid email addresses
                 emails = []
                 for user in users:
-                    email = user.get('email', '').strip()
+                    # Handle None values - email field may be null in API response
+                    email = (user.get('email') or '').strip()
                     if email and EMAIL_REGEX.match(email):
                         emails.append(email)
                         print(f"  Found user: {user.get('friendly_name', 'Unknown')} <{email}>")


### PR DESCRIPTION
## Summary

Fixes the newsletter sync script crashing when users have null email fields.

## Problem

The Tautulli API may return `null` for the email field rather than omitting it:
```json
{"email": null, "friendly_name": "SomeUser"}
```

The script was using `user.get('email', '').strip()` which returns `None` when the key exists but has a null value, causing:
```
Error fetching users: 'NoneType' object has no attribute 'strip'
```

## Solution

Changed to `(user.get('email') or '').strip()` which handles both:
- Missing email key (returns empty string)
- Null email value (returns empty string)

## Testing

After merge, run:
```bash
kubectl delete job test-sync-1764735603 -n media
kubectl create job --from=cronjob/tautulli-newsletter-sync test-sync -n media
kubectl logs -n media job/test-sync -f
```