### PR TITLE
fix(security): add PostgreSQL password env var for Authentik

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -32,6 +32,11 @@ spec:
             secretKeyRef:
               name: authentik-secret
               key: AUTHENTIK_BOOTSTRAP_EMAIL
+        - name: AUTHENTIK_POSTGRESQL__PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: authentik-secret
+              key: POSTGRES_PASSWORD
 
     authentik:
       error_reporting:


### PR DESCRIPTION
## Summary
Fix Authentik pod startup failure - missing PostgreSQL password environment variable.

## Problem
Authentik server and worker pods failing to connect to PostgreSQL:
```
PostgreSQL connection failed: fe_sendauth: no password supplied
```

## Fix
Add `AUTHENTIK_POSTGRESQL__PASSWORD` env var referencing existing `POSTGRES_PASSWORD` from `authentik-secret`.

## Testing
- [ ] Pods start successfully
- [ ] Authentik connects to PostgreSQL
- [ ] Web UI accessible