### PR TITLE
feat(network): add Authentik to Cloudflare tunnel ingress

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -111,6 +111,13 @@ spec:
                   http2Origin: true
                   originServerName: tautulli.${SECRET_DOMAIN}
 
+              # Authentik (identity provider for external auth)
+              - hostname: "authentik.${SECRET_DOMAIN}"
+                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                originRequest:
+                  http2Origin: true
+                  originServerName: authentik.${SECRET_DOMAIN}
+
               # NOTE: Apps NOT routed through Cloudflare tunnel:
               # - Plex (DMZ): UDM SE port forward for high bandwidth streaming
               # - Home Assistant (IoT): Internal-only access via cluster DNS


### PR DESCRIPTION
## Summary
Adds Authentik identity provider to Cloudflare tunnel ingress configuration, enabling external access for Plex OAuth authentication flow.

## Changes
- Add authentik.homelab0.org hostname routing through Cloudflare tunnel
- Routes via envoy-external gateway with HTTP/2 origin
- Follows existing pattern for external services (overseerr, wizarr, tautulli)

## Testing
- [ ] Verify Cloudflare tunnel config reloads
- [ ] Test external access to authentik.homelab0.org
- [ ] Confirm Plex OAuth flow works externally

## Notes
**Important**: This PR also requires a DNS CNAME record to be added in Cloudflare:
- `authentik.homelab0.org` → `external.homelab0.org`

Without the CNAME, external traffic won't route through the tunnel.

Part of STORY-060: Media Health Dashboard with Plex OAuth