### PR TITLE
feat(security): add custom CSS for Authentik branding

### DIFF
--- a/kubernetes/apps/security/authentik/app/configmap-custom-css.yaml
+++ b/kubernetes/apps/security/authentik/app/configmap-custom-css.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-custom-css
+  namespace: security
+data:
+  custom.css: |
+    /* Homelab.0 Authentik Custom Theme */
+
+    /* Override PatternFly primary button colors - blue instead of red */
+    :root {
+      --pf-c-button--m-primary--BackgroundColor: #3b82f6;
+      --pf-c-button--m-primary--hover--BackgroundColor: #2563eb;
+      --pf-c-button--m-primary--active--BackgroundColor: #1d4ed8;
+      --pf-c-button--m-primary--focus--BackgroundColor: #2563eb;
+      --pf-global--primary-color--100: #3b82f6;
+      --pf-global--primary-color--200: #2563eb;
+      --pf-global--link--Color: #3b82f6;
+      --pf-global--link--Color--hover: #2563eb;
+      --ak-accent: #3b82f6;
+    }
+
+    /* Force blue buttons everywhere */
+    .pf-c-button.pf-m-primary {
+      background-color: #3b82f6 !important;
+      border-color: #3b82f6 !important;
+    }
+
+    .pf-c-button.pf-m-primary:hover {
+      background-color: #2563eb !important;
+      border-color: #2563eb !important;
+    }
+
+    /* Login page title - white text, centered */
+    .pf-c-login__main-header h1,
+    .ak-flow-title,
+    h1.pf-c-title {
+      color: #ffffff !important;
+      text-align: center !important;
+      width: 100%;
+    }
+
+    /* Center the logo and branding */
+    .ak-brand {
+      display: flex;
+      justify-content: center;
+      width: 100%;
+    }
+
+    .ak-brand img {
+      display: block;
+      margin: 0 auto;
+    }

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -56,6 +56,15 @@ spec:
         enabled: true
         serviceMonitor:
           enabled: true
+      volumes:
+        - name: custom-css
+          configMap:
+            name: authentik-custom-css
+      volumeMounts:
+        - name: custom-css
+          mountPath: /web/dist/custom.css
+          subPath: custom.css
+          readOnly: true
 
     worker:
       replicas: 1

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./helmrepository.yaml
   - ./externalsecret.yaml
+  - ./configmap-custom-css.yaml
   - ./helmrelease.yaml
   - ./httproute-external.yaml
   - ./httproute-internal.yaml


### PR DESCRIPTION
## Summary
- Add ConfigMap with custom CSS to change button colors from red to blue (#3b82f6)
- Mount custom.css file to Authentik server at /web/dist/custom.css
- Improve login page styling with centered title and white text

## Changes
- New `configmap-custom-css.yaml` with PatternFly CSS variable overrides
- HelmRelease updated with volume and volumeMount for custom.css
- Kustomization updated to include the new ConfigMap

## Why
The brand CSS in Authentik's admin UI doesn't penetrate Shadow DOM components. Mounting a custom.css file is the documented approach for Kubernetes deployments to properly theme the login button and other components.

## Testing
- [ ] Verify ConfigMap is created in security namespace
- [ ] Verify custom.css is mounted in authentik-server pod
- [ ] Verify login button renders as blue instead of red
- [ ] Verify "Welcome to Homelab.0" title is white and centered

## Security Review
- [x] security-guardian approval received
- [x] No secrets in plaintext
- [x] YAML syntax validated
- [x] CSS-only changes, no executable code