### PR TITLE
fix(media): correct storageClassName field for Gatus PVC

### DIFF
--- a/kubernetes/apps/media/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gatus/app/helmrelease.yaml
@@ -164,7 +164,7 @@ spec:
 
     persistence:
       enabled: true
-      storageClass: ceph-block
+      storageClassName: ceph-block
       size: 1Gi
       accessModes:
         - ReadWriteOnce


### PR DESCRIPTION
One-line fix: TwiN chart uses `storageClassName` not `storageClass`

PVC was stuck pending because storageClass wasn't being applied.