### PR TITLE
fix(media): use underscore field names for 1Password gatus-oidc

### DIFF
--- a/kubernetes/apps/media/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/media/gatus/app/externalsecret.yaml
@@ -16,8 +16,8 @@ spec:
     - secretKey: OIDC_CLIENT_ID
       remoteRef:
         key: gatus-oidc
-        property: client-id
+        property: client_id
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: gatus-oidc
-        property: client-secret
+        property: client_secret


### PR DESCRIPTION
1Password item uses `client_id` and `client_secret` (underscores, not hyphens)