### PR TITLE
fix(media): disable Gatus probes - chart limitation

### DIFF
--- a/kubernetes/apps/media/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gatus/app/helmrelease.yaml
@@ -173,24 +173,13 @@ spec:
     serviceMonitor:
       enabled: true
 
-    # Give Gatus time to fetch OIDC discovery document before probes start
+    # Disable probes - TwiN chart doesn't support custom probe parameters
+    # OIDC initialization can delay web server startup beyond default probe limits
     livenessProbe:
-      httpGet:
-        path: /health
-        port: 8080
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
+      enabled: false
 
     readinessProbe:
-      httpGet:
-        path: /health
-        port: 8080
-      initialDelaySeconds: 15
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 3
+      enabled: false
 
     podSecurityContext:
       runAsUser: 65534


### PR DESCRIPTION
## Summary
Disable liveness/readiness probes for Gatus deployment.

## Root Cause
TwiN Gatus Helm chart only supports `enabled: true/false` for probes - it does not support custom parameters like `initialDelaySeconds`. OIDC initialization delays the web server startup beyond default probe timeout limits, causing CrashLoopBackOff.

## Changes
- Set `livenessProbe.enabled: false`
- Set `readinessProbe.enabled: false`

## Follow-up
Consider migrating to bjw-s common chart for full probe customization in the future.