### PR TITLE
fix(media): use external Authentik URL for Gatus OIDC issuer

### DIFF
--- a/kubernetes/apps/media/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gatus/app/helmrelease.yaml
@@ -45,8 +45,8 @@ spec:
 
       security:
         oidc:
-          # Use internal service for OIDC discovery to avoid external network dependency
-          issuer-url: http://authentik-server.security.svc.cluster.local/application/o/gatus-health-dashboard/
+          # Use external Authentik URL so browser can reach authorization endpoint
+          issuer-url: https://authentik.homelab0.org/application/o/gatus-health-dashboard/
           redirect-url: https://media-status.homelab0.org/authorization-code/callback
           client-id: ${OIDC_CLIENT_ID}
           client-secret: ${OIDC_CLIENT_SECRET}


### PR DESCRIPTION
## Summary
Fixes OIDC login redirect - browser couldn't reach internal cluster URL.

## Problem
The OIDC issuer was using `http://authentik-server.security.svc.cluster.local/...` which the user's browser cannot resolve when redirecting to the authorization endpoint.

## Changes
Changed issuer-url to external Authentik URL: `https://authentik.homelab0.org/application/o/gatus-health-dashboard/`

## Testing
- [ ] Click OIDC login on media-status.homelab0.org
- [ ] Should redirect to Authentik login page
- [ ] Plex OAuth should work