### PR TITLE
fix(media): correct rook-ceph dependency namespace for uptime-kuma

### DIFF
--- a/kubernetes/apps/media/uptime-kuma/ks.yaml
+++ b/kubernetes/apps/media/uptime-kuma/ks.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/name: uptime-kuma
   dependsOn:
     - name: rook-ceph-cluster
-      namespace: flux-system
+      namespace: rook-ceph
   path: ./kubernetes/apps/media/uptime-kuma/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
Fixes Uptime Kuma deployment failure due to incorrect dependency namespace reference.

## Problem
The Kustomization was depending on `flux-system/rook-ceph-cluster` but the actual Kustomization is in the `rook-ceph` namespace:

```
dependency 'flux-system/rook-ceph-cluster' not found
```

## Fix
Changed `namespace: flux-system` to `namespace: rook-ceph` in ks.yaml dependsOn.

## Testing
- Verified rook-ceph-cluster Kustomization exists in rook-ceph namespace
- Verified ceph-block StorageClass is available