### PR TITLE
fix(media): correct uptime-kuma helm chart values for storage

### DIFF
--- a/kubernetes/apps/media/uptime-kuma/app/helmrelease.yaml
+++ b/kubernetes/apps/media/uptime-kuma/app/helmrelease.yaml
@@ -34,9 +34,9 @@ spec:
     service:
       port: 3001
 
-    persistence:
+    volume:
       enabled: true
-      storageClass: ceph-block
+      storageClassName: ceph-block
       size: 2Gi
 
     # Pod security


### PR DESCRIPTION
## Summary
Fixes PVC not binding due to incorrect helm chart value keys.

## Problem
The PVC was created without a storage class:
```
no persistent volumes available for this claim and no storage class is set
```

## Root Cause
The uptime-kuma helm chart uses different value keys than expected:
- `volume` instead of `persistence`
- `storageClassName` instead of `storageClass`

## Fix
Updated HelmRelease values to match chart expectations.