### PR TITLE
fix(media): add SETUID/SETGID capabilities for uptime-kuma

### DIFF
--- a/kubernetes/apps/media/uptime-kuma/app/helmrelease.yaml
+++ b/kubernetes/apps/media/uptime-kuma/app/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
       capabilities:
         drop:
           - ALL
+        add:
+          - SETUID
+          - SETGID
 
     # Liveness/readiness probes
     livenessProbe:


### PR DESCRIPTION
## Summary
Fixes container startup failure due to missing capabilities.

## Problem
```
setpriv: setgroups failed: Operation not permitted
```

The container entrypoint uses `setpriv` to drop privileges from root to the node user. This requires SETUID and SETGID capabilities.

## Fix
Added SETUID and SETGID capabilities while keeping all others dropped.

## Security Note
These capabilities are only used during container startup to drop from root to unprivileged user. The application runs as non-root after initialization.