### PR TITLE
feat(media): add dedicated internal URL for Uptime Kuma dashboard

### DIFF
--- a/kubernetes/apps/media/uptime-kuma/app/httproute-internal.yaml
+++ b/kubernetes/apps/media/uptime-kuma/app/httproute-internal.yaml
@@ -1,18 +1,20 @@
 ---
+# Internal HTTPRoute - Full dashboard access via kuma.homelab0.org
+# External status pages use media-status.homelab0.org (separate route)
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: uptime-kuma-internal
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: media-status.homelab0.org
+    external-dns.alpha.kubernetes.io/hostname: kuma.homelab0.org
 spec:
   parentRefs:
     - name: envoy-internal
       namespace: network
       sectionName: https
   hostnames:
-    - media-status.homelab0.org
+    - kuma.homelab0.org
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary
Adds a dedicated internal hostname for Uptime Kuma dashboard access, separating admin functionality from public status pages.

## Changes
- Changed internal HTTPRoute hostname from `media-status.homelab0.org` to `kuma.homelab0.org`
- Added clarifying comments about internal vs external routing
- Internal DNS record will be created via unifi-dns external-dns controller

## Access Pattern After Merge

| URL | Gateway | Purpose |
|-----|---------|---------|
| `kuma.homelab0.org` | envoy-internal | Full dashboard access (internal only) |
| `media-status.homelab0.org/status/media` | envoy-external | Public status page (restricted paths) |

## Why This Change
Previously both internal and external routes used the same hostname (`media-status.homelab0.org`), causing DNS to resolve to Cloudflare for all clients. This made internal dashboard access go through Cloudflare tunnel which only allowed restricted paths.

With separate hostnames:
- `kuma.homelab0.org` → UniFi DNS → internal gateway → full access
- `media-status.homelab0.org` → Cloudflare DNS → external gateway → status pages only

## Future Expandability
This pattern allows adding more public status pages:
- `homelab-apps.homelab0.org/status/apps`
- Other dedicated status page URLs

## Testing
- [ ] HTTPRoute deploys successfully
- [ ] DNS record created in UniFi (`kuma.homelab0.org` → internal.homelab0.org)
- [ ] Dashboard accessible at `https://kuma.homelab0.org/dashboard`
- [ ] External status page still works at `https://media-status.homelab0.org/status/media`