### PR TITLE
fix(media): remove BookStack init container causing deadlock

### DIFF
--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -22,22 +22,8 @@ spec:
     controllers:
       bookstack:
         strategy: Recreate
-        initContainers:
-          # Wait for MariaDB to be ready before starting BookStack
-          wait-for-db:
-            image:
-              repository: busybox
-              tag: "1.37.0"
-            command:
-              - sh
-              - -c
-              - |
-                echo "Waiting for MariaDB to be ready..."
-                until nc -z localhost 3306; do
-                  echo "MariaDB not ready, waiting..."
-                  sleep 2
-                done
-                echo "MariaDB is ready!"
+        # NOTE: No initContainer for DB check - sidecar containers start AFTER
+        # init containers, creating a deadlock. BookStack has built-in DB retry logic.
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary

Fixes BookStack pod stuck in `Init:0/1` state.

## Problem

The init container `wait-for-db` was checking for MariaDB on `localhost:3306`, but:
- Init containers run **before** sidecar containers start
- MariaDB is a sidecar container
- This creates a deadlock: init waits for DB, DB waits for init to complete

## Solution

Remove the init container. BookStack has built-in database connection retry logic that handles waiting for MariaDB to be ready.

## Testing

After merge, BookStack pod should start normally with both `app` and `db` containers running.