### PR TITLE
fix(media): align BookStack MariaDB secret name with chart expectations

### DIFF
--- a/kubernetes/apps/media/bookstack/app/externalsecret.yaml
+++ b/kubernetes/apps/media/bookstack/app/externalsecret.yaml
@@ -32,11 +32,12 @@ spec:
         property: mail-password
 ---
 # Bitnami MariaDB subchart secret
+# gabe565 chart expects secret named: <release-name>-mariadb = bookstack-mariadb
 # Requires specific key names: mariadb-password, mariadb-root-password
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: bookstack-db-secret
+  name: bookstack-mariadb
   namespace: media
 spec:
   refreshInterval: 5m
@@ -44,7 +45,7 @@ spec:
     name: onepassword-connect
     kind: ClusterSecretStore
   target:
-    name: bookstack-db-secret
+    name: bookstack-mariadb
     creationPolicy: Owner
   data:
     # Bitnami MariaDB expects these exact key names

--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
       auth:
         database: bookstackapp
         username: bookstack
-        existingSecret: bookstack-db-secret
+        existingSecret: bookstack-mariadb
       primary:
         persistence:
           enabled: true


### PR DESCRIPTION
## Summary
Fixes CreateContainerConfigError in BookStack deployment after PR #366 merge.

## Problem
The gabe565 BookStack Helm chart expects the MariaDB secret to be named `<release-name>-mariadb` (i.e., `bookstack-mariadb`). Our ExternalSecret was creating a secret named `bookstack-db-secret`, causing the pod to fail with:
```
Error: secret "bookstack-mariadb" not found
```

## Changes
- Renamed ExternalSecret from `bookstack-db-secret` to `bookstack-mariadb`
- Updated HelmRelease `existingSecret` reference to match

## Testing
- [ ] ExternalSecret creates `bookstack-mariadb` secret
- [ ] BookStack pod starts without CreateContainerConfigError
- [ ] MariaDB initializes with correct credentials