### PR TITLE
fix(media): disable Bitnami MariaDB restrictive NetworkPolicy

### DIFF
--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -81,6 +81,10 @@ spec:
         persistence:
           enabled: true
           existingClaim: bookstack-db-pvc
+      # Disable Bitnami's restrictive NetworkPolicy - it blocks BookStack from connecting
+      # We manage network policies separately via Cilium
+      networkPolicy:
+        enabled: false
 
     # Security context - LinuxServer images require root for s6-overlay
     podSecurityContext:

--- a/kubernetes/apps/media/bookstack/app/networkpolicy.yaml
+++ b/kubernetes/apps/media/bookstack/app/networkpolicy.yaml
@@ -39,6 +39,16 @@ spec:
             - port: "80"
               protocol: TCP
   egress:
+    # MariaDB database connection (same namespace)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: mariadb
+            app.kubernetes.io/instance: bookstack
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary
Fixes BookStack unable to connect to MariaDB database (504 Gateway Timeout).

## Root Cause
The Bitnami MariaDB subchart creates a NetworkPolicy that only allows traffic from pods matching MariaDB labels:
```yaml
podSelector:
  matchLabels:
    app.kubernetes.io/name: mariadb
```

This blocks the BookStack pod (`app.kubernetes.io/name: bookstack`) from connecting.

## Changes
- Disabled Bitnami's built-in NetworkPolicy via `networkPolicy.enabled: false`
- Network policies are managed separately via Cilium

## Testing
- [ ] BookStack connects to MariaDB successfully
- [ ] BookStack health check returns 200