### PR TITLE
feat(network): add BookStack guides to Cloudflare tunnel

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -125,6 +125,13 @@ spec:
                   http2Origin: true
                   originServerName: media-status.${SECRET_DOMAIN}
 
+              # BookStack Guides (documentation/wiki)
+              - hostname: "guides.${SECRET_DOMAIN}"
+                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                originRequest:
+                  http2Origin: true
+                  originServerName: guides.${SECRET_DOMAIN}
+
               # NOTE: Apps NOT routed through Cloudflare tunnel:
               # - Plex (DMZ): UDM SE port forward for high bandwidth streaming
               # - Home Assistant (IoT): Internal-only access via cluster DNS


### PR DESCRIPTION
## Summary
Add guides.homelab0.org to Cloudflare tunnel ingress configuration.

## Changes
- Add ingress rule for guides.homelab0.org pointing to envoy-external gateway

## Context
DNS (via external-dns) already points guides.homelab0.org → external.homelab0.org (Cloudflare tunnel), but the tunnel config was missing the ingress rule, causing "problem with this site" errors.

## Testing
- Verify guides.homelab0.org loads BookStack after merge