### PR TITLE
fix(media): update Renovate annotation format for BookStack

### DIFF
--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/linuxserver/bookstack
-      # renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack
+      # datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
       tag: version-v24.12.1
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
The previous annotation format (`# renovate: datasource=...`) wasn't being detected by Renovate.

Updated to use the regexManager-compatible format that matches the `matchStrings` pattern in `.github/renovate.json5`.

## Changes
- Changed annotation from `# renovate: datasource=docker depName=...`
- To: `# datasource=docker depName=... versioning=loose`

## Expected Result
After merge, Renovate should detect BookStack image and propose v24.12.1 → v25.11.4 update.