### PR TITLE
fix(renovate): update regexManager to support YAML comment annotations

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,8 +32,8 @@
       "description": "Process custom dependencies in YAML files",
       "fileMatch": ["kubernetes/.+\\.ya?ml$"],
       "matchStrings": [
-        // Match patterns like: tag: 1.2.3 with renovate comment
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"?(?<currentValue>[^\\s\"]+)\"?"
+        // Match patterns like: # datasource=docker depName=foo\n  tag: 1.2.3
+        "#?\\s*datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?\"?(?<currentValue>[^\\s\"]+)\"?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"


### PR DESCRIPTION
## Summary
The regexManager pattern was looking for lines starting with `datasource=` but YAML annotations are in comments starting with `# datasource=`.

## Changes
- Updated regex from `datasource=...` to `#?\s*datasource=...`
- This allows matching both plain and commented annotation formats

## Impact
Enables detection of BookStack image:
```yaml
# datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
tag: version-v24.12.1
```

After merge, Renovate should propose the v24.12.1 → v25.11.4 update.