### PR TITLE
fix(renovate): use correct annotation format for BookStack image

### DIFF
--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/linuxserver/bookstack
-      # datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
+      # renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
       tag: version-v24.12.1
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
Fixes BookStack image not being detected by Renovate by using the correct annotation format.

## Problem
The previous annotation format `# datasource=docker depName=...` was only matched by the deprecated `regexManagers` block in `renovate.json5`. Renovate now uses `customManagers` from `customManagers.json5`, which requires the `# renovate:` prefix.

## Changes
- Added `renovate:` prefix to the BookStack image annotation:
  - Before: `# datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose`
  - After: `# renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose`

## Testing
- After merge, trigger Renovate to verify BookStack image is detected
- Renovate should create PR to update from v24.12.1 to v25.11.4

## Notes
The deprecated `regexManagers` block in `renovate.json5` should be removed in a separate cleanup PR.