### PR TITLE
fix(renovate): fix regex pattern for YAML key:value format

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,18 +27,8 @@
   "kubernetes": {
     "fileMatch": ["kubernetes/.+\\.ya?ml$"]
   },
-  "regexManagers": [
-    {
-      "description": "Process custom dependencies in YAML files",
-      "fileMatch": ["kubernetes/.+\\.ya?ml$"],
-      "matchStrings": [
-        // Match patterns like: # datasource=docker depName=foo\n  tag: 1.2.3
-        "#?\\s*datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.*?\"?(?<currentValue>[^\\s\"]+)\"?"
-      ],
-      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
+  // Note: customManagers are defined in .github/renovate/customManagers.json5
+  // The deprecated regexManagers property was removed - use customManagers instead
   "packageRules": [
     // === Disabled Updates ===
     {

--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -9,7 +9,10 @@
         "(^|/).+\\.ya?ml(\\.j2)?$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.+?\"?(?<currentValue>[^\\s\"]+)\"?"
+        // Matches both "key: value" format and bare value format
+        // Example 1: # renovate: datasource=docker depName=foo/bar\n  tag: v1.2.3
+        // Example 2: # renovate: datasource=docker depName=foo/bar\n  v1.2.3
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n(?:\\s*\\w+:\\s*|\\s*)\"?(?<currentValue>[^\\s\"]+)\"?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"

--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/linuxserver/bookstack
-      # datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
+      # renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
       tag: version-v24.12.1
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
Fixes the customManagers regex pattern that was broken for YAML files using `key: value` format. This enables Renovate to track the BookStack image (and any other images using the annotation pattern).

## Problem
The regex pattern `# renovate: datasource=...depName=...\n.+?"?(?<currentValue>[^\s"]+)"?` was capturing the YAML key name (e.g., `tag:`) instead of the actual version value.

**Root cause:** The non-greedy `.+?` matched minimum characters, then `[^\s"]+` captured until the first whitespace - which was the space between `tag:` and `version-v24.12.1`.

## Solution
Changed the pattern from:
```regex
\n.+?"?(?<currentValue>[^\s"]+)"?
```
To:
```regex
\n(?:\s*\w+:\s*|\s*)"?(?<currentValue>[^\s"]+)"?
```

The alternation `(?:\s*\w+:\s*|\s*)` explicitly handles:
- `\s*\w+:\s*` - YAML key: value format with optional indentation
- `\s*` - bare value format (just whitespace before value)

## Testing
Verified with JavaScript regex (which Renovate uses):
```javascript
// All test cases pass:
// 1. key: value format (BookStack) → captures "version-v24.12.1" ✓
// 2. bare value format → captures "v1.11.3" ✓
// 3. quoted values → captures "v2.0.0" ✓
// 4. complex key names → captures "v1.34.1" ✓
```

## Changes
1. **`.github/renovate/customManagers.json5`** - Fixed regex pattern
2. **`.github/renovate.json5`** - Removed deprecated `regexManagers` block
3. **`kubernetes/apps/media/bookstack/app/helmrelease.yaml`** - Added `# renovate:` prefix to annotation

## Expected Outcome
After merge, Renovate should:
1. Detect `ghcr.io/linuxserver/bookstack` image
2. Create PR to update from `version-v24.12.1` to `version-v25.11.4`
3. No longer show "Config Migration Needed" warning (deprecated regexManagers removed)