### PR TITLE
fix(renovate): use regex versioning for BookStack image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,15 +43,24 @@
       "enabled": false
     },
 
-    // === LinuxServer.io Images (version-v*.* and date-based formats) ===
+    // === LinuxServer.io Images ===
+    // BookStack uses version-v* format (e.g., version-v24.12.1) which requires regex versioning
     {
-      "description": "Loose versioning for LinuxServer.io images",
+      "description": "Regex versioning for BookStack image (version-v prefix)",
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^version-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["ghcr.io/linuxserver/bookstack"]
+    },
+    // Other LinuxServer images may use different formats (date-based, etc.)
+    {
+      "description": "Loose versioning for other LinuxServer.io images",
       "matchDatasources": ["docker"],
       "versioning": "loose",
       "matchPackagePatterns": [
         "lscr.io/linuxserver/.*",
         "ghcr.io/linuxserver/.*"
-      ]
+      ],
+      "excludePackageNames": ["ghcr.io/linuxserver/bookstack"]
     },
 
     // === onedr0p Images (4-segment versioning: major.minor.patch.build) ===

--- a/kubernetes/apps/media/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookstack/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/linuxserver/bookstack
-      # renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack versioning=loose
+      # renovate: datasource=docker depName=ghcr.io/linuxserver/bookstack
       tag: version-v24.12.1
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

Fix Renovate detection of BookStack image updates. The `loose` versioning was not correctly parsing the `version-v24.12.1` format.

**Root cause from Renovate logs:**
```
DEBUG: Dependency ghcr.io/linuxserver/bookstack has unsupported/unversioned value version-v24.12.1 (versioning=loose)
DEBUG: Skipping ghcr.io/linuxserver/bookstack because no currentDigest or pinDigests
```

## Changes

- Add specific packageRule for BookStack with regex versioning pattern
- Pattern extracts semver from version-v prefix: `^version-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$`
- Split LinuxServer.io rule to exclude BookStack (now handled by specific rule)
- Remove redundant `versioning=loose` from inline annotation

## Testing

- [x] Regex pattern validated in JavaScript (matches `version-v24.12.1`)
- [x] Security review passed
- [ ] Verify Renovate creates update PR after merge (v24.12.1 → v25.11.5)

## Notes

Available updates: `version-v25.11.5` (from `version-v24.12.1`)