### PR TITLE
fix(health): fix API /tmp overflow and sidecar token storage

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -294,8 +294,7 @@ spec:
       tmp-api:
         enabled: true
         type: emptyDir
-        medium: Memory
-        sizeLimit: 256Mi
+        sizeLimit: 512Mi
         advancedMounts:
           api:
             app:
@@ -326,6 +325,16 @@ spec:
           sidecar:
             app:
               - path: /tmp
+      # Sidecar writable home for Claude/Codex OAuth token storage
+      # Uses emptyDir (tokens lost on restart) since RWO PVC can't share across nodes
+      sidecar-home:
+        enabled: true
+        type: emptyDir
+        sizeLimit: 64Mi
+        advancedMounts:
+          sidecar:
+            app:
+              - path: /home/sidecar
 
     service:
       api:


### PR DESCRIPTION
## Summary
Fixes two remaining writable-path issues with GlycemicGPT's `readOnlyRootFilesystem` deployment.

## Changes
- **API /tmp**: Switch from memory-backed (256Mi) to disk-backed emptyDir (512Mi). fastembed downloads ~256MB model files to /tmp during startup, which was filling the memory-backed tmpfs completely and causing pod failures.
- **Sidecar home**: Add `sidecar-home` emptyDir (64Mi) at `/home/sidecar` for Claude/Codex OAuth token storage. Uses emptyDir since RWO PVC can't be shared across nodes (sidecar and API pods may schedule on different nodes).

## Testing
- [ ] All 3 pods start with 0 restarts
- [ ] API startup probe passes within 300s (fastembed model download)
- [ ] AI subscription auth works end-to-end
- [ ] WebUI loads and is interactive

## Notes
Tokens stored in sidecar emptyDir will be lost on pod restart — user will need to re-authenticate AI subscription if the sidecar pod restarts.