### PR TITLE
fix(health): allow inline scripts in CSP for Next.js hydration

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/httproute.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/httproute.yaml
@@ -36,6 +36,6 @@ spec:
               - name: Referrer-Policy
                 value: "strict-origin-when-cross-origin"
               - name: Content-Security-Policy
-                value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+                value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
               - name: Permissions-Policy
                 value: "geolocation=(), microphone=(), camera=(), payment=()"


### PR DESCRIPTION
## Summary
Fixes blank/frozen WebUI caused by overly strict Content-Security-Policy header.

## Changes
- Add `'unsafe-inline'` to `script-src` in the WebUI HTTPRoute CSP header
- Previous CSP (`script-src 'self'`) blocked Next.js inline hydration scripts, preventing the page from rendering after SSO redirect

## Root Cause
Next.js 15 uses inline `<script>` blocks for:
- React Server Components payload (`self.__next_f.push`)
- Theme detection (`localStorage.getItem("glycemicgpt-theme")`)
- Polyfill loading

Without `'unsafe-inline'`, browsers block these scripts and the page appears blank/frozen — HTML loads but JavaScript never executes.

## Testing
- [ ] WebUI loads after Authentik SSO
- [ ] Page is interactive (not frozen)
- [ ] Sign In / Create Account buttons work