### PR TITLE
fix(health): increase API /tmp to 2Gi for fastembed model staging

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -294,7 +294,7 @@ spec:
       tmp-api:
         enabled: true
         type: emptyDir
-        sizeLimit: 512Mi
+        sizeLimit: 2Gi
         advancedMounts:
           api:
             app:


### PR DESCRIPTION
## Summary
Fixes API pod eviction caused by EmptyDir volume overflow during embedding model download.

## Changes
- Increase `tmp-api` emptyDir sizeLimit from 512Mi to 2Gi

## Root Cause
fastembed downloads the ONNX model (~256MB compressed) to `/tmp`, extracts it (larger uncompressed), then copies to the embeddings-cache PVC. The intermediate staging in `/tmp` exceeded 512Mi, triggering pod eviction with:
```
Usage of EmptyDir volume "tmp-api" exceeds the limit "512Mi"
```

## Testing
- [ ] API pod starts without eviction
- [ ] Embedding model loads successfully
- [ ] Pod remains stable with 0 restarts