### PR TITLE
fix(health): bump GlycemicGPT images to 0.4.0

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
             image:
               repository: ghcr.io/glycemicgpt/glycemicgpt-api
               # renovate: datasource=docker depName=ghcr.io/glycemicgpt/glycemicgpt-api
-              tag: 0.3.1
+              tag: 0.4.0
             command:
               - /bin/sh
               - -c
@@ -161,7 +161,7 @@ spec:
             image:
               repository: ghcr.io/glycemicgpt/glycemicgpt-web
               # renovate: datasource=docker depName=ghcr.io/glycemicgpt/glycemicgpt-web
-              tag: 0.3.1
+              tag: 0.4.0
             env:
               API_URL: http://glycemicgpt-api:8000
             probes:
@@ -209,7 +209,7 @@ spec:
             image:
               repository: ghcr.io/glycemicgpt/glycemicgpt-sidecar
               # renovate: datasource=docker depName=ghcr.io/glycemicgpt/glycemicgpt-sidecar
-              tag: 0.3.1
+              tag: 0.4.0
             env:
               SIDECAR_API_KEY:
                 valueFrom:


### PR DESCRIPTION
## Summary
Bump all three GlycemicGPT container images from 0.3.1 to 0.4.0.

## Changes
- `glycemicgpt-api`: 0.3.1 → 0.4.0
- `glycemicgpt-web`: 0.3.1 → 0.4.0
- `glycemicgpt-sidecar`: 0.3.1 → 0.4.0

## Key Fix
Includes fix for AI chat 401 error (GlycemicGPT/GlycemicGPT#504) — subscription provider now sends the correct `SIDECAR_API_KEY` as the Bearer token to the sidecar instead of the placeholder `"sidecar-managed"` string.

## Testing
- [ ] All 3 pods start with 0 restarts
- [ ] AI chat works via subscription provider
- [ ] Pump data continues flowing
- [ ] WebUI loads and is interactive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services/Namespaces Affected
- **Namespace**: `health`
- **Services**: GlycemicGPT (3-pod deployment: api, web, sidecar)

## Changes Summary
Container image tags bumped from 0.3.1 to 0.4.0 for all three controllers:
- `ghcr.io/glycemicgpt/glycemicgpt-api`: 0.3.1 → 0.4.0
- `ghcr.io/glycemicgpt/glycemicgpt-web`: 0.3.1 → 0.4.0
- `ghcr.io/glycemicgpt/glycemicgpt-sidecar`: 0.3.1 → 0.4.0

No changes to deployment configuration, environment variables, resource limits/requests, or pod security settings.

## Security Implications
- Fixes AI chat 401 authentication error (resolves upstream issue GlycemicGPT/GlycemicGPT#504) by correcting Bearer token handling to use `SIDECAR_API_KEY` from secrets instead of placeholder value
- All containers maintain strict security posture: readOnlyRootFilesystem enabled, no privilege escalation allowed, all Linux capabilities dropped, runs as non-root user (UID 1000)
- Secrets references unchanged (glycemicgpt-secrets, glycemicgpt-db-app, glycemicgpt-valkey)

## Flux Dependency Impacts
- HelmRelease continues using `app-template` chart v4.4.0 (bjw-s HelmRepository)
- Renovate automation annotations configured on all container images for future updates
- No Flux version changes or helm dependencies modified

## Resource Changes
No resource allocation changes. Existing requests and limits remain:
- **API**: 250m CPU/512Mi memory (requests), 2 CPU/2Gi memory (limits)
- **Web**: 100m CPU/256Mi memory (requests), 1 CPU/1Gi memory (limits)
- **Sidecar**: 50m CPU/128Mi memory (requests), 500m CPU/512Mi memory (limits)

## No Talos, SOPS, or ExternalSecrets Changes
Configuration uses standard Kubernetes secrets without external secret management tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->