### PR TITLE
feat(network): wire glycemicgpt.org zone for Discord bot

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager-config/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager-config/app/clusterissuer.yaml
@@ -15,4 +15,4 @@ spec:
               name: cert-manager-secret
               key: api-token
         selector:
-          dnsZones: ["${SECRET_DOMAIN}"]
+          dnsZones: ["${SECRET_DOMAIN}", "glycemicgpt.org"]

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
     sources: ["crd", "gateway-httproute"]
     txtPrefix: k8s.
     txtOwnerId: default
-    domainFilters: ["${SECRET_DOMAIN}"]
+    domainFilters: ["${SECRET_DOMAIN}", "glycemicgpt.org"]
     serviceMonitor:
       enabled: true
     podAnnotations:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -147,6 +147,20 @@ spec:
                   http2Origin: true
                   originServerName: glycemicgpt.${SECRET_DOMAIN}
 
+              # GlycemicGPT Discord bot (dashboard + OAuth callbacks for /verify)
+              - hostname: "discord.glycemicgpt.org"
+                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                originRequest:
+                  http2Origin: true
+                  originServerName: discord.glycemicgpt.org
+
+              # GlycemicGPT verify vanity URL (302s to discord.glycemicgpt.org/verify)
+              - hostname: "verify.glycemicgpt.org"
+                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                originRequest:
+                  http2Origin: true
+                  originServerName: verify.glycemicgpt.org
+
               # NOTE: Apps NOT routed through Cloudflare tunnel:
               # - Plex (DMZ): UDM SE port forward for high bandwidth streaming
               # - Home Assistant (IoT): Internal-only access via cluster DNS

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -154,7 +154,8 @@ spec:
                   http2Origin: true
                   originServerName: discord.glycemicgpt.org
 
-              # GlycemicGPT verify vanity URL (302s to discord.glycemicgpt.org/verify)
+              # GlycemicGPT verify vanity URL (tunnel entry only; any redirect
+              # to discord.glycemicgpt.org/verify is handled by the app HTTPRoute)
               - hostname: "verify.glycemicgpt.org"
                 service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
                 originRequest:

--- a/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
@@ -81,6 +81,8 @@ spec:
         certificateRefs:
           - kind: Secret
             name: ${SECRET_DOMAIN/./-}-production-tls
+          - kind: Secret
+            name: glycemicgpt-org-production-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -111,6 +113,8 @@ spec:
         certificateRefs:
           - kind: Secret
             name: ${SECRET_DOMAIN/./-}-production-tls
+          - kind: Secret
+            name: glycemicgpt-org-production-tls
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy

--- a/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway-operator/app/certificate.yaml
@@ -10,3 +10,15 @@ spec:
     kind: ClusterIssuer
   commonName: "homelab0.org"
   dnsNames: ["homelab0.org", "*.homelab0.org"]
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "glycemicgpt-org-production"
+spec:
+  secretName: "glycemicgpt-org-production-tls"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "glycemicgpt.org"
+  dnsNames: ["glycemicgpt.org", "*.glycemicgpt.org"]


### PR DESCRIPTION
## Summary

Adds the `glycemicgpt.org` zone to the cluster so we can serve the GlycemicGPT Discord bot dashboard + OAuth callbacks from `discord.glycemicgpt.org` (and a vanity redirect at `verify.glycemicgpt.org`).

- `cloudflare-dns` (external-dns) `domainFilters`: add `glycemicgpt.org`
- `letsencrypt-production` ClusterIssuer `dnsZones`: add `glycemicgpt.org` (same Cloudflare DNS-01 solver; the existing `cert-manager-secret` token must already have access to the zone — done manually)
- Cloudflare tunnel ingress: add entries for `discord.glycemicgpt.org` and `verify.glycemicgpt.org`, both pointing at the existing `envoy-external` gateway in the same way every other tunnel-routed app does

Zero impact on `homelab0.org` — all changes are additive.

## Prereqs already done

- [x] Cloudflare API tokens (`cloudflare-dns-secret`, `cert-manager-secret`) extended to include the `glycemicgpt.org` zone
- [x] `glycemicgpt.org` zone is active on the same Cloudflare account as `homelab0.org`

## Test plan

- [ ] Flux reconciles cleanly (`flux get hr -A`)
- [ ] `kubectl -n network logs -l app.kubernetes.io/name=cloudflare-dns` shows it discovering `glycemicgpt.org`
- [ ] `kubectl -n cert-manager get clusterissuer letsencrypt-production -o jsonpath='{.spec.acme.solvers[0].selector.dnsZones}'` → `["homelab0.org","glycemicgpt.org"]`
- [ ] Cloudflare tunnel pod rolls and picks up the new ingress config
- [ ] DNS lookup for `discord.glycemicgpt.org` returns the tunnel CNAME (after bot HTTPRoute lands in a follow-up PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services/Namespaces Affected
- **cert-manager**: ClusterIssuer (letsencrypt-production) updated to include glycemicgpt.org in DNS-01 solver dnsZones
- **network**: cloudflare-dns and cloudflare-tunnel HelmReleases updated to route traffic for glycemicgpt.org domain

## Breaking Changes
None. Changes are purely additive, expanding existing domain filter and DNS zone configurations alongside existing `${SECRET_DOMAIN}` (homelab0.org) without modifying or removing any existing routes or policies.

## Security Implications
**ExternalSecrets dependency**: Both cert-manager and cloudflare-dns rely on ExternalSecrets pulling Cloudflare API tokens from OnePassword ClusterSecretStore. The PR depends on **manual pre-requisite credential scope expansion** — the `cert-manager-secret` and `cloudflare-dns-secret` Cloudflare API tokens must already have permissions for glycemicgpt.org (completed outside this PR). No new secrets are introduced, but token scoping is a prerequisite condition for successful reconciliation.

## Flux Dependency Impacts
All three modified resources are Flux-managed (one ClusterIssuer and two HelmReleases). The PR objectives note testing requirements: Flux must reconcile cleanly, cloudflare-dns pod logs must confirm glycemicgpt.org discovery, and the ClusterIssuer must reflect both dnsZones in its status. No Flux version, CRD, or dependency file changes required.

## Resource Changes
- **clusterissuer.yaml**: +1/-1 (dnsZones expanded from `["${SECRET_DOMAIN}"]` to `["${SECRET_DOMAIN}", "glycemicgpt.org"]`)
- **cloudflare-dns helmrelease.yaml**: +1/-1 (domainFilters expanded to include glycemicgpt.org)
- **cloudflare-tunnel helmrelease.yaml**: +14/-0 (two new ingress routes added: `discord.glycemicgpt.org` and `verify.glycemicgpt.org` both routing to envoy-external gateway)

All routing targets the existing envoy-external gateway with HTTP/2 origin support, consistent with homelab0.org patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->