### PR TITLE
feat(tools): deploy GlycemicGPT Discord bot

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -57,6 +57,16 @@ jobs:
         uses: renovatebot/github-action@v44.0.2
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Docker registry auth for private GHCR images.
+          # Classic PAT with read:packages scope on the GlycemicGPT org;
+          # used by Renovate's Docker datasource to discover new tags for
+          # ghcr.io/glycemicgpt/* private images. `password` (not `token`)
+          # is required — GHCR's v2 API needs HTTP Basic, and Renovate picks
+          # `token` first when both are set. `hostType: docker` prevents
+          # the auto-provisioned GitHub App rule from shadowing this one.
+          # See: renovatebot/renovate#25134, #29218.
+          RENOVATE_HOST_RULES: >-
+            [{"matchHost":"ghcr.io","hostType":"docker","username":"jlengelbrecht","password":"${{ secrets.GHCR_READ_PAT }}"}]
         with:
           configurationFile: .github/renovate.json5
           token: "${{ steps.app-token.outputs.token }}"

--- a/kubernetes/apps/database/cluster/app/database-glycemicgpt-bot.yaml
+++ b/kubernetes/apps/database/cluster/app/database-glycemicgpt-bot.yaml
@@ -1,0 +1,15 @@
+---
+# GlycemicGPT Discord bot database — declaratively managed on the shared
+# postgres cluster. Owner role is created by the Cluster's managed roles
+# block; this CR just creates the database with that role as owner.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: glycemicgpt-bot
+  namespace: database
+spec:
+  name: glycemicgpt_bot
+  owner: glycemicgpt_bot
+  cluster:
+    name: postgres
+  ensure: present

--- a/kubernetes/apps/database/cluster/app/externalsecret-glycemicgpt-bot.yaml
+++ b/kubernetes/apps/database/cluster/app/externalsecret-glycemicgpt-bot.yaml
@@ -1,0 +1,33 @@
+---
+# Credentials for the glycemicgpt_bot role. Kubernetes basic-auth type so
+# CNPG's declarative role management picks up the password. Same 1Password
+# key the bot-side ExternalSecret pulls from — single source of truth.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: glycemicgpt-bot-db-credentials
+  namespace: database
+  labels:
+    cnpg.io/reload: "true"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: glycemicgpt-bot-db-credentials
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: postgres-cluster
+        property: GLYCEMICGPT_BOT_USER
+    - secretKey: password
+      remoteRef:
+        key: postgres-cluster
+        property: GLYCEMICGPT_BOT_PASSWORD

--- a/kubernetes/apps/database/cluster/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cluster/app/helmrelease.yaml
@@ -76,6 +76,12 @@ spec:
           createdb: false
           passwordSecret:
             name: zabbix-db-credentials
+        - name: glycemicgpt_bot
+          ensure: present
+          login: true
+          createdb: false
+          passwordSecret:
+            name: glycemicgpt-bot-db-credentials
 
     # Backups - disabled until S3 storage is available
     # When MinIO/S3 is ready, enable and configure:

--- a/kubernetes/apps/database/cluster/app/kustomization.yaml
+++ b/kubernetes/apps/database/cluster/app/kustomization.yaml
@@ -12,3 +12,5 @@ resources:
   - externalsecret-toolhive.yaml
   - database-zabbix.yaml
   - externalsecret-zabbix.yaml
+  - database-glycemicgpt-bot.yaml
+  - externalsecret-glycemicgpt-bot.yaml

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/externalsecret.yaml
@@ -1,0 +1,91 @@
+---
+# Runtime env bundle — Discord + GitHub App + Fernet key from 1Password.
+# Field names match the bot's .env.op.tpl contract; rotating a value in the
+# 1Password `glycemicgpt-bot` item rolls into the pod via Stakater Reloader.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: glycemicgpt-bot-secrets
+  namespace: tools
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: glycemicgpt-bot-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DISCORD_BOT_TOKEN
+      remoteRef: { key: glycemicgpt-bot, property: DISCORD_BOT_TOKEN }
+    - secretKey: DISCORD_CLIENT_ID
+      remoteRef: { key: glycemicgpt-bot, property: DISCORD_CLIENT_ID }
+    - secretKey: DISCORD_CLIENT_SECRET
+      remoteRef: { key: glycemicgpt-bot, property: DISCORD_CLIENT_SECRET }
+    - secretKey: GITHUB_APP_ID
+      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_ID }
+    - secretKey: GITHUB_APP_CLIENT_ID
+      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_ID }
+    - secretKey: GITHUB_APP_CLIENT_SECRET
+      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_SECRET }
+    - secretKey: GITHUB_APP_PRIVATE_KEY
+      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_PRIVATE_KEY }
+    - secretKey: GITHUB_APP_INSTALLATION_ID
+      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_INSTALLATION_ID }
+    - secretKey: TOKEN_ENCRYPTION_KEY
+      remoteRef: { key: glycemicgpt-bot, property: TOKEN_ENCRYPTION_KEY }
+---
+# Per-app Postgres role + password pulled from the same 1Password key the
+# CNPG cluster uses to manage the role in `database` namespace. We pull a
+# separate copy here so the bot doesn't need cross-namespace secret access.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: glycemicgpt-bot-db
+  namespace: tools
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: glycemicgpt-bot-db
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef: { key: postgres-cluster, property: GLYCEMICGPT_BOT_USER }
+    - secretKey: password
+      remoteRef: { key: postgres-cluster, property: GLYCEMICGPT_BOT_PASSWORD }
+---
+# GHCR pull secret rendered from a classic PAT stored in 1Password.
+# Template packages `username:password` into a dockerconfigjson blob so
+# containerd can pull the private ghcr.io/glycemicgpt/glycemicgpt-discord-bot
+# image. Rotate by updating the PAT in 1Password — Reloader restarts the
+# pod to pick up the new credential.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: glycemicgpt-bot-ghcr
+  namespace: tools
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: glycemicgpt-bot-ghcr
+    creationPolicy: Owner
+    template:
+      # Pin template engine — v2 is required for the sprig `b64enc` pipe below.
+      # The ESO default was flipped from v1 → v2 in 0.9.x; pin so upgrades
+      # can't silently regress the auth blob.
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}
+  data:
+    - secretKey: username
+      remoteRef: { key: glycemicgpt-bot-ghcr, property: username }
+    - secretKey: password
+      remoteRef: { key: glycemicgpt-bot-ghcr, property: password }

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/externalsecret.yaml
@@ -17,23 +17,23 @@ spec:
     creationPolicy: Owner
   data:
     - secretKey: DISCORD_BOT_TOKEN
-      remoteRef: { key: glycemicgpt-bot, property: DISCORD_BOT_TOKEN }
+      remoteRef: {key: glycemicgpt-bot, property: DISCORD_BOT_TOKEN}
     - secretKey: DISCORD_CLIENT_ID
-      remoteRef: { key: glycemicgpt-bot, property: DISCORD_CLIENT_ID }
+      remoteRef: {key: glycemicgpt-bot, property: DISCORD_CLIENT_ID}
     - secretKey: DISCORD_CLIENT_SECRET
-      remoteRef: { key: glycemicgpt-bot, property: DISCORD_CLIENT_SECRET }
+      remoteRef: {key: glycemicgpt-bot, property: DISCORD_CLIENT_SECRET}
     - secretKey: GITHUB_APP_ID
-      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_ID }
+      remoteRef: {key: glycemicgpt-bot, property: GITHUB_APP_ID}
     - secretKey: GITHUB_APP_CLIENT_ID
-      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_ID }
+      remoteRef: {key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_ID}
     - secretKey: GITHUB_APP_CLIENT_SECRET
-      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_SECRET }
+      remoteRef: {key: glycemicgpt-bot, property: GITHUB_APP_CLIENT_SECRET}
     - secretKey: GITHUB_APP_PRIVATE_KEY
-      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_PRIVATE_KEY }
+      remoteRef: {key: glycemicgpt-bot, property: GITHUB_APP_PRIVATE_KEY}
     - secretKey: GITHUB_APP_INSTALLATION_ID
-      remoteRef: { key: glycemicgpt-bot, property: GITHUB_APP_INSTALLATION_ID }
+      remoteRef: {key: glycemicgpt-bot, property: GITHUB_APP_INSTALLATION_ID}
     - secretKey: TOKEN_ENCRYPTION_KEY
-      remoteRef: { key: glycemicgpt-bot, property: TOKEN_ENCRYPTION_KEY }
+      remoteRef: {key: glycemicgpt-bot, property: TOKEN_ENCRYPTION_KEY}
 ---
 # Per-app Postgres role + password pulled from the same 1Password key the
 # CNPG cluster uses to manage the role in `database` namespace. We pull a
@@ -53,9 +53,9 @@ spec:
     creationPolicy: Owner
   data:
     - secretKey: username
-      remoteRef: { key: postgres-cluster, property: GLYCEMICGPT_BOT_USER }
+      remoteRef: {key: postgres-cluster, property: GLYCEMICGPT_BOT_USER}
     - secretKey: password
-      remoteRef: { key: postgres-cluster, property: GLYCEMICGPT_BOT_PASSWORD }
+      remoteRef: {key: postgres-cluster, property: GLYCEMICGPT_BOT_PASSWORD}
 ---
 # GHCR pull secret rendered from a classic PAT stored in 1Password.
 # Template packages `username:password` into a dockerconfigjson blob so
@@ -76,16 +76,21 @@ spec:
     name: glycemicgpt-bot-ghcr
     creationPolicy: Owner
     template:
-      # Pin template engine — v2 is required for the sprig `b64enc` pipe below.
-      # The ESO default was flipped from v1 → v2 in 0.9.x; pin so upgrades
-      # can't silently regress the auth blob.
+      # Pin template engine — v2 is required for the sprig `b64enc` / `toJson`
+      # pipes below. The ESO default was flipped from v1 → v2 in 0.9.x; pin
+      # so upgrades can't silently regress the auth blob.
       engineVersion: v2
       type: kubernetes.io/dockerconfigjson
       data:
+        # `toJson` wraps its output in double quotes AND JSON-escapes any
+        # special chars in the PAT (quotes, backslashes, newlines). A
+        # credential containing one of those rotates cleanly without
+        # producing an invalid dockerconfigjson → ImagePullBackOff. The
+        # `auth` field is base64 bytes, so no escaping is needed there.
         .dockerconfigjson: |
-          {"auths":{"ghcr.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}
+          {"auths":{"ghcr.io":{"username":{{ .username | toJson }},"password":{{ .password | toJson }},"auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}
   data:
     - secretKey: username
-      remoteRef: { key: glycemicgpt-bot-ghcr, property: username }
+      remoteRef: {key: glycemicgpt-bot-ghcr, property: username}
     - secretKey: password
-      remoteRef: { key: glycemicgpt-bot-ghcr, property: password }
+      remoteRef: {key: glycemicgpt-bot-ghcr, property: password}

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
@@ -116,7 +116,6 @@ spec:
       # file-based features. 2Gi is plenty.
       data:
         enabled: true
-        existingClaim: ""
         type: persistentVolumeClaim
         storageClass: ceph-block
         accessMode: ReadWriteOnce

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
@@ -1,8 +1,10 @@
 ---
 # GlycemicGPT Discord bot — FastAPI + discord.py service.
-# Serves /dashboard (mod cockpit, Authentik-protected), /linked-role/* and
-# /dashboard/oauth/callback (OAuth callbacks, Authentik-exempt), and /verify
-# (Discord Linked Roles entrypoint). Pulls a private image from GHCR.
+# Serves /dashboard (mod cockpit, gated by the bot's own Discord-OAuth
+# session layer — Authentik forward-auth will land in a follow-up PR),
+# /linked-role/* and /dashboard/oauth/callback (Discord/GitHub OAuth
+# callbacks), and /verify (Discord Linked Roles entrypoint).
+# Pulls a private image from GHCR.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
@@ -1,0 +1,130 @@
+---
+# GlycemicGPT Discord bot — FastAPI + discord.py service.
+# Serves /dashboard (mod cockpit, Authentik-protected), /linked-role/* and
+# /dashboard/oauth/callback (OAuth callbacks, Authentik-exempt), and /verify
+# (Discord Linked Roles entrypoint). Pulls a private image from GHCR.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: glycemicgpt-bot
+  namespace: tools
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: glycemicgpt-bot
+  interval: 1h
+  values:
+    controllers:
+      glycemicgpt-bot:
+        strategy: RollingUpdate
+        annotations:
+          # Roll pod when the runtime env bundle or DB creds change.
+          reloader.stakater.com/auto: "true"
+        pod:
+          imagePullSecrets:
+            - name: glycemicgpt-bot-ghcr
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            runAsNonRoot: true
+            fsGroup: 10001
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+        containers:
+          app:
+            image:
+              repository: ghcr.io/glycemicgpt/glycemicgpt-discord-bot
+              # renovate: datasource=docker depName=ghcr.io/glycemicgpt/glycemicgpt-discord-bot
+              tag: v0.20.0
+            env:
+              PUBLIC_BASE_URL: https://discord.glycemicgpt.org
+              DB_HOST: postgres-rw.database.svc.cluster.local
+              DB_PORT: "5432"
+              DB_NAME: glycemicgpt_bot
+              # The bot reads these and assembles DATABASE_URL at startup
+              # (see scripts/entrypoint.sh in the bot repo).
+              DB_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: glycemicgpt-bot-db
+                    key: username
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: glycemicgpt-bot-db
+                    key: password
+            envFrom:
+              - secretRef:
+                  name: glycemicgpt-bot-secrets
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                <<: *probes
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  # Alembic migrations run before the web server binds,
+                  # so startup probe needs slack on first boot.
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        controller: glycemicgpt-bot
+        ports:
+          http:
+            port: *port
+    persistence:
+      # Writable working dir for any runtime-local state. The bot's
+      # persistent data (tickets, moderation log, sessions) all live in
+      # Postgres — this PVC is here for log/tmp spooling and future
+      # file-based features. 2Gi is plenty.
+      data:
+        enabled: true
+        existingClaim: ""
+        type: persistentVolumeClaim
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        globalMounts:
+          - path: /app/data
+      # Scratch tmp because readOnlyRootFilesystem is true.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-oauth.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-oauth.yaml
@@ -1,10 +1,16 @@
 ---
-# OAuth callback routes — NO SecurityPolicy attached.
-# Discord and GitHub redirect browsers to these paths carrying a short-lived
-# auth `code`. Putting Authentik forward-auth in front would strip the code
-# (Authentik redirects unauthenticated requests to its own login page) and
-# break the `/verify` + dashboard login flows. The bot validates the state
-# cookie + HMAC itself, so bypassing Authentik here is safe.
+# Dedicated HTTPRoute for Discord + GitHub OAuth callback paths. Kept
+# separate from the catch-all HTTPRoute so (a) Gateway API's path-match
+# precedence guarantees these paths reach the bot directly, and (b) when
+# the Authentik forward-auth SecurityPolicy lands in the follow-up PR,
+# it'll target only the catch-all route — this one stays unauthenticated
+# so Discord/GitHub can complete redirects with their short-lived `code`.
+# The bot's own state-cookie + HMAC validation gates these endpoints at
+# the application layer.
+#
+# Security headers are duplicated from httproute.yaml because Gateway API
+# filters do not inherit across HTTPRoutes — each route applies only its
+# own filter block. Keep the two lists in sync.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -26,6 +32,20 @@ spec:
       backendRefs:
         - name: glycemicgpt-bot
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: X-Content-Type-Options
+                value: "nosniff"
+              - name: Referrer-Policy
+                value: "strict-origin-when-cross-origin"
+              - name: Permissions-Policy
+                value: "geolocation=(), microphone=(), camera=(), payment=()"
     # /verify flow callbacks — Discord + GitHub both land under /linked-role/*.
     - matches:
         - path:
@@ -34,3 +54,17 @@ spec:
       backendRefs:
         - name: glycemicgpt-bot
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: X-Content-Type-Options
+                value: "nosniff"
+              - name: Referrer-Policy
+                value: "strict-origin-when-cross-origin"
+              - name: Permissions-Policy
+                value: "geolocation=(), microphone=(), camera=(), payment=()"

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-oauth.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-oauth.yaml
@@ -1,0 +1,36 @@
+---
+# OAuth callback routes — NO SecurityPolicy attached.
+# Discord and GitHub redirect browsers to these paths carrying a short-lived
+# auth `code`. Putting Authentik forward-auth in front would strip the code
+# (Authentik redirects unauthenticated requests to its own login page) and
+# break the `/verify` + dashboard login flows. The bot validates the state
+# cookie + HMAC itself, so bypassing Authentik here is safe.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-bot-oauth
+  namespace: tools
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "discord.glycemicgpt.org"
+  rules:
+    # Dashboard login callback — Discord OAuth returns to /dashboard/oauth/callback.
+    - matches:
+        - path:
+            type: Exact
+            value: /dashboard/oauth/callback
+      backendRefs:
+        - name: glycemicgpt-bot
+          port: 8080
+    # /verify flow callbacks — Discord + GitHub both land under /linked-role/*.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /linked-role/
+      backendRefs:
+        - name: glycemicgpt-bot
+          port: 8080

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-verify-vanity.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/httproute-verify-vanity.yaml
@@ -1,0 +1,33 @@
+---
+# Vanity URL: verify.glycemicgpt.org → 302 discord.glycemicgpt.org/verify.
+# Entire hostname is a pure redirect — no backendRefs. Nothing ever hits the
+# bot on this host. Keeps external comms terse ("visit verify.glycemicgpt.org")
+# while the actual OAuth callbacks live on the single canonical host.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-bot-verify-vanity
+  namespace: tools
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: verify.glycemicgpt.org
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "verify.glycemicgpt.org"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: discord.glycemicgpt.org
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /verify
+            statusCode: 302

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/httproute.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/httproute.yaml
@@ -1,0 +1,43 @@
+---
+# Catch-all HTTPRoute for the bot dashboard. The bot's own Discord-OAuth
+# session layer gates access to dashboard routes internally; Authentik
+# forward-auth will be layered on in a follow-up PR once the Discord-role
+# policy gate is properly architected.
+# More-specific OAuth routes live in httproute-oauth.yaml and win by
+# Gateway API longest-prefix-match.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-bot
+  namespace: tools
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: discord.glycemicgpt.org
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "discord.glycemicgpt.org"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: glycemicgpt-bot
+          port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: X-Content-Type-Options
+                value: "nosniff"
+              - name: Referrer-Policy
+                value: "strict-origin-when-cross-origin"
+              - name: Permissions-Policy
+                value: "geolocation=(), microphone=(), camera=(), payment=()"

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/kustomization.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocirepository.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - httproute-oauth.yaml
+  - httproute-verify-vanity.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/networkpolicy.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/networkpolicy.yaml
@@ -1,0 +1,60 @@
+---
+# Default-deny egress + ingress, allow only what the bot actually needs:
+# - ingress from envoy-external (only the gateway reaches the pod)
+# - egress to postgres (database ns)
+# - egress to kube-dns and to the Kubernetes API (discord.py needs no API access,
+#   but Flux/cogs may reach cluster API in future cogs — omit for now)
+# - egress to world:443 for Discord gateway, GitHub/Discord OAuth token endpoints,
+#   GHCR pulls (though pulls happen at node level, not pod)
+# NOTE: Authentik ext_authz egress will be re-added in the Authentik forward-auth
+# follow-up PR.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: glycemicgpt-bot
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glycemicgpt-bot
+
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            gateway.envoyproxy.io/owning-gateway-name: envoy-external
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+  egress:
+    # DNS
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+
+    # Postgres (shared CNPG cluster)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: database
+            cnpg.io/cluster: postgres
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+
+    # Outbound 443 for Discord gateway, GitHub/Discord OAuth APIs
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: glycemicgpt-bot
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  # renovate: datasource=docker depName=ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/glycemicgpt-bot/ks.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/ks.yaml
@@ -10,8 +10,8 @@ spec:
       namespace: flux-system
     - name: postgres-cluster
       namespace: flux-system
-    - name: authentik
-      namespace: flux-system
+    # NOTE: no authentik dep — option-a posture ships without forward-auth.
+    # Re-add this dependency in the Authentik-gate follow-up PR.
   interval: 1h
   path: ./kubernetes/apps/tools/glycemicgpt-bot/app
   prune: true

--- a/kubernetes/apps/tools/glycemicgpt-bot/ks.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: glycemicgpt-bot
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: flux-system
+    - name: postgres-cluster
+      namespace: flux-system
+    - name: authentik
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/tools/glycemicgpt-bot/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./homepage/ks.yaml
   - ./n8n/storage/ks.yaml
   - ./n8n/ks.yaml
+  - ./glycemicgpt-bot/ks.yaml


### PR DESCRIPTION
## Summary

Deploys the GlycemicGPT Discord bot (`ghcr.io/glycemicgpt/glycemicgpt-discord-bot:v0.12.0`) to the \`tools\` namespace. Serves the mod dashboard and the \`/verify\` OAuth callbacks at **discord.glycemicgpt.org**, with a vanity redirect at **verify.glycemicgpt.org → /verify**.

Stacks on top of PR #1106 (glycemicgpt.org zone wiring, already merged).

### What lives where

| Path | Auth posture | Backs |
|---|---|---|
| \`/\` (dashboard) | Authentik forward-auth | bot service |
| \`/linked-role/*\` | **bypasses Authentik** | bot service |
| \`/dashboard/oauth/callback\` | **bypasses Authentik** | bot service |
| \`/outpost.goauthentik.io/*\` | — | authentik-server (cross-ns) |
| verify.glycemicgpt.org | — | 302 → discord.glycemicgpt.org/verify |

The OAuth routes have to bypass forward-auth or Discord/GitHub's auth codes get eaten by Authentik's login redirect.

### Security posture

- Container runs as uid/gid **10001**, \`runAsNonRoot=true\`, \`readOnlyRootFilesystem=true\`, all caps dropped.
- \`CiliumNetworkPolicy\` locks ingress to envoy-external only; egress restricted to DNS + Postgres + Authentik + world:443 (Discord gateway, OAuth token endpoints).
- Private image pulled via a **classic PAT** stored in 1Password, rendered as a \`dockerconfigjson\` Secret by External Secrets Operator (not committed to git, not on any node's disk).
- All other secrets (Discord bot token, GitHub App private key, Fernet encryption key) pulled from the existing \`glycemicgpt-bot\` 1Password item via ESO. Stakater Reloader restarts the pod on rotation.

### Database

Adds a new managed role \`glycemicgpt_bot\` and a \`Database\` CR on the **existing shared** \`database/cluster\` CNPG cluster (same pattern as toolhive/zabbix). No new CNPG cluster, no schema-level blast radius with other apps.

### Prereqs the user must have in place

- [x] PR #1106 merged (glycemicgpt.org zone, certs, tunnel entries)
- [ ] 1Password item \`glycemicgpt-bot\` in vault \`automation\` with fields: \`DISCORD_BOT_TOKEN\`, \`DISCORD_CLIENT_ID\`, \`DISCORD_CLIENT_SECRET\`, \`GITHUB_APP_ID\`, \`GITHUB_APP_CLIENT_ID\`, \`GITHUB_APP_CLIENT_SECRET\`, \`GITHUB_APP_PRIVATE_KEY\`, \`GITHUB_APP_INSTALLATION_ID\`, \`TOKEN_ENCRYPTION_KEY\`
- [ ] 1Password item \`glycemicgpt-bot-ghcr\` with fields \`username\` + \`password\` (the GHCR read:packages PAT)
- [ ] 1Password item \`postgres-cluster\` (existing) extended with fields \`GLYCEMICGPT_BOT_USER\` + \`GLYCEMICGPT_BOT_PASSWORD\`
- [ ] Discord Developer Portal → OAuth2 → Redirects:
  - \`https://discord.glycemicgpt.org/linked-role/discord/callback\`
  - \`https://discord.glycemicgpt.org/dashboard/oauth/callback\`
- [ ] GitHub App \`glycemicgpt-verify\` → Callback URL: \`https://discord.glycemicgpt.org/linked-role/github/callback\`

### Test plan

- [ ] Flux reconciles: \`flux get ks -A\` shows \`glycemicgpt-bot\` Ready
- [ ] ExternalSecrets Synced: \`kubectl -n tools get externalsecret\` → all three Ready
- [ ] Database ready: \`kubectl -n database get database glycemicgpt-bot -o jsonpath='{.status.applied}'\` → \`true\`
- [ ] Pod pulls + starts: \`kubectl -n tools get pods -l app.kubernetes.io/name=glycemicgpt-bot\`
- [ ] Startup probe passes (alembic migrations succeed)
- [ ] \`curl -I https://discord.glycemicgpt.org/healthz\` → 200 (or 302 to Authentik if bypass rule misbehaves — then adjust)
- [ ] Discord \`/verify\` → full OAuth roundtrip succeeds
- [ ] Dashboard loads at https://discord.glycemicgpt.org/dashboard/ → Authentik login → Discord OAuth → tiers visible

### Rollback

- App-only issue: \`flux suspend ks glycemicgpt-bot -n flux-system\`, pin previous image tag, resume
- Schema issue: alembic is forward-only; DB survives pod replacement. Restore from CNPG backup if needed
- Full abort: revert this PR. Flux prunes HelmRelease + routes + secrets. The \`Database\` CR and managed role remain (dropping them may destroy data); delete manually later if desired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services & Namespaces Affected

- **Namespace**: `tools` (primary) and `database` (secondary)
- **Service**: GlycemicGPT Discord bot (v0.20.0, image: `ghcr.io/glycemicgpt/glycemicgpt-discord-bot:v0.20.0`)
- **DNS/Hostnames**: `discord.glycemicgpt.org` (main service), `verify.glycemicgpt.org` (vanity redirect to `/verify`)
- **Shared Resources**: Existing PostgreSQL CNPG cluster in `database` namespace

## Breaking Changes

None. This is an initial deployment; the force-push updated the image tag from v0.12.0 to v0.20.0 to include intervening releases and avoid feature regressions (team-join admin UI, claimable-gate flow). Authentik forward-auth integration (originally planned) was deferred and removed from this PR; the bot retains its own Discord-OAuth session layer for internal dashboard access control.

## Security Implications

- **Container Hardening**: Runs as non-root (UID/GID 10001), `readOnlyRootFilesystem: true`, dropped all Linux capabilities, `seccomp: RuntimeDefault`, no privilege escalation.
- **ExternalSecrets (prominent)**: Three `ExternalSecret` resources pull sensitive data from 1Password `ClusterSecretStore` (`onepassword-connect`):
  - `glycemicgpt-bot-secrets`: Discord token, GitHub App credentials, encryption key
  - `glycemicgpt-bot-db`: PostgreSQL user/password (managed role `glycemicgpt_bot`)
  - `glycemicgpt-bot-ghcr`: Private GHCR image pull credentials (classic PAT, template engine pinned to v2 for stability)
- **Stakater Reloader**: Monitors secret changes and restarts pods on rotation.
- **CiliumNetworkPolicy**: Restrictive ingress (TCP 8080 from `envoy-external` in `network` namespace only) and egress (DNS, Postgres cluster, Authentik-capable DNS lookup, world:443 for Discord/OAuth).

## Flux Dependency Impacts

New `Kustomization` in `kubernetes/apps/tools/glycemicgpt-bot/ks.yaml` (`flux-system` namespace) declares explicit dependencies:
- `external-secrets-operator` (required for secret materialization)
- `postgres-cluster` (required for CNPG Database CR and managed role)
- `authentik` (required for future auth integration; currently only DNS egress used)

Reconciliation interval: 1 hour, pruning enabled, wait disabled. Added to top-level `kubernetes/apps/tools/kustomization.yaml`.

## Resource Changes

**Database Layer** (`database` namespace):
- CNPG `Database` CR: `glycemicgpt-bot` (database name: `glycemicgpt_bot`)
- Managed role `glycemicgpt_bot` added to CNPG HelmRelease (`spec.values.roles`)
- `ExternalSecret` (`glycemicgpt-bot-db-credentials`) with CNPG reload signaling labels

**Application Layer** (`tools` namespace):
- Flux `HelmRelease`: Chart `oci://ghcr.io/bjw-s-labs/helm/app-template:4.4.0`
- OCIRepository (polling interval 15m)
- Three `ExternalSecret` resources (1h refresh)
- Three `HTTPRoute` resources:
  - `glycemicgpt-bot`: catch-all `/` on `discord.glycemicgpt.org` with security response headers
  - `glycemicgpt-bot-oauth`: OAuth callback and linked-role routes on `discord.glycemicgpt.org`
  - `glycemicgpt-bot-verify-vanity`: vanity domain redirect (302) from `verify.glycemicgpt.org` → `discord.glycemicgpt.org/verify`
- `CiliumNetworkPolicy`: intra-cluster only except outbound DNS, Postgres, and HTTPS

**CI/CD** (GitHub Actions):
- `renovate.yaml`: Added `RENOVATE_HOST_RULES` for private GHCR authentication (`ghcr.io`, `hostType: docker`, secret: `GHCR_READ_PAT`)

**Storage**:
- PVC (2Gi `ceph-block` RWO) mounted at `/app/data`
- `emptyDir` scratch volume at `/tmp`

## Notable Configuration Decisions

- **Authentik Gateway** integration (SecurityPolicy, forward-auth) is **deferred to follow-up PR**; Authentik still listed as dependency (for future DNS egress and gateway configuration).
- **No CPU limit** on HelmRelease (intentional; acknowledged during review).
- **ExternalSecrets template engine pinned to v2** for `dockerconfigjson` to protect sprig `b64enc` function from future ESO default changes.
- **Stakater Reloader** enabled via annotation to trigger pod rollouts on secret mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->