### PR TITLE
feat(network): expose Authentik on authentik.glycemicgpt.org for GlycemicGPT brand

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -119,6 +119,14 @@ spec:
                   http2Origin: true
                   originServerName: authentik.${SECRET_DOMAIN}
 
+              # Authentik on glycemicgpt.org (same backend; Host header triggers
+              # the glycemicgpt-branded flow/logo via Authentik brand matching)
+              - hostname: "authentik.glycemicgpt.org"
+                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                originRequest:
+                  http2Origin: true
+                  originServerName: authentik.glycemicgpt.org
+
               # Media Status (Uptime Kuma public status page)
               - hostname: "media-status.${SECRET_DOMAIN}"
                 service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443

--- a/kubernetes/apps/security/authentik/app/httproute-external.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute-external.yaml
@@ -11,6 +11,7 @@ spec:
       sectionName: https
   hostnames:
     - authentik.homelab0.org
+    - authentik.glycemicgpt.org
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

- Route `authentik.glycemicgpt.org` through the existing Cloudflare tunnel → envoy-external → authentik-server backend (same pod that already serves `authentik.homelab0.org`).
- Authentik's Host-suffix brand matcher picks the new `glycemicgpt.org` brand (Title=GlycemicGPT + custom logo, already configured via webui) for requests on the new hostname. Requests on `authentik.homelab0.org` keep falling through to `authentik-default` — zero change in behavior there.
- Enables branded SSO for the GlycemicGPT Discord bot dashboard once it lands in the cluster.

## Why it's safe (pre-flight)

- **Additive only** — 9 inserted lines, nothing removed or modified. The existing `authentik.${SECRET_DOMAIN}` tunnel rule and HTTPRoute hostname are untouched.
- **TLS** — `glycemicgpt-org-production-tls` wildcard cert already covers `*.glycemicgpt.org` and is attached to the `envoy-external` Gateway's `:443` listener (see `kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml:85`).
- **DNS** — `cloudflare-dns/app/helmrelease.yaml:31` lists `glycemicgpt.org` in `domainFilters`, so external-dns will auto-create the CNAME for the new hostname from the HTTPRoute.
- **Cookies** — `AUTHENTIK_COOKIE_DOMAIN` is unset in the Authentik helmrelease, so session cookies scope to the request host. Sessions on `authentik.homelab0.org` and `authentik.glycemicgpt.org` don't cross-contaminate.
- **No collisions** — `grep -r "authentik.glycemicgpt"` across the repo confirms nothing else claims this hostname.
- Pattern mirrors existing `discord.glycemicgpt.org` / `verify.glycemicgpt.org` entries in the same tunnel file, which are already in production.

## Intentionally *not* changed

- `httproute-internal.yaml` — internal (LAN) access stays on homelab0 only.
- Authentik Helm values — no env var changes needed.
- `cluster-secrets.sops.yaml` — no SOPS re-encrypt; literal matches the existing glycemicgpt-domain convention in this repo.

## Test plan

- [ ] Flux reconciles both Kustomizations (`kubernetes/apps/network/cloudflare-tunnel`, `kubernetes/apps/security/authentik`) cleanly
- [ ] `cloudflared` pod rolls out with the new tunnel config (Stakater reloader handles this via the auto-reload annotation already present)
- [ ] external-dns creates the CNAME `authentik.glycemicgpt.org` → `external.homelab0.org`
- [ ] `curl -vk https://authentik.glycemicgpt.org/-/health/live/` returns 204 via the Authentik backend (SNI + cert verify pass with the `*.glycemicgpt.org` cert)
- [ ] Browser visit to `https://authentik.glycemicgpt.org/if/admin/` shows the Authentik admin UI with the GlycemicGPT brand (Title "GlycemicGPT", custom logo) — confirming the brand matcher is firing on the new Host
- [ ] `https://authentik.homelab0.org/` still renders the Homelab.0 brand — no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services and Namespaces Affected

- **network/cloudflare-tunnel**: HelmRelease updated to add new tunnel ingress route
- **security/authentik**: HTTPRoute modified to accept traffic for new hostname
- **Existing authentik-server backend** (security namespace): No changes; serves both hostnames via same pod

## Breaking Changes

None. This is a purely additive change. The existing `authentik.homelab0.org` endpoint and internal LAN HTTPRoute remain unchanged.

## Security Implications

- **Session isolation**: Session cookies are scoped to the request host (AUTHENTIK_COOKIE_DOMAIN unset), preventing cross-host contamination
- **TLS coverage**: Existing wildcard certificate `glycemicgpt-org-production-tls` (*.glycemicgpt.org) covers the new hostname
- **No credential changes**: Helm values, cluster secrets, and authentication backends remain unchanged
- **Brand segregation**: Authentik uses Host-suffix matcher to serve GlycemicGPT brand on `authentik.glycemicgpt.org` and Homelab.0 brand on `authentik.homelab0.org`

Note: **Talos, SOPS, and ExternalSecrets are not affected by these changes.**

## Flux Dependency Impacts

- **Two Kustomizations require reconciliation**: cloudflare-tunnel and authentik app
- **cloudflared pod reload** needed to load new tunnel configuration
- **external-dns** will automatically create CNAME for `authentik.glycemicgpt.org` (already configured with glycemicgpt.org in domainFilters)

## Resource Changes

| File | Changes | Details |
|------|---------|---------|
| `kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml` | +8/-0 | New Cloudflare tunnel ingress route to `authentik.glycemicgpt.org` → `envoy-external` with `http2Origin: true` and matching originServerName |
| `kubernetes/apps/security/authentik/app/httproute-external.yaml` | +1/-0 | Added `authentik.glycemicgpt.org` hostname to HTTPRoute spec |

All other routing, backend references, and response header modifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->