### PR TITLE
feat(tools): wire ConfigMap mount for glycemicgpt-bot config.yml

### DIFF
--- a/kubernetes/apps/tools/glycemicgpt-bot/app/configmap.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/configmap.yaml
@@ -4,6 +4,10 @@
 # bot repo). Anything secret (tokens, PATs, Fernet keys, DB creds) comes
 # from the ExternalSecrets instead — keep this file free of credentials.
 #
+# Source-of-truth lives in the bot repo at config/config.yml; this is the
+# deployed copy. Keep the two in sync when the schema (YamlConfig class in
+# the bot's config.py) changes.
+#
 # Stakater Reloader rolls the pod when this ConfigMap changes.
 apiVersion: v1
 kind: ConfigMap
@@ -12,13 +16,167 @@ metadata:
   namespace: tools
 data:
   config.yml: |
-    # TODO: populate from the bot repo's config schema.
-    # Fields the bot expects at minimum — update once you've confirmed
-    # against glycemicgpt_bot/config.py:
-    #
-    # discord:
-    #   guild_id: <your-server-id>
-    #   mod_role_ids: []
-    # features:
-    #   tickets: true
-    #   moderation: true
+    # GlycemicGPT Bot Config
+    # Non-sensitive tunables. Secrets live in env vars (ExternalSecrets).
+
+    Guild:
+      # The live GlycemicGPT server ID — keep this as a string to avoid YAML int overflow.
+      ID: "1492605462728806482"
+      # Owners / admins who can bypass protections entirely.
+      # Populate with Discord user IDs. Consider moving to env if disclosure concerns grow.
+      OwnerOverrideIDs: []
+
+    ModLog:
+      # Channel name in Discord (resolved at startup) — not an ID.
+      ChannelName: "mod-log"
+
+    # ---------------------------------------------------------------------------
+    # Protection modules
+    # ---------------------------------------------------------------------------
+
+    AntiNuke:
+      Enabled: true
+      # User IDs whose destructive actions are never counted. Role-based
+      # bypass is driven by the ``protection.bypass`` capability — assign
+      # it to any permission role from the Permissions admin page.
+      WhitelistedUserIDs: []
+      Default:
+        Tiers:
+          Tier1:
+            Protection:
+              duration: "10m"        # rolling window for counters
+              kickThreshold: 3
+              banThreshold: 3
+              channelDeleteThreshold: 2
+              roleDeleteThreshold: 2
+            Actions:
+              notifyUserIDs: []      # populate with owner discord IDs
+              removeRole: true       # strip ManageGuild roles from the offender
+              mute: true             # 10-minute timeout
+              ban: false
+            Log:
+              Title: "Anti-Nuke Tier 1"
+              Color: "#FFA500"
+          Tier2:
+            Protection:
+              duration: "10m"
+              kickThreshold: 5
+              banThreshold: 5
+              channelDeleteThreshold: 4
+              roleDeleteThreshold: 4
+            Actions:
+              notifyUserIDs: []
+              removeRole: true
+              mute: true
+              ban: true
+            Log:
+              Title: "Anti-Nuke Tier 2"
+              Color: "#E74C3C"
+
+    AntiSpam:
+      Enabled: true
+      MsgLimit: 5
+      TimeWindowSeconds: 5
+      TimeoutSeconds: 600
+      # Role bypass → ``protection.bypass`` capability (Permissions admin).
+      WhitelistedChannelNames: []
+      DMUser: true
+      DMMessage: "You were muted for {seconds}s for spamming in {guild}. Please slow down."
+
+    AntiMassMention:
+      Enabled: true
+      Threshold: 5                   # > this many user mentions in one message → trigger
+      TimeoutSeconds: 600
+      # Role bypass → ``protection.bypass`` capability.
+      DMUser: true
+      DMMessage: "You were muted for {seconds}s for mass-mentioning in {guild}."
+
+    AntiHoist:
+      Enabled: true
+      EnableOnUserJoin: true
+      EnableOnUserUpdate: true
+      DisallowedLeadingChars: "!\"#$%&'()*+,-./"
+      DefaultDisplayName: "Member"
+      # Role bypass → ``protection.bypass`` capability.
+
+    AntiRaid:
+      Enabled: true
+      MinAccountAgeDays: 7           # kick accounts younger than this
+      Kick: true
+      DMUser: true
+      DMMessage: |
+        Sorry, GlycemicGPT requires Discord accounts at least {days} days old to join.
+        Your account was created {created_at}. Please try again later.
+
+    ContentFilter:
+      Enabled: true
+      Blacklist:
+        # Patterns: literal strings, wildcard (*), or regex (prefix with "regex:").
+        Patterns:
+          - "regex:(?i)\\bcashapp\\s+me\\b"
+          - "regex:(?i)\\bfree\\s+nitro\\b"
+        Whitelist: []
+      AntiInvite:
+        Enabled: true
+        # Allow invites to these specific guild IDs (empty = no exceptions).
+        AllowedGuildIDs: []
+      # Role bypass → ``protection.bypass`` capability.
+      BypassChannelNames: []
+
+    Welcome:
+      Enabled: true
+      DMTemplate: |
+        **Welcome to GlycemicGPT!**
+
+        We're an open-source, self-hosted diabetes management platform. Some quick links:
+
+        - Website: https://glycemicgpt.org
+        - GitHub: https://github.com/GlycemicGPT/GlycemicGPT
+        - Need help? Open a ticket in #get-help
+
+        If you're a contributor to any GlycemicGPT repo, run `/verify` in any channel
+        to link your GitHub and get your **Contributor** / **Maintainer** / **Sponsor** role.
+
+    # ---------------------------------------------------------------------------
+    # GitHub Linked Roles (Phase 2)
+    # ---------------------------------------------------------------------------
+
+    LinkedRoles:
+      Enabled: true
+      GitHubOrg: "GlycemicGPT"
+      CoreContributorPRs: 5
+      RefreshIntervalHours: 24
+      # Optional: restrict maintainer check to specific repos.
+      # If omitted, ALL repos in the org are considered.
+      # MaintainerRepos: ["GlycemicGPT/GlycemicGPT"]
+
+    # ---------------------------------------------------------------------------
+    # Web dashboard — access is driven by the RBAC tables populated by the
+    # onboarding wizard (see the Permissions admin page). No role-name YAML.
+    # ---------------------------------------------------------------------------
+
+    Dashboard:
+      Enabled: true
+      SessionTTLHours: 24
+
+    # ---------------------------------------------------------------------------
+    # Slash commands
+    # ---------------------------------------------------------------------------
+
+    Commands:
+      Docs:
+        URL: "https://glycemicgpt.org"
+      Quickstart:
+        URL: "https://github.com/GlycemicGPT/GlycemicGPT#getting-started"
+      GitHub:
+        URL: "https://github.com/GlycemicGPT"
+      # /issue <number> pulls from this repo by default (users can be given an override).
+      IssueDefaultRepo: "GlycemicGPT/GlycemicGPT"
+
+    Tickets:
+      Enabled: true
+      OpenCategoryName: "Tickets"
+      ArchiveCategoryName: "Archived Tickets"
+      # Staff membership is resolved via the ``tickets.handle`` capability.
+      AutoDeleteAfterHours: 0
+      ChannelNameTemplate: "ticket-{number:04d}-{username}"

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/configmap.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/configmap.yaml
@@ -1,0 +1,24 @@
+---
+# Non-secret runtime config for the Discord bot. The bot loads this from
+# /app/config/config.yml at startup (see glycemicgpt_bot/config.py in the
+# bot repo). Anything secret (tokens, PATs, Fernet keys, DB creds) comes
+# from the ExternalSecrets instead — keep this file free of credentials.
+#
+# Stakater Reloader rolls the pod when this ConfigMap changes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glycemicgpt-bot-config
+  namespace: tools
+data:
+  config.yml: |
+    # TODO: populate from the bot repo's config schema.
+    # Fields the bot expects at minimum — update once you've confirmed
+    # against glycemicgpt_bot/config.py:
+    #
+    # discord:
+    #   guild_id: <your-server-id>
+    #   mod_role_ids: []
+    # features:
+    #   tickets: true
+    #   moderation: true

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
@@ -117,6 +117,18 @@ spec:
           http:
             port: *port
     persistence:
+      # Non-secret runtime config. Mounted as a single file via subPath so
+      # the container's /app/config/ dir stays writable for any sibling
+      # files the bot may create. Reloader rolls the pod when the
+      # ConfigMap changes.
+      config:
+        enabled: true
+        type: configMap
+        name: glycemicgpt-bot-config
+        globalMounts:
+          - path: /app/config/config.yml
+            subPath: config.yml
+            readOnly: true
       # Writable working dir for any runtime-local state. The bot's
       # persistent data (tickets, moderation log, sessions) all live in
       # Postgres — this PVC is here for log/tmp spooling and future

--- a/kubernetes/apps/tools/glycemicgpt-bot/app/kustomization.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ocirepository.yaml
   - externalsecret.yaml
+  - configmap.yaml
   - helmrelease.yaml
   - httproute.yaml
   - httproute-oauth.yaml


### PR DESCRIPTION
## Summary
Bot pod crashes on startup with \`FileNotFoundError: Config file not found at config/config.yml\`. Add the ConfigMap + mount wiring so the app can find its runtime config.

## Changes
- **\`configmap.yaml\`** (new): ConfigMap \`glycemicgpt-bot-config\` with a single \`config.yml\` key. Ships with placeholder TODO comments only — fill in the real schema after merge.
- **\`helmrelease.yaml\`**: new \`persistence.config\` entry, type \`configMap\`, mounts at \`/app/config/config.yml\` via \`subPath\`, \`readOnly: true\`.
- **\`kustomization.yaml\`**: registers the new file.

## Notes
- No secrets in the ConfigMap — those keep flowing through the three ExternalSecrets (\`glycemicgpt-bot-secrets\`, \`glycemicgpt-bot-db\`, \`glycemicgpt-bot-ghcr\`).
- Reloader is already on the Deployment, so editing the ConfigMap rolls the pod automatically.
- Mount is \`readOnly\`. The rest of \`/app/config/\` remains writable because \`subPath\` projects only the single file.

## After merge
You'll need to edit the ConfigMap \`data.config.yml\` with the real config from the bot's \`config.py\` schema. Either commit it here (if non-secret) or edit via \`kubectl\` if you want it out-of-repo.

## Testing Plan
- [ ] Flux reconciles HelmRelease
- [ ] Pod mounts \`/app/config/config.yml\` (check: \`kubectl exec ... -- cat /app/config/config.yml\`)
- [ ] Populate config.yml → Reloader rolls pod → bot connects to Discord gateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services/Namespaces Affected
- **Namespace:** `tools`
- **Service:** `glycemicgpt-bot` Discord bot deployment

## Resource Changes
- **New ConfigMap:** `glycemicgpt-bot-config` in `tools` namespace containing a single `config.yml` data key with placeholder bot runtime configuration
- **HelmRelease Update:** Added `persistence.config` volume mount sourcing from the ConfigMap, mounting `/app/config/config.yml` as read-only via `subPath: config.yml`; remainder of `/app/config/` directory remains writable
- **Kustomization Update:** Added `configmap.yaml` to resources list

## Breaking Changes
None. The ConfigMap mount is read-only for `config.yml` while permitting runtime writes to sibling files in `/app/config/`. Existing three **ExternalSecrets** (`glycemicgpt-bot-secrets`, `glycemicgpt-bot-db`, `glycemicgpt-bot-ghcr`) remain unchanged and continue to provide secret data.

## Security Implications
Minimal. No secrets are stored in the new ConfigMap—all sensitive data continues to be sourced from **ExternalSecrets**. The mounted `config.yml` is read-only, preventing accidental pod-side mutation. Non-secret bot runtime configuration is now externalized, improving separation of concerns between config and secrets.

## Flux Dependency Impacts
**HelmRelease** `glycemicgpt-bot` must be reconciled for Flux to recognize the new ConfigMap volume mount. The existing Reloader will automatically trigger pod rollout on ConfigMap edits. Post-merge, the ConfigMap's `data.config.yml` must be populated with actual bot configuration (either committed if non-secret or edited via `kubectl`); until then, the bot will read the placeholder content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->