### PR TITLE
fix(tools): use Recreate strategy for glycemicgpt-bot

### DIFF
--- a/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml
@@ -18,7 +18,13 @@ spec:
   values:
     controllers:
       glycemicgpt-bot:
-        strategy: RollingUpdate
+        # Single replica backed by a ReadWriteOnce Ceph RBD volume. A
+        # RollingUpdate schedules the new pod before terminating the old,
+        # which deadlocks at FailedAttachVolume whenever the two land on
+        # different nodes (force-detach is ~6min). Recreate tears down
+        # the old pod first, yielding a short (~30s) downtime window per
+        # deploy but eliminating the Multi-Attach stall.
+        strategy: Recreate
         annotations:
           # Roll pod when the runtime env bundle or DB creds change.
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
Switch the glycemicgpt-bot Deployment from `RollingUpdate` to `Recreate` to eliminate the Multi-Attach deadlock that stalls every image update.

## Problem
Single-replica Deployment, storage backed by a ReadWriteOnce Ceph RBD PVC. RollingUpdate schedules the new pod before terminating the old; when the scheduler picks a different node for the new pod, the volume can't detach in time and the rollout stalls:

```
Warning  FailedAttachVolume  Multi-Attach error for volume "pvc-2959af17..."
         Volume is already used by pod(s) glycemicgpt-bot-7f757688fd-pqxjx
```

Kubernetes' default force-detach timer is ~6 min, so every Renovate bump (e.g. #1113, #1114) sits in `ContainerCreating` for several minutes before self-healing.

## Fix
`strategy: Recreate` tears down the old pod first, releasing the RBD lock, then starts the new one. Small downtime window (~30 s) per rollout, zero Multi-Attach stalls.

## Changes
- `kubernetes/apps/tools/glycemicgpt-bot/app/helmrelease.yaml`: flip `strategy` + add a comment explaining the rationale

## Testing Plan
- [ ] Flux reconciles after merge
- [ ] Next Renovate image bump (or a forced rollout) terminates the old pod first and the new pod attaches the PVC cleanly
- [ ] Downtime stays within expected ~30 s

## Security Review
- [x] security-guardian approval received
- [x] No secrets touched; only controller rollout semantics changed
- [x] No network, image, or secret fields modified

## Notes
Follow-up from observed Multi-Attach stalls on PR #1113 and PR #1114 rollouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services & Namespaces Affected
- **Namespace**: `tools` (restricted pod-security policy enforced)
- **Service**: `glycemicgpt-bot` – Discord bot providing FastAPI endpoints for authentication, moderation dashboards, and Discord/GitHub OAuth callbacks
- **Flux Dependencies**: Depends on `external-secrets-operator` and `postgres-cluster` (database namespace)

## Deployment Strategy Change
Changes HelmRelease spec from `RollingUpdate` to `Recreate` strategy. This introduces approximately 30-second downtime during pod updates but eliminates Multi-Attach deadlocks that occur when a new pod is scheduled on a different node before the old pod terminates (affecting the single-replica deployment's ReadWriteOnce Ceph RBD PVC). Previously, force-detach timers (~6 minutes) would block reconciliation.

## Breaking Changes
Deployments will now incur brief planned downtime (~30 seconds) during rollouts. This is intentional and resolves the observed stalling behavior from Renovate image bumps (PRs #1113, #1114).

## Security Implications
No security impact:
- ExternalSecrets configuration unchanged; Discord bot tokens, GitHub App credentials, and database passwords continue to be pulled from 1Password via ExternalSecrets operator
- Pod security context and RBAC posture remain hardened (non-root, read-only root filesystem, automountServiceAccountToken disabled, seccomp enforced)
- No modifications to network policies, image references, or secret handling

## Flux Dependency Impacts
- HelmRelease strategy change applies only to rollout semantics; no impact on chart fetch intervals (1h), dependency ordering, or kustomization wait behavior
- Kustomization dependency chain (`flux-system` → `external-secrets-operator`, `postgres-cluster`) unaffected

## Resource Changes
- PVC configuration unchanged: 2Gi ReadWriteOnce Ceph RBD volume mounted at `/app/data`
- Service, pod security context, container resource limits, and probe configurations remain unchanged
- Only alteration: `spec.values.controllers.glycemicgpt-bot.strategy: Recreate` with inline documentation of the ReadWriteOnce attach behavior rationale

## ExternalSecrets Usage
Two ExternalSecrets resources manage credentials from 1Password:
- `glycemicgpt-bot-secrets`: Discord and GitHub App credentials, Fernet encryption key
- `glycemicgpt-bot-db`: Per-app Postgres role and password (mirrored from cluster management key)
- 1h refresh interval; Stakater Reloader auto-rolls pods on credential rotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->