### PR TITLE
fix(glycemicgpt): enable Dexcom server-side sync

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -19,9 +19,9 @@ spec:
     controllers:
       # FastAPI backend - core API server
       api:
-        # Singleton: the in-process APScheduler runs the Dexcom Share poll
+        # Singleton: the in-process APScheduler runs the Dexcom poll
         # and Tandem Cloud Upload jobs. Multiple replicas would duplicate
-        # polls (DB unique constraint absorbs duplicates, but Dexcom Share
+        # polls (DB unique constraint absorbs duplicates, but Dexcom
         # rate-limits would not). Pin to 1 alongside the Recreate strategy.
         replicas: 1
         strategy: Recreate
@@ -89,7 +89,7 @@ spec:
               SESSION_EXPIRE_HOURS: "24"
               ACCESS_TOKEN_EXPIRE_MINUTES: "60"
               REFRESH_TOKEN_EXPIRE_DAYS: "30"
-              # Data sync - Dexcom Share polling runs server-side; Tandem pump events
+              # Data sync - Dexcom polling runs server-side; Tandem pump events
               # are uploaded by the mobile client via /api/integrations/pump/push,
               # so server-side Tandem sync stays off to avoid racing the mobile uploader.
               DEXCOM_SYNC_ENABLED: "true"

--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -84,8 +84,10 @@ spec:
               SESSION_EXPIRE_HOURS: "24"
               ACCESS_TOKEN_EXPIRE_MINUTES: "60"
               REFRESH_TOKEN_EXPIRE_DAYS: "30"
-              # Data sync (disabled by default - configure device credentials first)
-              DEXCOM_SYNC_ENABLED: "false"
+              # Data sync - Dexcom Share polling runs server-side; Tandem pump events
+              # are uploaded by the mobile client via /api/integrations/pump/push,
+              # so server-side Tandem sync stays off to avoid racing the mobile uploader.
+              DEXCOM_SYNC_ENABLED: "true"
               TANDEM_SYNC_ENABLED: "false"
               # Alerts
               ALERT_CHECK_ENABLED: "true"

--- a/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
     controllers:
       # FastAPI backend - core API server
       api:
+        # Singleton: the in-process APScheduler runs the Dexcom Share poll
+        # and Tandem Cloud Upload jobs. Multiple replicas would duplicate
+        # polls (DB unique constraint absorbs duplicates, but Dexcom Share
+        # rate-limits would not). Pin to 1 alongside the Recreate strategy.
+        replicas: 1
         strategy: Recreate
         containers:
           app:


### PR DESCRIPTION
## Summary
Flip `DEXCOM_SYNC_ENABLED` from `"false"` to `"true"` in the GlycemicGPT API HelmRelease so the APScheduler Dexcom Share poll registers at startup.

## Problem
- Dashboard at `glycemicgpt.${SECRET_DOMAIN}` shows `?` for glucose and "No glucose readings yet", while IOB/basal/battery/reservoir populate normally.
- DB inspection: `glucose_readings` has 0 rows; `pump_events` has 85,968 rows. Pump data flows via the mobile uploader hitting `/api/integrations/pump/push`; CGM data has no mobile push path and depends on the server-side Dexcom Share poll.
- `integration_credentials` already has `dexcom: connected` for the user, but `last_sync_at` is `NULL`.
- API logs show APScheduler running `Alert Escalation Check`, `Tandem Cloud Upload`, and `Predictive Alert Check`, but no Dexcom sync job — that job is gated on `DEXCOM_SYNC_ENABLED=true` at app startup.

## Changes
- `kubernetes/apps/health/glycemicgpt/app/helmrelease.yaml`: set `DEXCOM_SYNC_ENABLED: "true"` and update the inline comment to document why Tandem stays off (mobile client already uploads pump events; server-side Tandem sync would race that path).

## Testing
- [ ] Flux reconciles the HelmRelease and the `api` controller restarts (Recreate strategy).
- [ ] On startup, API logs show a new APScheduler job registered for Dexcom Share.
- [ ] Within one poll interval, `glucose_readings` row count increases for the connected user.
- [ ] Dashboard renders a current glucose value and Glucose Trend populates.

## Notes
- No secrets touched. Dexcom Share credentials remain encrypted in `integration_credentials`.
- `TANDEM_SYNC_ENABLED` deliberately stays `"false"`.
- security-guardian review: approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services & Namespaces Affected
- **Namespace**: health
- **Service**: glycemicgpt (API controller specifically)
- **Related services**: PostgreSQL (glycemicgpt-db-rw), Valkey cache (cross-namespace), LiteLLM sidecar for AI providers

## Configuration Changes
- **DEXCOM_SYNC_ENABLED**: Changed from `"false"` to `"true"` in API container environment
- **Comment updated** to clarify that Dexcom Share polling runs server-side via APScheduler, while Tandem pump events are handled exclusively by mobile client via `/api/integrations/pump/push` (keeping TANDEM_SYNC_ENABLED disabled to avoid concurrent upload/race conditions)

## Breaking Changes
None. This enables a previously disabled scheduler job without altering existing functionality.

## Security Implications
None. No credential changes or secrets modified. Dexcom credentials remain encrypted in `integration_credentials` table and injected via ExternalSecrets (glycemicgpt-secrets). The change only activates server-side polling of already-connected Dexcom credentials.

## Flux Dependency Impacts
- **HelmRelease**: Flux will reconcile the helmrelease and trigger API controller restart via Recreate strategy
- **Chart**: app-template v4.4.0 (bjw-s repository)
- **Reconcile interval**: 1h
- Pod annotations include `secret.reloader.stakater.com/reload` for glycemicgpt-secrets, enabling dynamic secret updates without manual restart

## Resource Changes
No changes to CPU/memory requests or limits.

## Testing Validation Criteria
- Flux successfully reconciles HelmRelease; API pod restarts
- APScheduler logs show Dexcom Share job registered on startup
- glucose_readings table populates within first poll interval
- Dashboard glucose value and trend visualization functional

<!-- end of auto-generated comment: release notes by coderabbit.ai -->