### PR TITLE
fix(talos): sync talenv to v1.12.4 and migrate admission patch to strategic merge

### DIFF
--- a/talos/patches/controller/admission-controller-patch.yaml
+++ b/talos/patches/controller/admission-controller-patch.yaml
@@ -1,2 +1,25 @@
-- op: remove
-  path: /cluster/apiServer/admissionControl
+# Disable PodSecurity admission enforcement (cluster-wide permissive).
+# Rationale: privileged workloads (rook-ceph, multus, tetragon, nvidia device
+# plugin) require host access. Previously done via JSON6902 `op: remove`, but
+# talhelper v3 rejects JSON6902 on multi-document machine configs
+# ("JSON6902 patches are not supported for multi-document machine configuration").
+# Strategic-merge `enforce: privileged` is the supported equivalent and matches
+# the live cluster behavior (controllers currently run with no admissionControl).
+cluster:
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+          kind: PodSecurityConfiguration
+          defaults:
+            enforce: privileged
+            enforce-version: latest
+            audit: privileged
+            audit-version: latest
+            warn: privileged
+            warn-version: latest
+          exemptions:
+            namespaces: []
+            runtimeClasses: []
+            usernames: []

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.11.6
+talosVersion: v1.12.4
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.34.1


### PR DESCRIPTION
## Summary
The cluster runs Talos **v1.12.4** on all 15 nodes (verified via `kubectl get nodes` and `talosctl get members`), but `talos/talenv.yaml` was still pinned to **v1.11.6**. Since `talenv.yaml` is the source `talhelper genconfig` reads, every generated machine config referenced the stale 1.11.6 installer — a version source split-brain with `terraform/variables.tf`, which is already at 1.12.4.

This PR makes the repo match reality. It changes **no running node** (the cluster is already on 1.12.4).

## Changes
- `talos/talenv.yaml`: `talosVersion` `v1.11.6` → `v1.12.4` (`kubernetesVersion` unchanged at `v1.34.1`).
- `talos/patches/controller/admission-controller-patch.yaml`: convert the `admissionControl` JSON6902 `op: remove` to a strategic-merge PodSecurity block.
  - **Why:** talhelper v3 rejects JSON6902 on multi-document machine configs (`"JSON6902 patches are not supported for multi-document machine configuration"`), so `talhelper genconfig` fails outright on the old patch at 1.12.4.
  - The replacement sets `enforce/audit/warn: privileged`, which is the supported equivalent and **preserves the live cluster's existing permissive behavior** (live controllers have no `admissionControl` enforcement). This permissiveness is required by privileged workloads: rook-ceph, multus, tetragon, and the nvidia device plugin.

## Verification
- `talhelper genconfig` succeeds at v1.12.4 (fails on the old JSON6902 patch).
- Generated controller config resolves to `enforce: privileged` (matches live: all 3 controllers have zero `admissionControl` blocks).
- `grep -rn "path: /etc" talos/clusterconfig/` reviewed; GPU schematic still scoped to work-4/work-10 only.
- security-guardian: approved (no secrets/IPs; `clusterconfig/` PKI and `age.key` not staged).

## Notes
- Follow-ups (out of scope, tracked under EPIC-033): a deliberate PodSecurity hardening story (move privileged namespaces to exemptions, raise default to `baseline`), and updating the PSA config `v1alpha1` → `v1`.
- Relates to **EPIC-033 / STORY-033-1**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services/Namespaces Affected

**Talos Control Plane & Workload Clusters:**
- **Controller nodes**: All 15 nodes (already running Talos v1.12.4 in live cluster; talenv.yaml now matches)
- **Privileged workloads requiring host access**: rook-ceph, multus, tetragon, nvidia device plugin (work-4, work-10 GPU nodes)
- **API Server admission pipeline**: PodSecurity controller configuration

## Breaking Changes

**talhelper v3 Incompatibility (resolved):**
- Previous JSON6902 `remove` patch on `cluster.apiServer.admissionControl` is incompatible with talhelper v3 for multi-document machine configs ("JSON6902 patches are not supported for multi-document machine configuration")
- Migrated to strategic-merge PodSecurityConfiguration, which is the supported equivalent
- talhelper genconfig now succeeds with v1.12.4 (fails with old JSON6902 patch)

**Generated Machine Configs:**
- Installer references will update from v1.11.6 → v1.12.4
- PodSecurity admission enforcement now explicitly configured via strategic-merge instead of implicit removal

## Security Implications

**PodSecurity Policy - Cluster-Wide Permissive:**
- All three PodSecurity enforcement modes (`enforce`, `audit`, `warn`) set to `privileged` with `version: latest`
- Disables PodSecurity admission enforcement cluster-wide—matches live controller behavior (no admissionControl blocks currently present)
- **Rationale**: Required for privileged workloads (rook-ceph, multus, tetragon, nvidia device plugin) that demand host access
- **Future remediation tracked**: EPIC-033 covers PodSecurity hardening (exemptions for privileged namespaces, raise default to `baseline`), PSA config version upgrade (v1alpha1 → v1)

## Flux Dependency Impacts

**talhelper Dependency:**
- talhelper v3+ required (v2 would reject this patch structure)
- Generated controller/worker machine configuration files will be regenerated with v1.12.4 references
- Kustomization/reconciliation of generated configs should trigger automatically on talhelper genconfig run

**No SOPS/ExternalSecrets Changes:**
- talsecret.sops.yaml unchanged
- PKI and age.key not included in verification scope

## Resource Changes

**Admission Controller Configuration:**
- Replaces deprecated JSON6902 remove operation with explicit PodSecurityConfiguration resource
- New structure includes:
  - `enforce: privileged` / `enforce-version: latest`
  - `audit: privileged` / `audit-version: latest`
  - `warn: privileged` / `warn-version: latest`
  - Empty exemptions arrays (no namespaces/runtimes/users whitelisted)
- **Net effect**: Same runtime behavior (no admission enforcement) with v1.12.4/talhelper v3 compatibility

**Talos Version Alignment:**
- talenv.yaml: `talosVersion` bumped v1.11.6 → v1.12.4 (kubernetesVersion v1.34.1 unchanged)
- Aligns source-of-truth (talenv.yaml) with live cluster state and terraform/variables.tf (already at v1.12.4)
- No running nodes restarted by this PR (configs are generated, not applied)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->