### PR TITLE
fix(ci): correct GPU validation false-failures in Talos upgrade workflows

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2864,7 +2864,7 @@ jobs:
 
       - name: Validate GPU functionality
         if: matrix.is_gpu == true
-        timeout-minutes: 8
+        timeout-minutes: 9
         run: |
           echo "::group::Validating GPU for ${{ matrix.node }}"
 
@@ -2872,7 +2872,7 @@ jobs:
           # Increased timeout for GPU nodes that may have longer initialization
           echo "Waiting for NVIDIA device plugin to register GPU..."
           RETRY_COUNT=0
-          MAX_RETRIES=36  # 36 * 10s = 6 minutes
+          MAX_RETRIES=42  # 42 * 10s = 7 minutes (GPU nodes boot ~5 min)
 
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
             if kubectl get nodes ${{ matrix.node }} -o jsonpath='{.status.allocatable}' | grep -q "nvidia.com/gpu"; then
@@ -2903,12 +2903,14 @@ jobs:
             exit 1
           fi
 
-          # Verify GPU count
+          # Verify GPU count. Time-slicing advertises multiple virtual GPUs per
+          # physical card (e.g. 3), so accept any positive count rather than
+          # requiring exactly 1.
           GPU_COUNT=$(kubectl get nodes ${{ matrix.node }} -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
-          echo "GPU count: $GPU_COUNT"
+          echo "Allocatable nvidia.com/gpu: ${GPU_COUNT:-0}"
 
-          if [[ "$GPU_COUNT" != "1" ]]; then
-            echo "::error::Expected 1 GPU, found $GPU_COUNT"
+          if [[ -z "$GPU_COUNT" || "$GPU_COUNT" -lt 1 ]]; then
+            echo "::error::GPU advertised but allocatable count is not positive ($GPU_COUNT)"
             exit 1
           fi
 

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -993,7 +993,11 @@ jobs:
           # on the node and the GPU label is set, the OS upgrade itself succeeded, so
           # warn rather than failing the whole upgrade over a slow device plugin.
           echo "::warning::nvidia.com/gpu not allocatable after $((MAX_RETRIES * 10))s; checking node-level NVIDIA state..."
-          EXT_PRESENT=$(talosctl -n ${{ matrix.node.ip }} get extensions -o json 2>/dev/null | grep -ci nvidia || echo 0)
+          # grep -c prints the count but exits 1 on zero matches; `|| true`
+          # swallows that exit without appending a second value (using `|| echo 0`
+          # would produce "0\n0" and break the numeric comparison below).
+          EXT_PRESENT=$(talosctl -n ${{ matrix.node.ip }} get extensions -o json 2>/dev/null | grep -ci nvidia || true)
+          EXT_PRESENT="${EXT_PRESENT:-0}"
           LABEL_PRESENT=$(kubectl get node ${{ matrix.node.name }} -o jsonpath='{.metadata.labels.nvidia\.com/gpu\.present}' 2>/dev/null || echo "")
           echo "NVIDIA extensions present: $EXT_PRESENT | gpu.present label: ${LABEL_PRESENT:-<none>}"
           kubectl get pods -n nvidia-device-plugin -o wide 2>/dev/null | grep "${{ matrix.node.name }}" || echo "no device-plugin pod on node yet"

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -952,18 +952,21 @@ jobs:
 
       - name: GPU validation (GPU nodes only)
         if: matrix.node.is_gpu == true
-        timeout-minutes: 3
+        timeout-minutes: 9
         run: |
           echo "::group::Validating GPU for ${{ matrix.node.name }}"
 
-          # Wait for NVIDIA device plugin to detect GPU
-          echo "Waiting for NVIDIA device plugin..."
+          # GPU nodes take ~5 min to boot (NVIDIA driver load) before the device
+          # plugin can advertise nvidia.com/gpu, so allow up to 7 minutes here.
+          echo "Waiting for NVIDIA device plugin to advertise GPU..."
           RETRY_COUNT=0
-          MAX_RETRIES=18
+          MAX_RETRIES=42  # 42 * 10s = 7 minutes
 
+          GPU_DETECTED=false
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
             if kubectl get nodes ${{ matrix.node.name }} -o jsonpath='{.status.allocatable}' | grep -q "nvidia.com/gpu"; then
-              echo "✅ GPU detected by Kubernetes"
+              echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s"
+              GPU_DETECTED=true
               break
             fi
             echo "Waiting for GPU detection (attempt $((RETRY_COUNT+1))/$MAX_RETRIES)..."
@@ -971,22 +974,38 @@ jobs:
             RETRY_COUNT=$((RETRY_COUNT+1))
           done
 
-          if [[ $RETRY_COUNT -eq $MAX_RETRIES ]]; then
-            echo "::error::GPU not detected after $MAX_RETRIES attempts"
-            exit 1
+          if [[ "$GPU_DETECTED" == "true" ]]; then
+            # Time-slicing advertises multiple virtual GPUs per physical card
+            # (e.g. 3), so accept any positive count rather than requiring exactly 1.
+            GPU_COUNT=$(kubectl get nodes ${{ matrix.node.name }} -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+            echo "Allocatable nvidia.com/gpu: ${GPU_COUNT:-0}"
+            if [[ -z "$GPU_COUNT" || "$GPU_COUNT" -lt 1 ]]; then
+              echo "::error::GPU advertised but allocatable count is not positive ($GPU_COUNT)"
+              exit 1
+            fi
+            echo "✅ GPU validation passed (${GPU_COUNT} schedulable GPU(s))"
+            echo "::endgroup::"
+            exit 0
           fi
 
-          # Verify GPU count
-          GPU_COUNT=$(kubectl get nodes ${{ matrix.node.name }} -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
-          echo "GPU count: $GPU_COUNT"
+          # Device plugin has not advertised the GPU yet. Distinguish a genuine GPU
+          # failure from device-plugin lag: if the NVIDIA system extension is present
+          # on the node and the GPU label is set, the OS upgrade itself succeeded, so
+          # warn rather than failing the whole upgrade over a slow device plugin.
+          echo "::warning::nvidia.com/gpu not allocatable after $((MAX_RETRIES * 10))s; checking node-level NVIDIA state..."
+          EXT_PRESENT=$(talosctl -n ${{ matrix.node.ip }} get extensions -o json 2>/dev/null | grep -ci nvidia || echo 0)
+          LABEL_PRESENT=$(kubectl get node ${{ matrix.node.name }} -o jsonpath='{.metadata.labels.nvidia\.com/gpu\.present}' 2>/dev/null || echo "")
+          echo "NVIDIA extensions present: $EXT_PRESENT | gpu.present label: ${LABEL_PRESENT:-<none>}"
+          kubectl get pods -n nvidia-device-plugin -o wide 2>/dev/null | grep "${{ matrix.node.name }}" || echo "no device-plugin pod on node yet"
 
-          if [[ "$GPU_COUNT" != "1" ]]; then
-            echo "::error::Expected 1 GPU, found $GPU_COUNT"
-            exit 1
+          if [[ "$EXT_PRESENT" -ge 1 && "$LABEL_PRESENT" == "true" ]]; then
+            echo "::warning::NVIDIA extension present and node labeled; device plugin lagging. Upgrade succeeded — flagging for follow-up, not failing the upgrade."
+            echo "::endgroup::"
+            exit 0
           fi
 
-          echo "✅ GPU validation passed"
-          echo "::endgroup::"
+          echo "::error::GPU not detected and NVIDIA extension/label missing on ${{ matrix.node.name }} — genuine GPU failure"
+          exit 1
 
       - name: Upgrade summary
         if: always()


### PR DESCRIPTION
## Summary
The "GPU validation" step in the Talos upgrade workflows reported **failure even when the upgrade succeeded**. This is what marked the last real automatic Talos upgrade (PR #1067 → v1.12.4) as failed: every node upgraded in place to v1.12.4, but the run went red solely because GPU validation on work-4/work-10 timed out. The false failures undermine confidence in the automation and break the auto-merge feedback loop.

## Root causes (two bugs)
1. **Timeout too short.** `upgrade-pets.yaml` waited `18 × 10s = 3 min` for the NVIDIA device plugin to advertise `nvidia.com/gpu`, but GPU nodes take **~5 min** to boot (NVIDIA driver load). The 3-min budget was structurally impossible to satisfy.
2. **Wrong count assertion.** Both workflows required *exactly* 1 GPU (`GPU_COUNT != 1`), but GPU **time-slicing** advertises **3** virtual GPUs per physical card (live `nvidia.com/gpu=3` on both work-4 and work-10). So the check would fail even with a correct timeout.

## Changes
- **pets + cattle:** raise device-plugin detection budget to 7 min (`MAX_RETRIES` 18/36 → 42) and bump step `timeout-minutes` to 9.
- **pets + cattle:** accept any positive allocatable `nvidia.com/gpu` count instead of requiring exactly 1.
- **pets:** add a fallback — if the device plugin still hasn't advertised the GPU but the NVIDIA system extension (`talosctl get extensions`) **and** the `nvidia.com/gpu.present` label are present, the OS upgrade itself succeeded, so emit a `::warning::` instead of failing the whole upgrade. A genuinely missing extension/label still hard-fails.
- Cattle's existing label check and `nvidia-smi` pod test are unchanged.

## Verification
- Both workflows parse as valid YAML.
- Live cluster confirms `nvidia.com/gpu=3` (time-slicing), validating the count-check fix.
- security-guardian: approved — changes confined to GPU validation; matrix values are static in-workflow node names/IPs (no injection); **all 2025-11-21 VM-destruction safety gates untouched**; shell error-handling correct.

## Notes
- Does not modify the running cluster; effective on the next upgrade run.
- Relates to **EPIC-033 / STORY-033-2**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Services/Namespaces Affected

**Talos Linux**: Both upgrade workflows (cattle and pets) target Talos OS upgrade operations. The cattle workflow (destructive rebuild) and pets workflow (in-place patch) both execute on a Talos-based Kubernetes cluster.

**NVIDIA Device Plugin** (`nvidia-device-plugin` namespace): GPU validation logic has been substantially reworked in both workflows to accommodate longer NVIDIA device plugin startup times (~5-7 minutes post-boot for driver initialization).

**Kubernetes Core**: Changes affect node upgrade sequencing and GPU resource validation across control plane and worker nodes.

## Breaking Changes

**GPU Count Validation**: Both workflows change from requiring `nvidia.com/gpu` allocatable count to equal exactly `1` to accepting any positive value (`>= 1`). This accommodates NVIDIA's time-slicing feature which advertises multiple virtual GPUs per physical card (e.g., 3 GPUs from a single physical device). The old validation would have hard-failed on time-sliced configurations.

**Timeout Extensions**:
- Pets workflow: GPU validation step timeout increased from ~3 minutes to ~7 minutes (MAX_RETRIES: 36→42)
- Cattle workflow: GPU validation step timeout-minutes increased 8→9 minutes
- These changes affect the critical path for GPU node upgrades but do not affect non-GPU nodes

**Pets Workflow Fallback Logic**: When GPU is not allocatable after the extended wait period, pets workflow now performs intelligent triage:
- **Warning (non-fatal)**: If NVIDIA system extension and `nvidia.com/gpu.present` label both exist, emit warning and proceed (interprets as device-plugin lag, not GPU failure)
- **Hard failure**: If extension/label are absent, fail the upgrade (genuine GPU detection failure)
- This prevents false upgrade failures due to slow device plugin initialization

Cattle workflow maintains its existing GPU validation approach without the fallback; it requires both device-plugin advertisement and label presence.

## Security Implications

**None**. All changes are workflow step logic modifications. No changes to:
- SOPS encryption handling
- ExternalSecrets integration
- Secret management
- Authentication/authorization boundaries

Terraform state lock safety gates and VM destruction safeguards remain unchanged. Flux GitOps validation steps persist in cattle workflow.

## Flux Dependency Impacts

**No breaking changes**. Cattle workflow includes pre-upgrade Flux validation checks that verify `GitRepository` and core `Kustomization` resources (cluster-apps, external-secrets-operator, 1password-connect) are reconciling. These checks are unchanged by this PR and do not impact Flux deployment or configuration.

## Resource Changes

**GPU Resource Allocatable Count**: Kubernetes node allocatable `nvidia.com/gpu` is now validated with a range check (`>= 1`) instead of an equality check (`== 1`). Live cluster validation confirms nodes advertise `nvidia.com/gpu: 3` under time-slicing, which now validates correctly.

No changes to:
- Flux resources (GitRepository, Kustomization, HelmRelease)
- SOPS file encryption requirements
- ExternalSecrets configuration
- Talos machine configuration schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->