### PR TITLE
fix(talos): remove redundant nvidia /etc drop-in and fix admission patch (upgrade prep)

### DIFF
--- a/talos/patches/controller/admission-controller-patch.yaml
+++ b/talos/patches/controller/admission-controller-patch.yaml
@@ -1,2 +1,25 @@
-- op: remove
-  path: /cluster/apiServer/admissionControl
+# Disable PodSecurity admission enforcement (cluster-wide permissive).
+# Rationale: privileged workloads (rook-ceph, multus, tetragon, nvidia device
+# plugin) require host access. Previously done via JSON6902 `op: remove`, but
+# talhelper v3 rejects JSON6902 on multi-document machine configs
+# ("JSON6902 patches are not supported for multi-document machine configuration").
+# Strategic-merge `enforce: privileged` is the supported equivalent and matches
+# the live cluster behavior (controllers currently run with no admissionControl).
+cluster:
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+          kind: PodSecurityConfiguration
+          defaults:
+            enforce: privileged
+            enforce-version: latest
+            audit: privileged
+            audit-version: latest
+            warn: privileged
+            warn-version: latest
+          exemptions:
+            namespaces: []
+            runtimeClasses: []
+            usernames: []

--- a/talos/patches/k8s-work-10/nvidia-gpu.yaml
+++ b/talos/patches/k8s-work-10/nvidia-gpu.yaml
@@ -7,22 +7,12 @@ machine:
       - name: nvidia_modeset
   sysctls:
     net.core.bpf_jit_harden: "1"  # NVIDIA GPU requirement
-  files:
-    - content: |
-        [plugins]
-          [plugins."io.containerd.cri.v1.runtime"]
-            [plugins."io.containerd.cri.v1.runtime".containerd]
-              [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
-                [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
-                  privileged_without_host_devices = false
-                  runtime_engine = ""
-                  runtime_root = ""
-                  runtime_type = "io.containerd.runc.v2"
-
-                  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
-                    BinaryName = "/usr/local/bin/nvidia-container-runtime"
-      path: /etc/cri/conf.d/20-customization.part
-      op: create
+  # No machine.files drop-in for the nvidia containerd runtime: the
+  # nvidia-container-toolkit system extension already registers it via
+  # /etc/cri/conf.d/10-nvidia-container-runtime.part (verified on work-4/work-10 —
+  # the active cri.toml sources the nvidia runtime from that extension file). A
+  # manual /etc/cri drop-in is redundant, and writing under /etc fails the
+  # writeUserFiles task on a fresh cattle cold boot (Talos 1.11+ read-only fs).
   nodeLabels:
     nvidia.com/gpu.present: "true"
     gpu.nvidia.com/model: "rtx-a5000"

--- a/talos/patches/k8s-work-4/nvidia-gpu.yaml
+++ b/talos/patches/k8s-work-4/nvidia-gpu.yaml
@@ -7,22 +7,12 @@ machine:
       - name: nvidia_modeset
   sysctls:
     net.core.bpf_jit_harden: "1"  # NVIDIA GPU requirement
-  files:
-    - content: |
-        [plugins]
-          [plugins."io.containerd.cri.v1.runtime"]
-            [plugins."io.containerd.cri.v1.runtime".containerd]
-              [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
-                [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
-                  privileged_without_host_devices = false
-                  runtime_engine = ""
-                  runtime_root = ""
-                  runtime_type = "io.containerd.runc.v2"
-
-                  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
-                    BinaryName = "/usr/local/bin/nvidia-container-runtime"
-      path: /etc/cri/conf.d/20-customization.part
-      op: create
+  # No machine.files drop-in for the nvidia containerd runtime: the
+  # nvidia-container-toolkit system extension already registers it via
+  # /etc/cri/conf.d/10-nvidia-container-runtime.part (verified on work-4/work-10 —
+  # the active cri.toml sources the nvidia runtime from that extension file). A
+  # manual /etc/cri drop-in is redundant, and writing under /etc fails the
+  # writeUserFiles task on a fresh cattle cold boot (Talos 1.11+ read-only fs).
   nodeLabels:
     nvidia.com/gpu.present: "true"
     gpu.nvidia.com/model: "rtx-a2000"


### PR DESCRIPTION
## Summary
Preparation for the upcoming Talos **v1.13.3** cattle (destructive rebuild) upgrade. Two patch fixes that are **safe no-ops on running nodes** (clusterconfig is gitignored and regenerated) but required for a clean cattle rebuild.

## Changes
### 1. Remove redundant nvidia `/etc/cri` drop-in (k8s-work-4, k8s-work-10)
Removed the `machine.files` block that wrote `/etc/cri/conf.d/20-customization.part`.

**Verified redundant** on both live GPU nodes: the `nvidia-container-toolkit` system extension (v570.211.01) already registers the nvidia containerd runtime via its own `/etc/cri/conf.d/10-nvidia-container-runtime.part`, and the active merged `cri.toml` sources the nvidia runtime from *that* extension file — not from our manual drop-in.

**Why it matters for cattle:** writing under `/etc` fails the `writeUserFiles` task on a *fresh cold boot* in Talos 1.11+ (read-only fs) — the failure mode behind the 2025-11-19 incident. Live nodes survived only because they were pets-upgraded (`--preserve`, no fresh `writeUserFiles`). Removing the redundant drop-in eliminates that cold-boot risk while the extension keeps GPUs working. Kernel modules, sysctl, and GPU `nodeLabels` are retained.

### 2. Fix admission patch for talhelper v3 (controller)
Convert the `admissionControl` JSON6902 `op: remove` to a strategic-merge PodSecurity block (`enforce/audit/warn: privileged`). talhelper v3 **rejects JSON6902 on multi-document configs** (`talhelper genconfig` fails outright otherwise). The replacement preserves the live cluster's existing permissive behavior, required by privileged workloads (rook-ceph, multus, tetragon, nvidia device plugin).

## Verification
- `talhelper genconfig` succeeds (fails on the old JSON6902 patch).
- `grep -r "path: /etc" talos/clusterconfig/` → clean (no machine.files writing under `/etc`).
- work-4/work-10 generated configs retain nvidia kernel modules + `nvidia.com/gpu.present` label.
- security-guardian: approved — no secrets; `clusterconfig/`/`age.key` not staged; removal drops a *redundant duplicate*, not a security control; admission change preserves posture.

## Notes
- All v1.13.3 upgrade prerequisites are now met (cattle hardened #1127, GPU validation #1126, Ceph HEALTH_OK, nvidia question resolved).
- Next: a `test_templates` cattle dry-run at v1.13.3, then the version-bump trigger PR.
- Follow-ups (separate stories): dedicated PodSecurity hardening; PSA `v1alpha1`→`v1`.
- Relates to **EPIC-033 / STORY-033-4**.