### PR TITLE
fix(ci): raise cattle template-rebuild step timeout to 45m

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -564,7 +564,10 @@ jobs:
 
       - name: Execute template rebuild
         working-directory: ./terraform
-        timeout-minutes: 20
+        # 8 templates rebuilt in 4 batches; each uploads an ~866M raw image to a
+        # Proxmox host and imports it into Ceph. Observed >20 min in practice
+        # (run 26735551452 timed out), so allow generous headroom.
+        timeout-minutes: 45
         env:
           TF_VAR_proxmox_username: ${{ secrets.PROXMOX_USERNAME }}
           TF_VAR_proxmox_password: ${{ secrets.PROXMOX_PASSWORD }}


### PR DESCRIPTION
## Summary
The v1.13.3 `test_templates` dry-run ([run 26735551452](https://github.com/jlengelbrecht/prox-ops/actions/runs/26735551452)) timed out: the **"Execute template rebuild"** step had `timeout-minutes: 20`, but rebuilding all 8 templates exceeds that in practice.

Each template uploads an **~866M** raw image to a Proxmox host and imports it into Ceph (4 batches of 2). The step was still creating templates when it hit the 20-min cap.

## Change
- `Execute template rebuild` step: `timeout-minutes: 20` → **45** (with an explanatory comment).

No logic, inputs, secrets, or safety gates touched — a single timeout value.

## Context
This is one of two issues the dry-run surfaced. The other (terraform building 1.12.4 because `terraform.tfvars` wasn't bumped alongside `variables.tf`) is fixed on the upgrade trigger branch. After this merges, I'll rebase the trigger branch and re-run the dry-run.

Relates to **EPIC-033 / STORY-033-4**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI Workflow Timeout Adjustment (No Infrastructure Impact)

**Services/namespaces affected:** None. This change is confined to GitHub Actions workflow configuration.

**Breaking changes:** None. The timeout increase does not modify any logic, inputs, or configuration that would affect deployments or operations.

**Security implications:** None. No secrets, access controls, authentication, or safety gates are modified.

**Flux dependency impacts:** None. While the workflow validates Flux GitOps reconciliation status, this change only affects the template rebuild step timeout and does not modify any Flux configurations or dependencies.

**Resource changes:** None. The timeout adjustment (20m → 45m) applies only to a CI step; no Proxmox VMs, Kubernetes resources, or infrastructure are modified by this change.

**Talos, SOPS, ExternalSecrets:** Not affected. The workflow uses Talos extensively for node bootstrap and validation, but this PR does not modify any Talos-related configurations, machine configs, or deployment logic.

---

### Details

The `rebuild-templates` job's "Execute template rebuild" step increases `timeout-minutes` from 20 to 45, with added comments documenting the resource-intensive nature of the operation: 8 templates rebuilt in 4 batches, each uploading an ~866 MB raw image to Proxmox and importing to Ceph. A previous test run (26735551452) exceeded the 20-minute threshold; the new 45-minute timeout provides adequate headroom for this long-running operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->