### PR TITLE
feat(renovate): expand safe auto-merge, fix backlog blockers, rate-limit rollout

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,30 @@
+# .coderabbit.yaml
+# Stop CodeRabbit from auto-reviewing Renovate dependency-bump PRs.
+#
+# Mechanism: two complementary exclusions so neither alone is a single point
+# of failure:
+#   1. ignore_usernames: ['renovate[bot]'] — skips any PR whose author is the
+#      Renovate GitHub App. This is the primary gate; it fires regardless of
+#      what labels are present on the PR.
+#   2. labels: ['!renovate'] — additionally skips any PR that carries the
+#      'renovate' label (added by the renovate.json5 `labels` config). Acts
+#      as a fallback if Renovate ever runs under a different bot identity.
+#
+# Why this approach instead of path/branch filters:
+#   - Renovate PRs modify files across many paths (kubernetes/, .github/, etc.)
+#     so path_filters would require exhaustive enumeration.
+#   - Branch name patterns ("renovate/*") would also work but CodeRabbit's
+#     base_branches field filters *target* branches, not source branches.
+#   - Author + label exclusion is the mechanism CodeRabbit explicitly documents
+#     for dependency-bot exemptions and is stable across schema versions.
+#
+# Result: CodeRabbit will never submit CHANGES_REQUESTED (or any review) on
+# Renovate PRs, eliminating the BLOCKED mergeStateStatus that was preventing
+# 16+ PRs from auto-merging.
+reviews:
+  auto_review:
+    enabled: true
+    ignore_usernames:
+      - renovate[bot]
+    labels:
+      - "!renovate"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -837,6 +837,28 @@
       matchCurrentVersion: 'latest',
       enabled: false,
     },
+    {
+      // MUST be the last packageRule. Renovate uses the last matching
+      // minimumReleaseAge value; the root "Wait N days" rules above otherwise
+      // shorten the critical-infra PATCH auto-merge soak (cert-manager &
+      // external-secrets to 1d, cilium & cloudnative-pg to 3d). This re-asserts
+      // the intended 5-day soak for the Tier-2b patch automerge in autoMerge.json5.
+      description: 'Enforce 5-day soak for auto-merged critical-infra patch updates',
+      matchDatasources: [
+        'docker',
+        'helm',
+      ],
+      matchUpdateTypes: [
+        'patch',
+      ],
+      matchPackageNames: [
+        '/cert-manager/',
+        '/cilium/',
+        '/external-secrets/',
+        '/cloudnative-pg/',
+      ],
+      minimumReleaseAge: '5 days',
+    },
   ],
   ignorePaths: [
     '**/*.sops.*',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,10 +19,16 @@
     'configErrorIssue',
   ],
   configWarningReuseIssue: false,
-  rebaseWhen: 'conflicted',
+  rebaseWhen: 'behind-base-branch',
   schedule: [
     'every weekend',
   ],
+  automergeSchedule: [
+    'at any time',
+  ],
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+  branchConcurrentLimit: 10,
   platformAutomerge: true,
   'pre-commit': {
     enabled: true,
@@ -618,6 +624,16 @@
       matchPackageNames: [
         '/ghcr.io/siderolabs/talos/',
         '/ghcr.io/siderolabs/installer/',
+      ],
+    },
+    {
+      description: 'Disable kubelet image tracking (owned by Talos; version must match schematic)',
+      matchDatasources: [
+        'docker',
+      ],
+      enabled: false,
+      matchPackageNames: [
+        '/ghcr.io/siderolabs/kubelet/',
       ],
     },
     {

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -253,7 +253,7 @@
       "automergeType": "pr",
       "matchUpdateTypes": ["patch"],
       "minimumReleaseAge": "3 days",
-      "matchPackageNames": ["/actions-runner/"]
+      "matchPackageNames": ["/actions-runner/", "/gha-runner/"]
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -352,19 +352,10 @@
         "/qdrant/"
       ]
     },
-    {
-      "description": "Auto-merge Talos PETS upgrades (patch versions in talenv.yaml, 1 day wait)",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/siderolabs/installer"],
-      "matchFileNames": ["talos/talenv.yaml"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "1 day",
-      "prBodyNotes": [
-        "**Talos PETS**: Patch version will be auto-merged after 1-day stabilization. In-place upgrade via talosctl."
-      ]
-    },
+    // NOTE: Talos talenv.yaml (ghcr.io/siderolabs/installer) updates are disabled in
+    // renovate.json5 ("Disable Talos updates (managed via Terraform)"), so talenv-based
+    // rules would be dead. Talos auto-updates flow via terraform/variables.tf (below);
+    // keeping talenv.yaml in sync is the upgrade workflow's job (EPIC-033 STORY-033-3).
     {
       "description": "Auto-merge Talos PETS upgrades (patch versions in Terraform, 1 day wait)",
       "matchDatasources": ["github-releases"],
@@ -376,17 +367,6 @@
       "minimumReleaseAge": "1 day",
       "prBodyNotes": [
         "**Talos PETS**: Patch version will be auto-merged after 1-day stabilization. In-place upgrade via talosctl."
-      ]
-    },
-    {
-      "description": "Require manual review for Talos CATTLE upgrades (major/minor in talenv.yaml)",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/siderolabs/installer"],
-      "matchFileNames": ["talos/talenv.yaml"],
-      "matchUpdateTypes": ["major", "minor"],
-      "automerge": false,
-      "prBodyNotes": [
-        "**Talos CATTLE**: Major/minor version requires manual approval. Full VM rebuild via Terraform."
       ]
     },
     {

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -62,9 +62,9 @@
       "automergeType": "pr",
       "matchUpdateTypes": ["patch"],
       "minimumReleaseAge": "3 days",
-      "matchPackagePatterns": [
-        "lscr.io/linuxserver/.*",
-        "ghcr.io/linuxserver/.*"
+      "matchPackageNames": [
+        "/lscr.io/linuxserver/.*/",
+        "/ghcr.io/linuxserver/.*/"
       ]
     },
     {
@@ -109,75 +109,296 @@
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // TIER 3: REQUIRE MANUAL REVIEW - Critical infrastructure
-    // These rules MUST come after automerge rules to override them
+    // GLOBAL SAFETY NET
+    // All minor and major updates are manual unless a later rule opts them in.
+    // Placed HERE so that later opt-in rules (Tier 2b/2c/2d) can override it
+    // for specific packages, while the Tier-3 force-manual rules then re-block
+    // critical/stateful packages.
     // ═══════════════════════════════════════════════════════════════════════════
     {
-      "description": "Require manual review for critical CNI/storage infrastructure",
-      "matchDatasources": ["docker", "helm"],
-      "automerge": false,
-      "matchPackagePatterns": [
-        "cilium",
-        "rook",
-        "ceph",
-        "kube-prometheus-stack",
-        "envoy-gateway",
-        "nvidia"
-      ]
+      "description": "Require manual review for major and minor updates (global safety net)",
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
     },
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // TIER 2b: CRITICAL INFRA PATCH (5-day soak)
+    // cert-manager, cilium, external-secrets, cloudnative-pg: patch-only
+    // automerge with 5-day soak. Minor + major remain manual via Tier-3.
+    // Note: envoy-gateway and kube-prometheus-stack are NOT here — owner
+    // decision: no automerge at all for those (fully manual via Tier-3).
+    // ═══════════════════════════════════════════════════════════════════════════
     {
-      "description": "Require manual review for security components",
+      "description": "Auto-merge critical infra PATCH updates (5 day soak) — cert-manager, cilium, external-secrets, cloudnative-pg",
       "matchDatasources": ["docker", "helm"],
-      "automerge": false,
-      "matchPackagePatterns": [
-        "authentik",
-        "goauthentik"
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "5 days",
+      "matchPackageNames": [
+        "/cert-manager/",
+        "/cilium/",
+        "/external-secrets/",
+        "/cloudnative-pg/"
       ]
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // TIER 4: SPECIAL HANDLING - AI apps, Talos
+    // TIER 2c: APP-TEMPLATE (bjw-s) — patch + minor automerge
+    // Chart is a scaffold only; its version does not change running container
+    // images. Minor bumps add optional new features (safe after 5d soak).
     // ═══════════════════════════════════════════════════════════════════════════
     {
-      "description": "Require manual review for AI apps (rapidly evolving)",
+      "description": "Auto-merge app-template (bjw-s) patch updates (3 day soak)",
+      "matchDatasources": ["helm"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days",
+      "matchPackageNames": ["app-template"]
+    },
+    {
+      "description": "Auto-merge app-template (bjw-s) minor updates (5 day soak)",
+      "matchDatasources": ["helm"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor"],
+      "minimumReleaseAge": "5 days",
+      "matchPackageNames": ["app-template"]
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // TIER 2d: STATELESS APP MINOR AUTOMERGE (5-day soak)
+    // LinuxServer/*arr apps, media utilities, cloudflared, Home Assistant
+    // patches, GitHub Actions, CLI tools (mise), Terraform providers, ARC runners.
+    // ═══════════════════════════════════════════════════════════════════════════
+    {
+      "description": "Auto-merge LinuxServer.io media app minor updates (5 day wait)",
       "matchDatasources": ["docker"],
-      "automerge": false,
-      "matchPackagePatterns": [
-        "lightrag",
-        "litellm",
-        "open-webui",
-        "ollama",
-        "qdrant"
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor"],
+      "minimumReleaseAge": "5 days",
+      "matchPackageNames": [
+        "/lscr.io/linuxserver/.*/",
+        "/ghcr.io/linuxserver/.*/"
       ]
     },
     {
-      "description": "Auto-merge Talos PETS upgrades (patch versions, 1 day wait)",
-      "matchLabels": ["talos-update/pets"],
+      "description": "Auto-merge media utility app minor updates (5 day wait)",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor"],
+      "minimumReleaseAge": "5 days",
+      "matchPackageNames": [
+        "ghcr.io/cleanuparr/cleanuparr",
+        "ghcr.io/maintainerr/maintainerr",
+        "ghcr.io/wizarrrr/wizarr",
+        "golift/notifiarr",
+        "sctx/overseerr",
+        "ghcr.io/onedr0p/exportarr",
+        "ghcr.io/gethomepage/homepage"
+      ]
+    },
+    {
+      "description": "Auto-merge Home Assistant patch updates (3 day wait)",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days",
+      "matchPackageNames": ["ghcr.io/home-assistant/home-assistant"]
+    },
+    {
+      "description": "Auto-merge cloudflared patch updates (3 day wait)",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days",
+      "matchPackageNames": [
+        "docker.io/cloudflare/cloudflared",
+        "cloudflare/cloudflared"
+      ]
+    },
+    {
+      "description": "Auto-merge GitHub Actions patch and minor updates (1 day wait; SHA-pinned by helpers:pinGitHubActionDigests)",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "description": "Auto-merge CLI tools patch and minor updates (1 day wait; mise-managed, no cluster impact until used)",
+      "matchManagers": ["mise"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "description": "Auto-merge Terraform provider patch and minor updates (1 day wait; no cluster impact until apply)",
+      "matchDatasources": ["terraform-provider"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "description": "Auto-merge ARC runner chart patch updates (3 day wait; ephemeral runners, stateless)",
+      "matchDatasources": ["helm"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days",
+      "matchPackageNames": ["/actions-runner/"]
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // TIER 3: REQUIRE MANUAL REVIEW — Critical infrastructure + stateful apps
+    //
+    // MUST come AFTER all automerge opt-in rules so they take final precedence.
+    // These enforce automerge: false for ALL update types (digest/patch/minor/major)
+    // for the named packages, overriding any earlier tier that may have matched.
+    //
+    // MUST-PRESERVE safety decisions (owner-specified, no automerge any type):
+    //
+    //   rook / ceph         — OSD corruption / PG rebalancing risk; maintenance
+    //                         window required for any update
+    //   authentik           — SSO gatekeeper; broken update locks out all web UIs
+    //   nvidia              — kernel/schematic coupling; must align with Talos
+    //   nvidia-device-plugin — same coupling as nvidia driver images
+    //
+    // Additional manual-only for minor + major (patch allowed via Tier-2b):
+    //   kube-prometheus-stack — CRD migrations; bundled multi-component (no patch
+    //                           automerge either per owner decision)
+    //   envoy-gateway         — ingress plane; fully manual per owner decision
+    //   cert-manager          — patch OK (Tier-2b); minor/major manual
+    //   cilium                — patch OK (Tier-2b); minor/major manual
+    //   external-secrets      — patch OK (Tier-2b); minor/major manual
+    //   cloudnative-pg        — patch OK (Tier-2b); minor/major manual
+    // ═══════════════════════════════════════════════════════════════════════════
+    {
+      "description": "FULLY MANUAL: rook-ceph and Ceph — no automerge for any update type (data integrity risk, OSD corruption risk)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/rook/",
+        "/ceph/"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL: authentik and goauthentik — no automerge for any update type (SSO lockout risk)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/authentik/",
+        "/goauthentik/"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL: NVIDIA — no automerge for any update type (Talos kernel/schematic coupling)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/nvidia/",
+        "/nvidia-device-plugin/"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL: kube-prometheus-stack — no automerge for any update type (CRD migrations, multi-component bundle)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "kube-prometheus-stack"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL: envoy-gateway — no automerge for any update type (ingress plane, owner decision overrides Tier-2b)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/envoy-gateway/",
+        "/envoyproxy/"
+      ]
+    },
+    {
+      "description": "Require manual review for critical-infra minor and major (cert-manager, cilium, external-secrets, cloudnative-pg)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchUpdateTypes": ["minor", "major"],
+      "matchPackageNames": [
+        "/cert-manager/",
+        "/cilium/",
+        "/external-secrets/",
+        "/cloudnative-pg/"
+      ]
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // TIER 4: SPECIAL HANDLING — AI apps, Talos
+    // ═══════════════════════════════════════════════════════════════════════════
+    {
+      "description": "Require manual review for AI apps (rapidly evolving, stateful DBs)",
+      "matchDatasources": ["docker"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/lightrag/",
+        "/litellm/",
+        "/open-webui/",
+        "/ollama/",
+        "/qdrant/"
+      ]
+    },
+    {
+      "description": "Auto-merge Talos PETS upgrades (patch versions in talenv.yaml, 1 day wait)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/siderolabs/installer"],
+      "matchFileNames": ["talos/talenv.yaml"],
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr",
       "minimumReleaseAge": "1 day",
       "prBodyNotes": [
-        "🐾 **Talos PETS**: Patch version will be auto-merged after 1-day stabilization. In-place upgrade via talosctl."
+        "**Talos PETS**: Patch version will be auto-merged after 1-day stabilization. In-place upgrade via talosctl."
       ]
     },
     {
-      "description": "Require manual review for Talos CATTLE upgrades (major/minor)",
-      "matchLabels": ["talos-update/cattle"],
+      "description": "Auto-merge Talos PETS upgrades (patch versions in Terraform, 1 day wait)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["siderolabs/talos"],
+      "matchFileNames": ["terraform/variables.tf", "terraform/terraform.tfvars"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "1 day",
+      "prBodyNotes": [
+        "**Talos PETS**: Patch version will be auto-merged after 1-day stabilization. In-place upgrade via talosctl."
+      ]
+    },
+    {
+      "description": "Require manual review for Talos CATTLE upgrades (major/minor in talenv.yaml)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/siderolabs/installer"],
+      "matchFileNames": ["talos/talenv.yaml"],
+      "matchUpdateTypes": ["major", "minor"],
       "automerge": false,
       "prBodyNotes": [
-        "🐄 **Talos CATTLE**: Major/minor version requires manual approval. Full VM rebuild via Terraform."
+        "**Talos CATTLE**: Major/minor version requires manual approval. Full VM rebuild via Terraform."
       ]
     },
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // GLOBAL SAFETY NET - Must be LAST rule
-    // Ensures minor/major updates always require review
-    // ═══════════════════════════════════════════════════════════════════════════
     {
-      "description": "Require manual review for major and minor updates",
+      "description": "Require manual review for Talos CATTLE upgrades (major/minor in Terraform)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["siderolabs/talos"],
+      "matchFileNames": ["terraform/variables.tf", "terraform/terraform.tfvars"],
       "matchUpdateTypes": ["major", "minor"],
-      "automerge": false
+      "automerge": false,
+      "prBodyNotes": [
+        "**Talos CATTLE**: Major/minor version requires manual approval. Full VM rebuild via Terraform."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why the cluster keeps falling behind
The 26-PR backlog was **un-mergeable for mechanical reasons, not CI failures** (CI was green on all of them):
1. **Stale branches (19/26):** `rebaseWhen: conflicted` + a branch ruleset requiring up-to-date branches → branches that drifted behind `main` were never rebased → GitHub refused to merge them indefinitely.
2. **CodeRabbit (16/26):** `CHANGES_REQUESTED` reviews put PRs in `BLOCKED` (required approvals is 0, but a changes-requested review still blocks), re-triggered on every version bump.

## Fixes
- `rebaseWhen: behind-base-branch` (the primary unblock)
- **`.coderabbit.yaml`** excludes renovate-authored/labelled PRs from CodeRabbit review. **Secret scanning is unaffected** — gitleaks, GitGuardian, SOPS, flux-local are separate GitHub Actions that still run on every PR.
- Rate limits: `prConcurrentLimit: 5`, `prHourlyLimit: 2`, `branchConcurrentLimit: 10`, `automergeSchedule: ['at any time']` → a rolling ~5-PR waterfall, never a flood.
- Stop tracking `ghcr.io/siderolabs/kubelet` (owned by the Talos schematic).

## Auto-merge policy (owner-approved risk tiers)
`autoMerge.json5` restructured so the global minor/major safety net sits **before** the opt-ins, and the fully-manual blocks sit **after** (later rules win):
- **Stateless** (media *arr / plex / qbittorrent, homepage, **app-template**, GH Actions, mise, terraform providers, ARC, cloudflared+HA patch): **patch + minor** auto-merge with soak.
- **Critical infra** (cert-manager, cilium, external-secrets, cloudnative-pg): **patch only** (5-day soak); **minor + major manual**.
- **Fully manual, all update types:** **rook/ceph, authentik, nvidia, kube-prometheus-stack, envoy-gateway**, AI apps.
- **Majors always manual** (nothing opts them in).
- Fixed a pre-existing invalid `matchLabels` field on the Talos pets/cattle rules.

## Verification
- `renovate-config-validator`: **clean** (0 errors/warnings); all files JSON5/YAML-parse.
- security-guardian: **approved** — confirmed every critical component stays manual, no major can auto-merge, and CI secret-scanning coverage is unchanged.

## Rollout (after merge — separate manual steps)
1. Close the 26 stale PRs (months-old, versions moved on).
2. Manually dispatch Renovate → it recreates the still-relevant PRs at current versions under the new rules, rate-limited.
3. Watch the first auto-merge cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Services and Namespaces Affected

This PR changes Renovate policy cluster-wide; impacted services/namespaces include:
- Core infra: Flux (flux-instance/operator), Cilium, CNI plugins, metrics-server, reloader, spegel, kube-prometheus-stack
- Security & secrets: Authentik, ExternalSecrets (external-secrets), cert-manager, gitleaks, ensure-sops / sops-managed secrets
- Storage: Rook / Ceph
- Database: CloudNative-PG / PostgreSQL
- Observability: Prometheus, Grafana, Loki, kube-prometheus-stack
- Network: Envoy-gateway, Cloudflare (cloudflared), external-dns, gluetun, coredns
- GPU & compute: NVIDIA images/operators
- AI/ML: Ollama, Open WebUI, LiteLLM, LightRAG, Qdrant
- Media & IoT: Plex, Sonarr, Radarr, Home Assistant and associated sidecars
- CI/CD: GitHub Actions, ARC runners, flux-local
- Talos (installer/talenv/terraform-managed versions) — policies and tracking adjusted

---

## Breaking Changes

- rebaseWhen: changed from "conflicted" → "behind-base-branch" (fixes stale-branch mergeability with branch protection requiring up-to-date branches).
- Concurrency & rate-limits: prConcurrentLimit: 5, prHourlyLimit: 2, branchConcurrentLimit: 10 and automergeSchedule: ["at any time"] — creates a rolling ~5-PR waterfall and limits Renovate churn.
- Renovate will stop tracking ghcr.io/siderolabs/kubelet (kubelet image tracking disabled).
- autoMerge.json5 precedence reworked: global safety-net (minor/major manual) placed before opt-ins; tiered opt-ins added (patch/minor rules), and fully-manual blocks placed after so later rules win as intended.
- Talos matching rules fixed (file-based matchFileNames for pets/cattle; previously invalid matchLabels removed); talenv/terraform Talos rules clarified.
- CodeRabbit: Renovate-authored/labelled PRs are excluded from CodeRabbit auto-reviews (prevents CHANGES_REQUESTED from blocking merges).

---

## Security Implications

- Secret-scanning Actions remain active: gitleaks, GitGuardian, SOPS-related checks, and flux-local CI validation are preserved for all PRs (including Renovate PRs).
- ensure-sops / SOPS: repo contains .sops.yaml and multiple .sops.yaml files; Renovate ignorePaths includes '**/*.sops.*' to avoid touching encrypted secrets.
- CodeRabbit exclusion is narrowly targeted: ignore_usernames: [renovate[bot]] plus labels: ["!renovate"] — only Renovate PRs skip CodeRabbit review; human and other bot PRs still receive full review and security checks.
- Critical infra components (authentik, rook-ceph, kube-prometheus-stack, NVIDIA, envoy-gateway, ExternalSecrets, cert-manager, CloudNative-PG) remain manual for minor/major updates; patch automerge for some critical infra is intentionally limited and soak times enforced.

---

## Flux Dependency Impacts

- Flux and flux-local remain tracked; flux-local has a dedicated minimumReleaseAge of 3 days and is required in CI validation (prBodyNotes instruct flux-local testing).
- No broad exemptions for Flux components; digest automerges for flux operator/instance (digest-only) remain allowed.
- Known note preserved: flux-local issue (`#986`) affecting CloudNative-PG chart validation is documented in prBodyNotes — manual verification may still be required for certain chart bumps.

---

## Resource Changes

- kubelet image tracking disabled: Renovate will no longer open PRs for ghcr.io/siderolabs/kubelet; kubelet version is expected to be managed via Talos installer schema / Talos workflows.
- Talos: dual-track labeling and behavior retained and corrected:
  - PETS (talos/talenv.yaml and terraform/variables.tf patch updates) labeled talos-update/pets and allowed for patch automerge per rule tiering (soak windows apply).
  - CATTLE (major/minor) labeled talos-update/cattle and remain manual (Terraform rebuilds).
- autoMerge.json5 enforces a 5-day minimumReleaseAge for Tier-2b critical-infra PATCH automerges (cert-manager, cilium, external-secrets, cloudnative-pg) via a final packageRule to re-assert intended soak when earlier/global rules might otherwise shorten it.
- Renovate ignorePaths: '**/*.sops.*' and '**/resources/**' prevent processing of encrypted secrets and generated resources.

---

## Notable Flags (Prominent)

- Talos: fixed matching and explicit removal of kubelet independent tracking — operators must manage Talos/kubelet via Talos/Terraform flows.
- SOPS: multiple sops.yaml files present; Renovate will not touch encrypted secrets and SOPS CI steps remain in place.
- ExternalSecrets: included in Tier-2b critical-infra patch automerge (patch-only, 5-day soak); minor/major updates remain manual and require review due to secrets/auth concerns.

---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->