### PR TITLE
feat(renovate): continuous (rate-limited) schedule instead of weekend-only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: '🤖 Renovate Dashboard 🤖',
-  dependencyDashboardHeader: '## 🏠 Homelab Dependency Management\n\nThis dashboard tracks all dependencies across the cluster. Updates are organized by category:\n\n| Emoji | Category | Description |\n|-------|----------|-------------|\n| 🎬 | **Media** | Plex, *arr apps, request management |\n| 📚 | **Homelab** | Documentation (BookStack) |\n| 🌐 | **Network** | Ingress, VPN, DNS, Cloudflare |\n| 🔧 | **Core** | Flux, Cilium, CNI, system utilities |\n| 📊 | **Observability** | Prometheus, Grafana, Loki |\n| 💾 | **Storage** | Rook-Ceph |\n| 🔐 | **Security** | Authentik, External Secrets, cert-manager |\n| 🖥️ | **CI/CD** | GitHub Actions, ARC runners, flux-local |\n| 🎮 | **GPU** | NVIDIA support |\n| 🏠 | **IoT** | Home Assistant |\n| 🤖 | **AI/ML** | Ollama, Open WebUI, LiteLLM, LightRAG |\n| 🔌 | **MCP** | Model Context Protocol servers |\n| 🗄️ | **Cache** | Valkey |\n| 🐘 | **Database** | CloudNative-PG, PostgreSQL |\n| 🛠️ | **Tools** | CLI tools (helm, flux, talos, sops, age) |\n| 🏗️ | **Terraform** | Providers and IaC |\n| 📦 | **Runtime** | Node.js, Python |\n\n**Schedule:** Updates run every weekend. Check a box to run immediately.\n\n---\n',
+  dependencyDashboardHeader: '## 🏠 Homelab Dependency Management\n\nThis dashboard tracks all dependencies across the cluster. Updates are organized by category:\n\n| Emoji | Category | Description |\n|-------|----------|-------------|\n| 🎬 | **Media** | Plex, *arr apps, request management |\n| 📚 | **Homelab** | Documentation (BookStack) |\n| 🌐 | **Network** | Ingress, VPN, DNS, Cloudflare |\n| 🔧 | **Core** | Flux, Cilium, CNI, system utilities |\n| 📊 | **Observability** | Prometheus, Grafana, Loki |\n| 💾 | **Storage** | Rook-Ceph |\n| 🔐 | **Security** | Authentik, External Secrets, cert-manager |\n| 🖥️ | **CI/CD** | GitHub Actions, ARC runners, flux-local |\n| 🎮 | **GPU** | NVIDIA support |\n| 🏠 | **IoT** | Home Assistant |\n| 🤖 | **AI/ML** | Ollama, Open WebUI, LiteLLM, LightRAG |\n| 🔌 | **MCP** | Model Context Protocol servers |\n| 🗄️ | **Cache** | Valkey |\n| 🐘 | **Database** | CloudNative-PG, PostgreSQL |\n| 🛠️ | **Tools** | CLI tools (helm, flux, talos, sops, age) |\n| 🏗️ | **Terraform** | Providers and IaC |\n| 📦 | **Runtime** | Node.js, Python |\n\n**Schedule:** Updates flow continuously, rate-limited (max 5 open PRs, 2 new/hour) with per-package soak windows. Check a box to run immediately.\n\n---\n',
   dependencyDashboardFooter: '\n---\n\n📚 **Documentation:** [Renovate Docs](https://docs.renovatebot.com/) | ⚙️ **Config:** `.github/renovate.json5`',
   suppressNotifications: [
     'prEditedNotification',
@@ -20,8 +20,11 @@
   ],
   configWarningReuseIssue: false,
   rebaseWhen: 'behind-base-branch',
+  // Continuous (rate-limited) instead of weekend-only: throttling is handled by
+  // prConcurrentLimit/prHourlyLimit + per-package minimumReleaseAge soaks, so PRs
+  // flow as updates release rather than batching weekly (keeps the cluster current).
   schedule: [
-    'every weekend',
+    'at any time',
   ],
   automergeSchedule: [
     'at any time',


### PR DESCRIPTION
## Why
Weekend-only PR creation (`schedule: ['every weekend']`) was a blunt throttle from before proper rate limits existed — and a key reason the cluster keeps falling behind, since updates only get a chance to flow once a week.

Now that #1131 added `prConcurrentLimit: 5` + `prHourlyLimit: 2` + per-package `minimumReleaseAge` soaks, those provide the "rolling, not overwhelming" behavior. The calendar restriction is redundant and just adds latency.

## Change
- `schedule: ['every weekend']` → `['at any time']` — PRs flow continuously, throttled by the rate limits + soaks (≤5 open, ≤2 new/hour). `automergeSchedule` was already `at any time`.
- Updated the Dependency Dashboard header text to match.

## Effect
Updates appear as they release (rate-limited) instead of weekly batches → cluster stays current. Also unblocks validating the new auto-merge policy immediately rather than waiting for Saturday.

`renovate-config-validator`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update schedule configuration to enable continuous updates with rate-limiting safeguards instead of weekend-only batching, allowing for more frequent dependency refresh cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->