### PR TITLE
feat(renovate): auto-merge glycemicgpt (owner-maintained)

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -223,6 +223,15 @@
       ]
     },
     {
+      "description": "Auto-merge glycemicgpt (owner-maintained app) digest/patch/minor updates (1 day soak)",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["digest", "patch", "minor"],
+      "minimumReleaseAge": "1 day",
+      "matchPackageNames": ["/glycemicgpt/"]
+    },
+    {
       "description": "Auto-merge GitHub Actions patch and minor updates (1 day wait; SHA-pinned by helpers:pinGitHubActionDigests)",
       "matchManagers": ["github-actions"],
       "automerge": true,

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -229,7 +229,10 @@
       "automergeType": "pr",
       "matchUpdateTypes": ["digest", "patch", "minor"],
       "minimumReleaseAge": "1 day",
-      "matchPackageNames": ["/glycemicgpt/"]
+      // Scope to the trusted GHCR namespace only (ghcr.io/glycemicgpt/*: discord-bot,
+      // glycemicgpt-api/-web/-sidecar). A bare "/glycemicgpt/" substring would also
+      // auto-merge a like-named image in any other namespace.
+      "matchPackageNames": ["/^ghcr\\.io\\/glycemicgpt\\/.+/"]
     },
     {
       "description": "Auto-merge GitHub Actions patch and minor updates (1 day wait; SHA-pinned by helpers:pinGitHubActionDigests)",


### PR DESCRIPTION
Auto-merge `ghcr.io/glycemicgpt/*` (api, web, sidecar, discord-bot) digest/patch/minor after a 1-day soak — you maintain these, so the releases are trusted. Major stays manual. `renovate-config-validator`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency management configuration for improved system maintenance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->