### PR TITLE
fix(ci): add id-token:write for claude triage OIDC

### DIFF
--- a/.github/workflows/upgrade-failure-triage.yaml
+++ b/.github/workflows/upgrade-failure-triage.yaml
@@ -29,7 +29,8 @@ on:
 
 permissions:
   contents: read
-  actions: read   # read the failed run's logs
+  actions: read    # read the failed run's logs
+  id-token: write  # required by claude-code-action to mint its GitHub token via OIDC
 
 jobs:
   triage:


### PR DESCRIPTION
First triage test got past gather + cred-removal but the Claude step failed with `Could not fetch an OIDC token. Did you remember to add id-token: write`. `claude-code-action` mints its GitHub token via OIDC → needs `id-token: write`. One-line permission fix; re-test after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance authentication security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->