### PR TITLE
fix(ci): trim claude oauth token (invalid-header auth failure)

### DIFF
--- a/.github/workflows/upgrade-failure-triage.yaml
+++ b/.github/workflows/upgrade-failure-triage.yaml
@@ -94,6 +94,11 @@ jobs:
                    # exit can't kill the script before we capture its error + usage
           npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code
           echo "claude version: $(claude --version 2>/dev/null || echo unknown)"
+          # Strip any stray whitespace/newline the GitHub secret may carry; otherwise the
+          # token becomes an invalid HTTP header value ("Header has invalid value") and auth
+          # is rejected at the handshake. The OAuth token contains no internal whitespace.
+          CLAUDE_CODE_OAUTH_TOKEN="$(printf '%s' "${CLAUDE_CODE_OAUTH_TOKEN:-}" | tr -d '[:space:]')"
+          export CLAUDE_CODE_OAUTH_TOKEN
           PROMPT=$(cat <<'EOF'
           A Talos upgrade workflow run FAILED and you are triaging it.
 


### PR DESCRIPTION
Last run reached Claude cleanly but auth was rejected at the handshake: `API Error: Header '14' has invalid value: '***'` (363ms — pre-work). That signature means a malformed header *value*, i.e. the `CLAUDE_CODE_OAUTH_TOKEN` secret has a trailing newline from pasting (an expired token would 401 instead). This strips whitespace from the token in-workflow so auth succeeds regardless of how the secret was stored. Everything else is green — this should yield the first real verdict + token usage.