### PR TITLE
fix(ci): post Claude briefings as bot identity; pin triage CLI

### DIFF
--- a/.github/workflows/renovate-critical-review.yaml
+++ b/.github/workflows/renovate-critical-review.yaml
@@ -37,9 +37,19 @@ jobs:
       - name: Checkout PR (new manifests visible to Claude)
         uses: actions/checkout@v4
 
+      # Mint a GitHub App token so the briefing comment + label post as the repo's
+      # bot identity (homebot), consistent with the other PR-automation workflows,
+      # instead of the generic github-actions[bot].
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Gather PR context (to files; not echoed)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set +e
@@ -91,6 +101,8 @@ jobs:
           - For stateful components (ceph, cloudnative-pg, authentik): data/migration risk.
 
           OUTPUT FORMAT (strict):
+          - Output ONLY the briefing. No preamble, no "Now I have all the information"
+            or "Let me produce the briefing" text, no leading horizontal rule.
           - The VERY FIRST line must be exactly one of:
               RISK: safe
               RISK: needs-action
@@ -118,7 +130,9 @@ jobs:
           RISK="$(grep -m1 -oE 'RISK: (safe|needs-action|needs-validation)' briefing.md | awk '{print $2}')"
           [ -n "$RISK" ] || RISK="needs-validation"
           echo "RISK=${RISK}" >> "$GITHUB_ENV"
-          sed '0,/^RISK: .*/{/^RISK: .*/d;}' briefing.md > briefing-body.md
+          # Drop everything up to and including the RISK marker (also removes any
+          # stray model preamble before it), leaving just the briefing body.
+          sed '1,/^RISK: /d' briefing.md > briefing-body.md
           # Visibility + usage (indent neutralizes any quoted ##[...] / :: log-commands)
           echo "----- briefing (sanitized) -----"; sed 's/^/  /' briefing.md
           USAGE="$(jq -r '"- input: \(.usage.input_tokens // "?") output: \(.usage.output_tokens // "?") cache_read: \(.usage.cache_read_input_tokens // 0) cost_usd: \(.total_cost_usd // "?") turns: \(.num_turns // "?")"' out.json 2>/dev/null)"
@@ -128,7 +142,7 @@ jobs:
       - name: Post briefing comment + risk label
         if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set +e

--- a/.github/workflows/upgrade-failure-triage.yaml
+++ b/.github/workflows/upgrade-failure-triage.yaml
@@ -92,7 +92,11 @@ jobs:
         run: |
           set +e   # default shell is `bash -e`; turn OFF errexit so a non-zero claude
                    # exit can't kill the script before we capture its error + usage
-          npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code
+          # Pin the CLI version (supply-chain: avoid running an unvetted latest publish
+          # with the OAuth token + cluster-adjacent runner in scope). Bump deliberately.
+          CLAUDE_CLI_VERSION="2.1.162"
+          npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}" >/dev/null 2>&1 \
+            || npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
           echo "claude version: $(claude --version 2>/dev/null || echo unknown)"
           # Strip any stray whitespace/newline the GitHub secret may carry; otherwise the
           # token becomes an invalid HTTP header value ("Header has invalid value") and auth


### PR DESCRIPTION
## Summary
Follow-up polish to the two Claude CI workflows.

## Changes
- **Bot identity**: the Renovate critical-review briefing comment + label now post as the repo's **homebot** identity (via `actions/create-github-app-token`, same pattern as `labeler.yaml`/`flux-local.yaml`/etc.) instead of `github-actions[bot]`. The minted token is scoped to the `gh` gather + post steps only — the Claude step still runs with `GITHUB_TOKEN` blanked and never sees the app token.
- **Comment cleanup**: prompt now suppresses model preamble, and the body extraction strips everything through the `RISK:` marker (`sed '1,/^RISK: /d'`) so the comment starts at the briefing.
- **Supply-chain**: pin the triage workflow's `npm install -g @anthropic-ai/claude-code` to `@2.1.162` (the Medium from the #1140 review; the reviewer workflow was already pinned).

## Security
security-guardian reviewed → **APPROVED**. `pull_request` (not `pull_request_target`); fork PRs fail safe (secrets withheld → token step no-ops). No scope widening — the homebot App's installation permissions are unchanged and already used by 8 other workflows.

## Notes
Maintenance nit (not in this PR): the repo has two SHA variants of `create-github-app-token` (`67018539…` and `29824e69…`); worth aligning in a future sweep.