### PR TITLE
fix(ci): correct briefing body extraction (empty-comment regression)

### DIFF
--- a/.github/workflows/renovate-critical-review.yaml
+++ b/.github/workflows/renovate-critical-review.yaml
@@ -130,9 +130,10 @@ jobs:
           RISK="$(grep -m1 -oE 'RISK: (safe|needs-action|needs-validation)' briefing.md | awk '{print $2}')"
           [ -n "$RISK" ] || RISK="needs-validation"
           echo "RISK=${RISK}" >> "$GITHUB_ENV"
-          # Drop everything up to and including the RISK marker (also removes any
-          # stray model preamble before it), leaving just the briefing body.
-          sed '1,/^RISK: /d' briefing.md > briefing-body.md
+          # Strip the RISK marker line(s) only, leaving the briefing body. Must NOT use a
+          # `1,/^RISK: /` range: sed searches the end-address from line 2, so a RISK marker
+          # on line 1 never closes the range and the whole file is deleted (empty body).
+          sed '/^RISK:/d' briefing.md > briefing-body.md
           # Visibility + usage (indent neutralizes any quoted ##[...] / :: log-commands)
           echo "----- briefing (sanitized) -----"; sed 's/^/  /' briefing.md
           USAGE="$(jq -r '"- input: \(.usage.input_tokens // "?") output: \(.usage.output_tokens // "?") cache_read: \(.usage.cache_read_input_tokens // 0) cost_usd: \(.total_cost_usd // "?") turns: \(.num_turns // "?")"' out.json 2>/dev/null)"


### PR DESCRIPTION
The #1141 sed change (`1,/^RISK: /d`) deleted the entire briefing when the RISK marker landed on line 1 — sed searches the range end-address from line 2, so a line-1 match never closes the range and it deletes to EOF. The last review run posted an empty comment body (correct homebot identity, no content). Replaced with `sed '/^RISK:/d'` which strips only the marker line(s). Verified locally against the actual output (old → 0 lines, new → full briefing). security-guardian → APPROVED.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow comment generation to properly preserve briefing content during the review process. Previously, critical briefing information could be inadvertently removed when processing review comments. The workflow now correctly maintains the full briefing context while appropriately filtering specific review markers to provide clearer, more complete feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->