### PR TITLE
feat(renovate): no-soak auto-merge for owner-maintained glycemicgpt

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -592,6 +592,9 @@
       prBodyNotes: [
         '🤖 **AI/ML**: Rapidly evolving stack. Check for breaking API changes, model compatibility, and integration updates.',
       ],
+      // glycemicgpt is owner-maintained and intentionally excluded here so it is
+      // not double-gated by this 2-day soak — its no-soak auto-merge is defined
+      // in autoMerge.json5. It keeps the deps/ai label via the labeling rule above.
       matchPackageNames: [
         '/ollama/',
         '/open-webui/',
@@ -599,7 +602,6 @@
         '/lightrag/',
         '/qdrant/',
         '/openclaw/',
-        '/glycemicgpt/',
       ],
     },
     {

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -223,15 +223,16 @@
       ]
     },
     {
-      "description": "Auto-merge glycemicgpt (owner-maintained app) digest/patch/minor updates (1 day soak)",
+      "description": "Auto-merge glycemicgpt (owner-maintained app) digest/patch/minor updates with no soak — owner controls release cadence",
       "matchDatasources": ["docker"],
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": ["digest", "patch", "minor"],
-      "minimumReleaseAge": "1 day",
+      "minimumReleaseAge": "0",
       // Scope to the trusted GHCR namespace only (ghcr.io/glycemicgpt/*: discord-bot,
       // glycemicgpt-api/-web/-sidecar). A bare "/glycemicgpt/" substring would also
-      // auto-merge a like-named image in any other namespace.
+      // auto-merge a like-named image in any other namespace. Major bumps still fall
+      // through to manual review (not listed here).
       "matchPackageNames": ["/^ghcr\\.io\\/glycemicgpt\\/.+/"]
     },
     {


### PR DESCRIPTION
## Summary

Makes Renovate auto-merge `glycemicgpt` update PRs with **no soak**, as intended for an owner-maintained app.

PR #1133 already added a glycemicgpt auto-merge rule (1-day soak), but the images are still matched by the `Wait 2 days for AI/ML stack updates` rule in `renovate.json5`. Because root-config packageRules are evaluated *after* extended ones, that rule's `minimumReleaseAge: '2 days'` overrides the auto-merge rule's 1-day value — so glycemicgpt updates effectively wait **2 days** before merging, not the intended fast path.

## Changes

- **`autoMerge.json5`**: glycemicgpt rule `minimumReleaseAge` `1 day` → `0` (no soak).
- **`renovate.json5`**: remove `/glycemicgpt/` from the 2-day AI/ML soak rule so it is no longer double-gated. It remains in the `deps/ai` labeling rule.

## Behavior after merge

- `digest`, `patch`, and `minor` updates for `ghcr.io/glycemicgpt/*` open and auto-merge as soon as checks pass (no release-age wait).
- `major` updates remain **manual** (excluded from `matchUpdateTypes`).
- Scope stays tightly anchored to `/^ghcr\.io\/glycemicgpt\/.+/` — cannot match like-named images in other namespaces.

## Context

The current `v0.8.2 → v0.9.0` (minor) update had not opened yet because of the 2-day AI/ML soak (released 2026-06-10). With this change, future glycemicgpt releases flow through immediately.

## Testing

- [x] `renovate-config-validator` passes on both files
- [x] security-guardian review: approved (namespace regex anchored, no secrets, major excluded)
- [x] Rebased on latest `origin/main` (includes #1133)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to enable immediate auto-merging of patch, minor, and digest updates for specified packages, removing any release-age waiting period while preserving manual review for major releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->