### PR TITLE
fix(authentik): replace deprecated user.ak_groups with user.groups

### DIFF
--- a/kubernetes/apps/security/authentik/app/configmap-blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/configmap-blueprints.yaml
@@ -118,7 +118,7 @@ data:
           description: "Returns user's Authentik group memberships for Open WebUI access control"
           expression: |
             # Return user's Authentik group names for Open WebUI
-            return {"groups": [group.name for group in user.ak_groups.all()]}
+            return {"groups": [group.name for group in user.groups.all()]}
       # MCP Gateway Audience - adds aud claim for ToolHive gateway token validation
       - model: authentik_providers_oauth2.scopemapping
         id: scope-mcp-audience


### PR DESCRIPTION
## Summary

Replaces the deprecated `user.ak_groups` accessor with `user.groups` in the "Open WebUI Groups" OAuth2 scope mapping, ahead of the authentik 2026.5.2 upgrade (#1151).

authentik [deprecated `user.ak_groups` in 2026.2](https://docs.goauthentik.io/releases/2026.2/): it continues to work but emits a configuration-warning event at most every 30 days. The [user object reference](https://docs.goauthentik.io/users-sources/user/user_ref/) documents `user.groups` as a QuerySet of the user's **direct** groups — identical semantics to `ak_groups.all()` — so the emitted `groups` claim is unchanged.

## Changes

- `configmap-blueprints.yaml`: `user.ak_groups.all()` → `user.groups.all()` in the `scope-openwebui-groups` mapping.

## Why now

This is the only `ak_groups` usage in the repo. Doing it as a small standalone change (rather than bundling into the #1151 chart bump) keeps the IDP upgrade diff minimal and lets this land independently.

## Behavior

- `user.groups.all()` returns the same direct-group set as `user.ak_groups.all()` — no change to which groups appear in the claim, no access broadening (security-guardian confirmed).
- Silences the recurring deprecation warning event post-upgrade.

## Testing

- [x] security-guardian review: approved (semantics equivalent, no secrets)
- [x] Verified replacement syntax against authentik user-object docs (`user.groups` is a QuerySet supporting `.all()`)
- [ ] Flux Local CI validation
- Can merge before or after #1151; works on both 2025.12 (deprecated path) and 2026.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed group membership information retrieval in authentication scope mapping for OpenWebUI integration to ensure accurate group data is provided during user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->