### PR TITLE
fix(talos): correct pets upgrade schematics to include net.ifnames=0

### DIFF
--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -796,9 +796,11 @@ jobs:
         run: |
           echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
 
-          # Controllers and workers require factory image with qemu-guest-agent
-          INSTALLER_IMAGE="factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v${{ inputs.new_version }}"
-          echo "Control plane node - using base factory image with qemu-guest-agent"
+          # Controllers require base factory image: qemu-guest-agent + net.ifnames=0
+          # CRITICAL: Must use the same schematic as talconfig.yaml (f683308f)
+          # ce4c9805 lacks net.ifnames=0 — causes ens18 naming and breaks Cilium L2 + Multus
+          INSTALLER_IMAGE="factory.talos.dev/installer/f683308f6e49ec36d715bd41c90d800910552d8cbc015c8363ec350594535fa1:v${{ inputs.new_version }}"
+          echo "Control plane node - using base factory image (qemu-guest-agent + net.ifnames=0)"
 
           echo "Installer image: $INSTALLER_IMAGE"
           echo "Starting in-place upgrade..."
@@ -907,14 +909,16 @@ jobs:
           echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
 
           # Select correct factory schematic based on node type
+          # CRITICAL: Must match schematics in talconfig.yaml and terraform.tfvars
+          # Wrong schematics (ce4c9805/990731763) lack net.ifnames=0 — breaks Cilium L2 + Multus
           if [[ "${{ matrix.node.is_gpu }}" == "true" ]]; then
-            # GPU schematic: qemu-guest-agent + NVIDIA extensions
-            INSTALLER_IMAGE="factory.talos.dev/installer/990731763242a6b3cf735e49d0f550ce4068b4d0e7f4dfbb49a31799b698877e:v${{ inputs.new_version }}"
-            echo "GPU node detected - using GPU factory image (qemu-guest-agent + NVIDIA)"
+            # GPU schematic: qemu-guest-agent + NVIDIA extensions + net.ifnames=0
+            INSTALLER_IMAGE="factory.talos.dev/installer/26a847a67a3a6575fdcb3a9a45d6f1add29827e0f549955806b532d590004982:v${{ inputs.new_version }}"
+            echo "GPU node detected - using GPU factory image (qemu-guest-agent + NVIDIA + net.ifnames=0)"
           else
-            # Base schematic: qemu-guest-agent only
-            INSTALLER_IMAGE="factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v${{ inputs.new_version }}"
-            echo "Non-GPU node - using base factory image (qemu-guest-agent)"
+            # Base schematic: qemu-guest-agent + net.ifnames=0
+            INSTALLER_IMAGE="factory.talos.dev/installer/f683308f6e49ec36d715bd41c90d800910552d8cbc015c8363ec350594535fa1:v${{ inputs.new_version }}"
+            echo "Non-GPU node - using base factory image (qemu-guest-agent + net.ifnames=0)"
           fi
 
           echo "Installer image: $INSTALLER_IMAGE"

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -796,10 +796,16 @@ jobs:
         run: |
           echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
 
-          # Controllers require base factory image: qemu-guest-agent + net.ifnames=0
-          # CRITICAL: Must use the same schematic as talconfig.yaml (f683308f)
-          # ce4c9805 lacks net.ifnames=0 — causes ens18 naming and breaks Cilium L2 + Multus
-          INSTALLER_IMAGE="factory.talos.dev/installer/f683308f6e49ec36d715bd41c90d800910552d8cbc015c8363ec350594535fa1:v${{ inputs.new_version }}"
+          # Controllers require the base factory image: qemu-guest-agent + net.ifnames=0
+          # Single source of truth: terraform/terraform.tfvars (talos_schematic_base).
+          # A schematic without net.ifnames=0 renames NICs (ens18) and breaks
+          # Cilium L2 announcements + Multus VLAN attachments — see PR #1160.
+          BASE_SCHEMATIC="$(grep -E '^talos_schematic_base[[:space:]]*=' terraform/terraform.tfvars | grep -oE '[a-f0-9]{64}')"
+          if [[ ! "$BASE_SCHEMATIC" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::Could not read talos_schematic_base from terraform/terraform.tfvars"
+            exit 1
+          fi
+          INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${{ inputs.new_version }}"
           echo "Control plane node - using base factory image (qemu-guest-agent + net.ifnames=0)"
 
           echo "Installer image: $INSTALLER_IMAGE"
@@ -908,16 +914,24 @@ jobs:
         run: |
           echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
 
-          # Select correct factory schematic based on node type
-          # CRITICAL: Must match schematics in talconfig.yaml and terraform.tfvars
-          # Wrong schematics (ce4c9805/990731763) lack net.ifnames=0 — breaks Cilium L2 + Multus
+          # Select correct factory schematic based on node type.
+          # Single source of truth: terraform/terraform.tfvars
+          # (talos_schematic_base / talos_schematic_gpu). Both include net.ifnames=0;
+          # a schematic without it renames NICs (ens18/19/20) and breaks Cilium L2
+          # announcements + Multus VLAN NADs — see PR #1160.
+          BASE_SCHEMATIC="$(grep -E '^talos_schematic_base[[:space:]]*=' terraform/terraform.tfvars | grep -oE '[a-f0-9]{64}')"
+          GPU_SCHEMATIC="$(grep -E '^talos_schematic_gpu[[:space:]]*=' terraform/terraform.tfvars | grep -oE '[a-f0-9]{64}')"
+          for s in "$BASE_SCHEMATIC" "$GPU_SCHEMATIC"; do
+            if [[ ! "$s" =~ ^[a-f0-9]{64}$ ]]; then
+              echo "::error::Could not read schematic IDs from terraform/terraform.tfvars"
+              exit 1
+            fi
+          done
           if [[ "${{ matrix.node.is_gpu }}" == "true" ]]; then
-            # GPU schematic: qemu-guest-agent + NVIDIA extensions + net.ifnames=0
-            INSTALLER_IMAGE="factory.talos.dev/installer/26a847a67a3a6575fdcb3a9a45d6f1add29827e0f549955806b532d590004982:v${{ inputs.new_version }}"
+            INSTALLER_IMAGE="factory.talos.dev/installer/${GPU_SCHEMATIC}:v${{ inputs.new_version }}"
             echo "GPU node detected - using GPU factory image (qemu-guest-agent + NVIDIA + net.ifnames=0)"
           else
-            # Base schematic: qemu-guest-agent + net.ifnames=0
-            INSTALLER_IMAGE="factory.talos.dev/installer/f683308f6e49ec36d715bd41c90d800910552d8cbc015c8363ec350594535fa1:v${{ inputs.new_version }}"
+            INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${{ inputs.new_version }}"
             echo "Non-GPU node - using base factory image (qemu-guest-agent + net.ifnames=0)"
           fi
 

--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -23,9 +23,12 @@ metadata:
   name: l2-policy
 spec:
   loadBalancerIPs: true
-  # Restrict to eth0 interface only (cluster network)
+  # Restrict to eth0 interface (cluster network)
+  # Defense-in-depth: also match ens18 so a net.ifnames drift does not fully
+  # silence L2 announcements cluster-wide. eth0 is the authoritative name when
+  # net.ifnames=0 is baked into the schematic (f683308f / 26a847a6).
   interfaces:
-    - ^eth0$
+    - ^(eth0|ens18)$
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
@@ -60,9 +63,10 @@ metadata:
   name: dmz-l2-policy
 spec:
   loadBalancerIPs: true
-  # Restrict to eth2 interface only (DMZ network)
+  # Restrict to eth2 interface (DMZ network)
+  # Defense-in-depth: also match ens20 for net.ifnames drift resilience
   interfaces:
-    - ^eth2$
+    - ^(eth2|ens20)$
   # Only select worker nodes (exclude control plane nodes without eth1/eth2)
   nodeSelector:
     matchExpressions:
@@ -98,9 +102,10 @@ metadata:
   name: iot-l2-policy
 spec:
   loadBalancerIPs: true
-  # Restrict to eth1 interface only (IoT network)
+  # Restrict to eth1 interface (IoT network)
+  # Defense-in-depth: also match ens19 for net.ifnames drift resilience
   interfaces:
-    - ^eth1$
+    - ^(eth1|ens19)$
   # Only select worker nodes (exclude control plane nodes without eth1/eth2)
   nodeSelector:
     matchExpressions:

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.3
+talosVersion: v1.13.4
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.34.1


### PR DESCRIPTION
## Summary
The homelab dashboard (`homepage.homelab0.org`) and all other LoadBalancer-backed services became unreachable from the LAN. Root cause: the pets Talos upgrade workflow used **incorrect Image Factory schematic IDs** that do not bake `net.ifnames=0` into the UKI kernel cmdline. After the `v1.13.3 → v1.13.4` patch upgrade (#1158) ran the pets workflow, all 15 nodes rebooted with predictable interface names (`ens18`/`ens19`/`ens20`) instead of `eth0`/`eth1`/`eth2`.

Two cascading failures resulted:
1. **Cilium L2 announcements** — the `CiliumL2AnnouncementPolicy` interface selectors target `^eth0$` etc., which no longer matched any device → the `l2-announce` table went empty cluster-wide → no ARP for any LoadBalancer VIP (`10.20.67.21/22/23`). Apps and Envoy gateways stayed healthy internally (homepage returns HTTP 200 from inside the cluster); only the LAN VIP path was dark.
2. **Multus VLAN NADs** (`dmz-vlan81`, `iot-vlan62`) expect `eth1`/`eth2` → attachments failed (e.g. `home-assistant` stuck `ContainerCreating`).

## Changes
- **`.github/workflows/upgrade-pets.yaml`** — replace the wrong hardcoded schematics with the ones already declared in `talconfig.yaml`: `f683308f…` (base) and `26a847a6…` (GPU). Both include `net.ifnames=0`. Prevents recurrence on the next pets upgrade.
- **`kubernetes/apps/kube-system/cilium/app/networks.yaml`** — broaden all three L2 announcement policies to match both naming schemes (`^(eth0|ens18)$`, `^(eth1|ens19)$`, `^(eth2|ens20)$`). This is the **immediate recovery**: once Flux reconciles, Cilium repopulates the announce table on the currently-active `ens18` and VIPs respond again with no node reboot. Also serves as defense-in-depth against future naming drift.
- **`talos/talenv.yaml`** — bump to `v1.13.4` to reflect the actual running version and end the talenv/cluster split-brain.

## Recovery sequence
1. Merge this PR → Flux applies the Cilium policy change (~10 min) → LoadBalancer VIPs (homepage, n8n, Grafana, Plex, k8s-gateway DNS, both Envoy gateways) come back on the LAN with no reboots.
2. Run the node-by-node `talosctl upgrade` to the corrected schematics (workers first, controllers one at a time for etcd quorum) to restore `eth0` naming permanently and fix Multus attachments. Extra care warranted given the ongoing Proxmox PSU/power instability.

## Testing
- [x] Root cause confirmed: `/proc/cmdline` on all nodes lacks `net.ifnames=0`; Cilium devices table shows `ens18/19/20`; `l2-announce` table empty on every node.
- [x] Verified homepage app/gateway healthy internally (HTTP 200, full dashboard content via in-cluster curl).
- [x] `talhelper genconfig` regenerated clusterconfig with corrected schematics locally.
- [x] security-guardian review passed (no secrets; schematic IDs already public in `talconfig.yaml`).
- [ ] Post-merge: confirm VIPs answer ARP from a LAN client after Flux reconcile.
- [ ] Post-upgrade: `talosctl get kernelcmdline` shows `net.ifnames=0` and `eth0` exists; Multus pods start.

## Notes
The local-only (gitignored) `nodes.yaml` inventory was also corrected separately on disk — it had every worker on the GPU schematic and all nodes on `net.ifnames=0`-less schematics, which would re-trigger this outage on a cattle rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated Talos cluster to v1.13.4 with new factory installer images for control-plane and worker nodes.
  * Enhanced network interface compatibility to support multiple naming conventions (eth* and ens*) for improved robustness across deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->