### PR TITLE
ci(talos): guard upgrades against net.ifnames=0 regression

### DIFF
--- a/.github/workflows/talos-schematic-validation.yaml
+++ b/.github/workflows/talos-schematic-validation.yaml
@@ -1,0 +1,96 @@
+---
+# Pre-merge guard against the net.ifnames=0 regression (incident: PR #1160).
+#
+# A Talos Image Factory schematic that omits the net.ifnames=0 kernel arg makes
+# nodes boot with predictable NIC names (ens18/ens19/ens20) instead of
+# eth0/eth1/eth2. That silently breaks:
+#   - Cilium L2 announcements (policies target eth0/eth1/eth2) -> all LB VIPs dark
+#   - Multus macvlan NADs (master: eth1/eth2) -> VLAN-attached pods fail to start
+#
+# This check fetches every schematic referenced in terraform/terraform.tfvars
+# directly from the Image Factory API and fails the PR if net.ifnames=0 is
+# missing, or if talconfig.yaml has drifted from terraform.tfvars.
+name: Talos Schematic Validation
+
+on:
+  pull_request:
+    paths:
+      - terraform/terraform.tfvars
+      - terraform/variables.tf
+      - talos/talconfig.yaml
+      - talos/talenv.yaml
+      - .github/workflows/upgrade-pets.yaml
+      - .github/workflows/upgrade-cattle.yaml
+      - .github/workflows/talos-schematic-validation.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schematics:
+    name: Schematics bake net.ifnames=0
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Assert schematics include net.ifnames=0 and are consistent
+        run: |
+          set -euo pipefail
+
+          TFVARS="terraform/terraform.tfvars"
+          TALCONFIG="talos/talconfig.yaml"
+
+          # REQUIRED kernel arg. Losing it renames NICs and breaks Cilium L2 +
+          # Multus (see header). Both schematics MUST bake it.
+          REQUIRED_ARG='net\.ifnames=0'
+
+          extract() { # $1 = tfvars key -> first 64-char hex schematic id on that line
+            grep -E "^$1[[:space:]]*=" "$TFVARS" | grep -oE '[a-f0-9]{64}' | head -n1
+          }
+
+          BASE="$(extract talos_schematic_base)"
+          GPU="$(extract talos_schematic_gpu)"
+
+          if [[ ! "$BASE" =~ ^[a-f0-9]{64}$ || ! "$GPU" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::Could not read talos_schematic_base / talos_schematic_gpu from $TFVARS"
+            exit 1
+          fi
+
+          fail=0
+          for pair in "base:$BASE" "gpu:$GPU"; do
+            name="${pair%%:*}"; id="${pair#*:}"
+            echo "::group::Schematic $name = $id"
+            if ! body="$(curl -fsSL --max-time 20 "https://factory.talos.dev/schematics/$id")"; then
+              echo "::error::Failed to fetch $name schematic ($id) from Image Factory"
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+            echo "$body"
+            # Match the YAML list item under extraKernelArgs: "  - net.ifnames=0"
+            if echo "$body" | grep -qE "^[[:space:]]*-[[:space:]]*${REQUIRED_ARG}([[:space:]]|$)"; then
+              echo "OK: $name schematic bakes net.ifnames=0"
+            else
+              echo "::error::$name schematic ($id) is MISSING net.ifnames=0 — it would rename NICs (ens18/19/20) and break Cilium L2 announcements + Multus VLAN NADs"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+
+          # Drift guard: talconfig.yaml must reference the same schematics as tfvars.
+          if ! grep -q "$BASE" "$TALCONFIG"; then
+            echo "::error::talconfig.yaml does not reference base schematic $BASE (drift vs terraform.tfvars)"
+            fail=1
+          fi
+          if ! grep -q "$GPU" "$TALCONFIG"; then
+            echo "::error::talconfig.yaml does not reference GPU schematic $GPU (drift vs terraform.tfvars)"
+            fail=1
+          fi
+
+          if [[ "$fail" != 0 ]]; then
+            echo "::error::Talos schematic validation failed — see annotations above"
+            exit 1
+          fi
+          echo "All Talos schematics validated: net.ifnames=0 present and talconfig.yaml is consistent."

--- a/.github/workflows/talos-schematic-validation.yaml
+++ b/.github/workflows/talos-schematic-validation.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: Assert schematics include net.ifnames=0 and are consistent
         run: |
@@ -69,6 +71,16 @@ jobs:
               continue
             fi
             echo "$body"
+            # A real schematic response is YAML beginning with "customization:".
+            # Guard against the API returning HTTP 200 with an unexpected body
+            # (maintenance page, API change) — which would otherwise look like a
+            # missing kernel arg and wrongly block a valid PR.
+            if ! grep -qE '^customization:' <<<"$body"; then
+              echo "::error::Unexpected response from Image Factory for $name schematic ($id) — not a schematic document"
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
             # Match the YAML list item under extraKernelArgs: "  - net.ifnames=0"
             if echo "$body" | grep -qE "^[[:space:]]*-[[:space:]]*${REQUIRED_ARG}([[:space:]]|$)"; then
               echo "OK: $name schematic bakes net.ifnames=0"

--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -1500,6 +1500,27 @@ jobs:
           rm -f /tmp/applied-config.yaml
           echo "::endgroup::"
 
+      - name: Verify interface naming (net.ifnames=0)
+        timeout-minutes: 2
+        run: |
+          echo "::group::Verifying net.ifnames=0 / eth0 on ${{ matrix.node.name }}"
+          # Guard against the net.ifnames=0 regression (PR #1160). A schematic that
+          # omits this arg renames NICs to ens18/19/20, silently breaking Cilium L2
+          # announcements and Multus VLAN NADs. Fail fast to halt the rollout before
+          # the whole cluster is rebuilt with the wrong image.
+          NODE_IP="${{ matrix.node.ip }}"
+          CMDLINE="$(talosctl read /proc/cmdline --nodes "$NODE_IP" 2>/dev/null || true)"
+          if ! grep -q 'net.ifnames=0' <<<"$CMDLINE"; then
+            echo "::error::net.ifnames=0 missing from kernel cmdline on ${{ matrix.node.name }} — schematic lacks it. Halting to prevent ens18 naming break (Cilium L2 + Multus)."
+            exit 1
+          fi
+          if ! talosctl get links --nodes "$NODE_IP" -o json 2>/dev/null | grep -q '"eth0"'; then
+            echo "::error::eth0 not present on ${{ matrix.node.name }} after rebuild (predictable ensXX naming detected). Halting rollout."
+            exit 1
+          fi
+          echo "✅ net.ifnames=0 present and eth0 exists"
+          echo "::endgroup::"
+
       - name: Verify Talos version
         timeout-minutes: 2
         run: |

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -841,6 +841,26 @@ jobs:
           echo "✅ Version verified: $UPGRADED_VERSION"
           echo "::endgroup::"
 
+      - name: Verify interface naming (net.ifnames=0)
+        run: |
+          echo "::group::Verifying net.ifnames=0 / eth0 on ${{ matrix.node.name }}"
+          # Guard against the net.ifnames=0 regression (PR #1160). A schematic that
+          # omits this arg renames NICs to ens18/19/20, silently breaking Cilium L2
+          # announcements and Multus VLAN NADs. Fail fast to halt the rollout before
+          # the whole cluster is reinstalled with the wrong image.
+          NODE_IP="${{ matrix.node.ip }}"
+          CMDLINE="$(talosctl read /proc/cmdline --nodes "$NODE_IP" 2>/dev/null || true)"
+          if ! grep -q 'net.ifnames=0' <<<"$CMDLINE"; then
+            echo "::error::net.ifnames=0 missing from kernel cmdline on ${{ matrix.node.name }} — schematic lacks it. Halting to prevent ens18 naming break (Cilium L2 + Multus)."
+            exit 1
+          fi
+          if ! talosctl get links --nodes "$NODE_IP" -o json 2>/dev/null | grep -q '"eth0"'; then
+            echo "::error::eth0 not present on ${{ matrix.node.name }} after upgrade (predictable ensXX naming detected). Halting rollout."
+            exit 1
+          fi
+          echo "✅ net.ifnames=0 present and eth0 exists"
+          echo "::endgroup::"
+
       - name: Upgrade summary
         if: always()
         run: |
@@ -966,6 +986,26 @@ jobs:
           fi
 
           echo "✅ Version verified: $UPGRADED_VERSION"
+          echo "::endgroup::"
+
+      - name: Verify interface naming (net.ifnames=0)
+        run: |
+          echo "::group::Verifying net.ifnames=0 / eth0 on ${{ matrix.node.name }}"
+          # Guard against the net.ifnames=0 regression (PR #1160). A schematic that
+          # omits this arg renames NICs to ens18/19/20, silently breaking Cilium L2
+          # announcements and Multus VLAN NADs. Fail fast to halt the rollout before
+          # the whole cluster is reinstalled with the wrong image.
+          NODE_IP="${{ matrix.node.ip }}"
+          CMDLINE="$(talosctl read /proc/cmdline --nodes "$NODE_IP" 2>/dev/null || true)"
+          if ! grep -q 'net.ifnames=0' <<<"$CMDLINE"; then
+            echo "::error::net.ifnames=0 missing from kernel cmdline on ${{ matrix.node.name }} — schematic lacks it. Halting to prevent ens18 naming break (Cilium L2 + Multus)."
+            exit 1
+          fi
+          if ! talosctl get links --nodes "$NODE_IP" -o json 2>/dev/null | grep -q '"eth0"'; then
+            echo "::error::eth0 not present on ${{ matrix.node.name }} after upgrade (predictable ensXX naming detected). Halting rollout."
+            exit 1
+          fi
+          echo "✅ net.ifnames=0 present and eth0 exists"
           echo "::endgroup::"
 
       - name: GPU validation (GPU nodes only)


### PR DESCRIPTION
## Summary
Makes the Talos upgrade pipeline resilient so the `net.ifnames=0` regression (PR #1160) can never silently recur. That incident happened because a patch upgrade ran the pets workflow with a schematic that omitted `net.ifnames=0`, renaming NICs to `ens18/19/20` and breaking Cilium L2 announcements (all LB VIPs) and Multus VLAN NADs (`home-assistant`).

PR #1160 closed the *drift* (pets now reads schematics from `terraform.tfvars`). This PR adds the *detection* layers so any future cause is caught — at PR time and at upgrade time.

## Changes
**New `talos-schematic-validation.yaml` (pre-merge guard)**
- Triggers on PRs touching `terraform.tfvars`, `variables.tf`, `talconfig.yaml`, `talenv.yaml`, or the upgrade workflows.
- Fetches each schematic ID from the public Image Factory API (`https://factory.talos.dev/schematics/<id>`) and **fails the PR unless `net.ifnames=0` is baked into `extraKernelArgs`**.
- Asserts `talconfig.yaml` references the same schematic IDs as `terraform.tfvars` (drift guard).
- `permissions: contents: read` only; `pull_request` trigger; schematic ID is hex-validated before use; `actions/checkout` SHA-pinned.

**`upgrade-pets.yaml` + `upgrade-cattle.yaml` (runtime guard)**
- After each node upgrade/rebuild, assert `net.ifnames=0` is in the kernel cmdline and `eth0` exists.
- **Fail-fast** — halts the rollout on the first bad node instead of reinstalling all 15 nodes with a broken image.

## Defense layers (after this PR)
1. **No drift** (PR #1160) — pets + cattle both source schematics from `terraform.tfvars`.
2. **Pre-merge** (this PR) — a schematic without `net.ifnames=0`, or a talconfig/tfvars mismatch, fails CI before merge.
3. **Runtime** (this PR) — even if a bad image somehow runs, the rollout halts at node 1.

## Testing
- [x] YAML valid for all three workflows.
- [x] New check **passes** the current schematics (`f683308f`, `26a847a6` — both bake `net.ifnames=0`).
- [x] New check **correctly fails** the old broken schematic (`ce4c9805`, which has no `extraKernelArgs`) — i.e. it would have caught the original incident.
- [x] security-guardian review passed (no secrets; injection-safe — schematic ID hex-validated, node IPs come from the static workflow matrix and are quoted; read-only CI permissions).

## Notes
Runtime-guard `talosctl` behavior is exercised the next time an upgrade runs; the pre-merge check runs on this PR itself (it modifies the upgrade workflows, which is a trigger path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened upgrade safety with validation for network interface configuration across cluster nodes.
  * Added automated consistency checks between infrastructure and cluster configurations to prevent configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->