### PR TITLE
fix(homepage): set HOMEPAGE_ALLOWED_HOSTS for v1.x host validation

### DIFF
--- a/kubernetes/apps/tools/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/homepage/app/helmrelease.yaml
@@ -44,6 +44,11 @@ spec:
               TZ: America/New_York
               PUID: "568"
               PGID: "568"
+              # homepage v1.x enforces strict Host validation (SSRF / DNS-rebind
+              # protection). Without this, every external request is rejected with
+              # "Host validation failed" and no config (services/bookmarks/widgets)
+              # is rendered. List every host used to reach the dashboard.
+              HOMEPAGE_ALLOWED_HOSTS: homepage.homelab0.org
             # Inject all HOMEPAGE_VAR_* secrets from ExternalSecret
             # These replace {{HOMEPAGE_VAR_*}} placeholders in services.yaml
             envFrom:


### PR DESCRIPTION
## Summary
The homepage dashboard loads but renders only **"Host validation failed. See logs for more details."** — none of the `services`/`bookmarks`/`widgets` config appears. Verified live with Playwright and confirmed in the pod logs:

```
error: Host validation failed for: homepage.homelab0.org. Hint: Set the
HOMEPAGE_ALLOWED_HOSTS environment variable to allow requests from this host / port.
```

**Root cause:** homepage **v1.x** (running `v1.10.0`) enforces strict `Host` header validation (SSRF / DNS-rebinding protection). With `HOMEPAGE_ALLOWED_HOSTS` unset, it rejects every external request and serves no config. The broken state surfaced when the pod restarted onto the current image during the recent node reboots — this is an app-config gap, unrelated to the Cilium/Multus network fixes.

The liveness/readiness probes still pass because they hit the pod IP/localhost (allowed by default); only the browser's `Host: homepage.homelab0.org` is rejected.

## Changes
- Add `HOMEPAGE_ALLOWED_HOSTS: homepage.homelab0.org` to the homepage container `env:` block (specific FQDN, not a wildcard).

## Testing
- [x] Reproduced live via Playwright (only the error renders) and confirmed in pod logs.
- [x] Hostname matches the existing `httproute.yaml` ingress host.
- [x] YAML validated; security-guardian review passed (no secrets; value already public in httproute).
- [ ] Post-merge: after Flux reconciles, reload `homepage.homelab0.org` and confirm services/bookmarks/widgets render.

## Notes
If the dashboard is later exposed on additional hostnames, add them to the same comma-separated variable.