### PR TITLE
ci(renovate): broad patch+minor auto-merge with critical denylist

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -52,6 +52,34 @@
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // DEFAULT POSTURE: broad auto-merge (denylist model)
+    // Auto-merge patch + minor for ALL packages by default, after a soak window.
+    // Placed FIRST so the specific Tier-2 soak refinements below (e.g. gluetun 5d,
+    // critical-infra 5d, github-actions 1d) and the Tier-3/Tier-4 force-manual
+    // rules both override it where needed. ALL major updates always remain manual.
+    // Digests stay opt-in (Tier 1 above).
+    // ═══════════════════════════════════════════════════════════════════════════
+    {
+      "description": "Default: auto-merge patch updates after a 3-day soak (non-critical packages; later tiers override)",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Default: auto-merge minor updates after a 5-day soak (non-critical packages; later tiers override)",
+      "matchUpdateTypes": ["minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "5 days"
+    },
+    {
+      "description": "Global safety net: ALL major updates require manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // TIER 2: PATCH AUTOMERGE - Stable apps with release age wait
     // Bug fixes only, community-tested before automerge
     // ═══════════════════════════════════════════════════════════════════════════
@@ -106,19 +134,6 @@
         "reloader",
         "spegel"
       ]
-    },
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // GLOBAL SAFETY NET
-    // All minor and major updates are manual unless a later rule opts them in.
-    // Placed HERE so that later opt-in rules (Tier 2b/2c/2d) can override it
-    // for specific packages, while the Tier-3 force-manual rules then re-block
-    // critical/stateful packages.
-    // ═══════════════════════════════════════════════════════════════════════════
-    {
-      "description": "Require manual review for major and minor updates (global safety net)",
-      "matchUpdateTypes": ["major", "minor"],
-      "automerge": false
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -347,6 +362,31 @@
         "/cilium/",
         "/external-secrets/",
         "/cloudnative-pg/"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL minor/major: critical cluster infra (Flux, CoreDNS, Multus) — control-plane / DNS / CNI. Patch still auto-merges via the default soak; minor/major need eyes (a bad reconcile/DNS/CNI update can take the cluster down).",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchUpdateTypes": ["minor", "major"],
+      "matchPackageNames": [
+        "/flux-operator/",
+        "/flux-instance/",
+        "/coredns/",
+        "/multus/"
+      ]
+    },
+    {
+      "description": "FULLY MANUAL minor/major: stateful data layer (Postgres, Valkey/Redis, MariaDB) — minor bumps can trigger restarts/migrations that need a maintenance window. Patch still auto-merges via the default soak.",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchUpdateTypes": ["minor", "major"],
+      "matchPackageNames": [
+        "/postgresql/",
+        "/postgres/",
+        "/valkey/",
+        "/redis/",
+        "/mariadb/"
       ]
     },
 


### PR DESCRIPTION
## Summary
Fixes the renovate backlog at its root. The old config used an **allowlist** model (auto-merge only for explicitly-listed packages). Any package *not* listed opened a PR that **never auto-merged** → PRs accumulated → jammed `prConcurrentLimit: 5` → renovate couldn't open *new* update PRs at all (including the Plex/Radarr/Sonarr updates, which were sitting in "Pending Status Checks" purely because the queue was full).

This inverts to a **denylist** model: auto-merge patch+minor by default, with critical/stateful packages explicitly held for manual review.

## Changes (`.github/renovate/autoMerge.json5`)
- **DEFAULT POSTURE** (placed right after Tier-1 digests, so the specific Tier-2 soaks and Tier-3/4 denylist both override it):
  - `patch` → auto-merge after **3-day** soak
  - `minor` → auto-merge after **5-day** soak
  - `major` → **always manual**
  - digests → unchanged (still opt-in via Tier-1 allowlist)
- **Denylist extended** for the broad model (minor/major manual, patch still auto via soak):
  - `flux-operator` / `flux-instance`, `coredns`, `multus` — control-plane / DNS / CNI (a bad reconcile/DNS/CNI update can take the cluster down; extra caution after the recent net.ifnames networking incident)
  - `postgres` / `valkey` / `redis` / `mariadb` — stateful data layer (minor bumps can trigger restarts/migrations)
- Existing Tier-3/4 force-manual rules **unchanged** and still take final precedence: rook/ceph, authentik, nvidia, kube-prometheus-stack, envoy-gateway, cert-manager/cilium/external-secrets/cloudnative-pg (minor+major), AI apps (litellm/open-webui/ollama/qdrant/lightrag), Talos cattle.

## Precedence (later overrides earlier)
`Tier-1 digests` → `DEFAULT (patch/minor auto, major manual)` → `Tier-2/2b/2c/2d specific soaks (gluetun 5d, critical-infra 5d, github-actions 1d, …)` → `Tier-3/4 force-manual denylist`

## Validation
- `renovate-config-validator`: **validated successfully**.
- security-guardian: **APPROVED** — denylist covers the security-critical classes (auth, secrets, TLS, CNI, ingress, storage, DBs); 3-5d soak + GitOps delivery (Flux) + gitleaks/GitGuardian is a reasonable supply-chain posture; no secrets in diff.
- Confirmed no general-purpose admission controllers (kyverno/gatekeeper/OPA) are deployed, so that conditional recommendation is N/A.

## Companion action (already done)
The 5 stuck PRs that were jamming the queue (#1159 merged; #1157/#1147/#1146/#1143 set to auto-merge) have been cleared, so renovate can open the media PRs on its next run.

## Notes / optional follow-ups
- `knative`/`kserve` (CRD-bearing AI-serving webhooks) currently auto-merge minor under the broad default — contained blast radius (AI namespace), but could be added to the denylist if you'd prefer them manual.
- `prConcurrentLimit` left at 5 — with auto-merge now flowing, PRs clear quickly so it shouldn't jam; easy to raise later if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency auto-merge strategy with refined timing: patch updates auto-merge after 3 days, minor updates after 5 days, and major updates require manual review. Enhanced control for critical packages (Flux, CoreDNS, Multus, and database systems) with stricter approval requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->