### PR TITLE
fix(homepage): make /app/config writable (fixes CrashLoop after config→Git migration)

### DIFF
--- a/kubernetes/apps/tools/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/homepage/app/helmrelease.yaml
@@ -109,8 +109,15 @@ spec:
         reloader.stakater.com/auto: "true"
 
     persistence:
-      # Git-managed config files — each file mounted individually via subPath so
-      # homepage can still write to /app/config (e.g. logs) without a read-only fs.
+      # /app/config must be writable: on startup homepage copies skeleton defaults
+      # (docker/kubernetes/proxmox.yaml, custom.css/js) for any config file not
+      # present, and writes logs there. Back it with an emptyDir, then overlay our
+      # Git-managed files (services/settings/widgets/bookmarks) read-only via subPath.
+      config-rw:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /app/config
       config:
         enabled: true
         type: configMap
@@ -128,12 +135,6 @@ spec:
           - path: /app/config/services.yaml
             subPath: services.yaml
             readOnly: true
-      # Writable scratch space for homepage runtime files (logs, cache, etc.)
-      config-rw:
-        enabled: true
-        type: emptyDir
-        globalMounts:
-          - path: /app/config/logs
 
     service:
       app:


### PR DESCRIPTION
## Problem
After #1166, the homepage pod is in **CrashLoopBackOff**:
```
error: ❌ Failed to initialize required config: /app/config/kubernetes.yaml
Reason: EACCES: permission denied, copyfile '/app/src/skeleton/kubernetes.yaml' -> '/app/config/kubernetes.yaml'
```
homepage v1.10 requires 9 config files and **copies skeleton defaults** for any not present (docker/kubernetes/proxmox.yaml, custom.css/js). The migration mounted our 4 managed files via subPath but left `/app/config` itself as the **read-only image dir** (root-owned, not writable by UID 568), so the skeleton copy fails.

## Fix
Back `/app/config` with an **emptyDir** (writable by 568 via `fsGroup`), and overlay the 4 Git-managed files (`services/settings/widgets/bookmarks.yaml`) **read-only via subPath** on top. homepage then copies its harmless skeleton defaults for the rest into the writable dir and writes logs there. This mirrors the old PVC behavior (writable `/app/config`) while keeping our config in Git.

Mount ordering (emptyDir base first, then subPath overlays) is the standard writable-base + read-only-overlay pattern (security-guardian confirmed).

## Testing
- [x] HelmRelease YAML valid; securityContext unchanged; no secrets.
- [x] Skeleton file set confirmed by inspecting the v1.10.0 image (`/app/src/skeleton/`).
- [ ] Post-merge: pod goes Ready; verify dashboard + new tiles + widget stats via Playwright.