### PR TITLE
fix(homepage): provide all 9 config files (fixes persistent CrashLoop)

### DIFF
--- a/kubernetes/apps/tools/homepage/app/configmap.yaml
+++ b/kubernetes/apps/tools/homepage/app/configmap.yaml
@@ -465,3 +465,20 @@ data:
             icon: cilium.png
             href: https://hubble.homelab0.org
             description: Cilium Network Observability
+  # homepage v1.10 requires these files to exist on startup (it copies skeleton
+  # defaults otherwise, which fails on the read-only mount). Provided here so the
+  # mount can stay read-only. Contents are the upstream skeleton defaults (unused).
+  docker.yaml: |
+    ---
+    # Docker integration is not used. See:
+    # https://gethomepage.dev/configs/docker/
+  kubernetes.yaml: |
+    ---
+    # Kubernetes service discovery is not used here.
+  proxmox.yaml: |
+    ---
+    # Proxmox widgets connect via services.yaml (HOMEPAGE_VAR_* creds), not this file.
+  custom.css: |
+    /* custom styles */
+  custom.js: |
+    // custom scripts

--- a/kubernetes/apps/tools/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/homepage/app/helmrelease.yaml
@@ -109,15 +109,10 @@ spec:
         reloader.stakater.com/auto: "true"
 
     persistence:
-      # /app/config must be writable: on startup homepage copies skeleton defaults
-      # (docker/kubernetes/proxmox.yaml, custom.css/js) for any config file not
-      # present, and writes logs there. Back it with an emptyDir, then overlay our
-      # Git-managed files (services/settings/widgets/bookmarks) read-only via subPath.
-      config-rw:
-        enabled: true
-        type: emptyDir
-        globalMounts:
-          - path: /app/config
+      # All 9 config files homepage v1.10 expects are provided by the ConfigMap and
+      # mounted read-only via subPath, so homepage never needs to write skeleton
+      # defaults into /app/config (which is the read-only image dir). Verified the
+      # pod starts cleanly this way (no EACCES). Logs go to a writable emptyDir.
       config:
         enabled: true
         type: configMap
@@ -135,6 +130,27 @@ spec:
           - path: /app/config/services.yaml
             subPath: services.yaml
             readOnly: true
+          - path: /app/config/docker.yaml
+            subPath: docker.yaml
+            readOnly: true
+          - path: /app/config/kubernetes.yaml
+            subPath: kubernetes.yaml
+            readOnly: true
+          - path: /app/config/proxmox.yaml
+            subPath: proxmox.yaml
+            readOnly: true
+          - path: /app/config/custom.css
+            subPath: custom.css
+            readOnly: true
+          - path: /app/config/custom.js
+            subPath: custom.js
+            readOnly: true
+      # Writable scratch for homepage runtime logs (/app/config itself is read-only).
+      config-rw:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /app/config/logs
 
     service:
       app:


### PR DESCRIPTION
## Problem
homepage is still in **CrashLoopBackOff** after #1168 (the dashboard is down). homepage v1.10 requires **9** config files and copies skeleton defaults for any not present — which fails because `/app/config` isn't writable. The emptyDir-at-`/app/config` approach (#1168) didn't resolve it (Helm upgrade timed out and Flux rolled back).

## Fix (verified locally)
Provide **all 9 files** in the ConfigMap so homepage never needs to write skeletons, and mount them **read-only** via subPath; logs go to a writable emptyDir at `/app/config/logs`.
- ConfigMap: add `docker.yaml`, `kubernetes.yaml`, `proxmox.yaml`, `custom.css`, `custom.js` (upstream skeleton defaults — comment-only/empty, no secrets).
- HelmRelease: 5 new `readOnly` subPath mounts; `config-rw` emptyDir back to `/app/config/logs`.

**Verified** by running `ghcr.io/gethomepage/homepage:v1.10.0` locally with these exact 9 files mounted read-only as UID 568: pod reaches **`✓ Ready`**, **0 init errors, no EACCES**.

## Testing
- [x] Both YAMLs valid; security-guardian approved (no secrets; securityContext unchanged).
- [x] Local image test with the actual ConfigMap content → starts clean.
- [ ] Post-merge: pod Ready, then Playwright verifies the dashboard + new tiles + widget stats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes configuration to support homepage v1.10 with all required configuration files now properly mounted as read-only.
  * Improved storage management architecture by separating immutable configuration mounts from a dedicated writable directory for runtime log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->