### PR TITLE
feat(ai/kserve): add Qwen3.6-27B llama.cpp InferenceService with MTP speculative decoding

### DIFF
--- a/kubernetes/apps/ai/kserve/app/kustomization.yaml
+++ b/kubernetes/apps/ai/kserve/app/kustomization.yaml
@@ -34,6 +34,8 @@ resources:
   - ./hermes-jarvis-networkpolicy.yaml  # STORY-150: Zero-trust network segmentation
   - ./whisper-inferenceservice.yaml  # STORY-030-4: Whisper STT for voice calling
   - ./whisper-networkpolicy.yaml  # STORY-030-4: Zero-trust network segmentation
+  - ./qwen36-27b-inferenceservice.yaml  # Qwen3.6-27B via llama.cpp with MTP speculative decoding
+  - ./qwen36-27b-networkpolicy.yaml  # Zero-trust network segmentation
 
 # Note: KServe controller installs in kserve namespace by default
 # InferenceServices can be created in any namespace (e.g., ai)

--- a/kubernetes/apps/ai/kserve/app/qwen36-27b-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen36-27b-inferenceservice.yaml
@@ -1,0 +1,182 @@
+---
+# KServe InferenceService: Qwen3.6-27B (llama.cpp + MTP)
+# Model: unsloth/Qwen3.6-27B-MTP-GGUF, UD-Q4_K_XL quant (~17.9GB file)
+# Framework: llama.cpp llama-server (OpenAI-compatible), first llama.cpp ISVC in cluster
+# GPU: RTX A5000 24GB (k8s-work-10 ONLY, NOT Plex rtx-a2000 node)
+#
+# Why llama.cpp here instead of vLLM:
+# - GGUF Q4_K_XL is the only 4-bit format that fits this 27B dense model in 24GB
+# - Qwen3.6 ships trained MTP layers (bundled in this GGUF); llama.cpp >= b9180
+#   supports self-speculative decoding via --spec-type draft-mtp for ~1.5-1.7x decode
+#   speedup (community-verified on RTX 3090/4090 24GB cards)
+#
+# VRAM budget (24GB card): 17.9GB weights + ~1-2GB MTP draft buffers
+#   + ~1.3GB KV at 64k ctx (hybrid DeltaNet: only 10/64 layers carry KV) => ~21-22GB
+# KV cache stays f16: q8_0 KV + flash-attn has known instability with some
+#   architectures and the hybrid-attention KV is small enough not to bother.
+#
+# Performance expectations (extrapolated from 3090/4090 community reports):
+# - Cold start: ~120-180s (17.9GB single file from CephFS is the bottleneck)
+# - Decode: ~35-40 t/s baseline, ~55-70 t/s with MTP accepted drafts
+# - Scale-to-zero: 5 minutes idle timeout (global Knative config)
+# - Single GPU: maxReplicas=1 enforced (only 1 RTX A5000 available)
+#
+# Usage:
+#   kubectl run -it --rm test-curl --image=curlimages/curl --restart=Never -- \
+#     curl -X POST http://qwen36-27b.ai.svc.cluster.local/v1/chat/completions \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"qwen3.6-27b","messages":[{"role":"user","content":"hello"}]}'
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen36-27b
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: qwen36-27b
+    app.kubernetes.io/component: inference
+    app.kubernetes.io/part-of: kserve
+    model.framework: llama-cpp
+    model.type: text-only
+    model.size: 27b
+  annotations:
+    serving.kserve.io/enable-prometheus-scraping: "true"
+    security.homelab/gpu-required: "NVIDIA RTX A5000 for LLM inference"
+    security.homelab/network: "Internal only - ClusterIP service"
+spec:
+  predictor:
+    # Scale-to-zero configuration (Knative Serving)
+    minReplicas: 0  # Enable scale-to-zero (GPU freed when idle)
+    maxReplicas: 1  # Single GPU workload - only 1 pod can run at a time
+
+    # CRITICAL: GPU and Node Targeting
+    # Target ONLY k8s-work-10 (RTX A5000 24GB)
+    # Do NOT schedule on Plex node (rtx-a2000 reserved for transcoding)
+    nodeSelector:
+      kubernetes.io/hostname: k8s-work-10
+      gpu.nvidia.com/model: rtx-a5000
+
+    # Custom container approach (no ClusterServingRuntime needed)
+    # Official llama.cpp CUDA server image; MTP support requires >= b9180
+    containers:
+      - name: llama-server
+        # renovate: datasource=docker depName=ghcr.io/ggml-org/llama.cpp
+        image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9917
+
+        # llama-server arguments
+        args:
+          # Model path (pre-downloaded to model-cache PVC by qwen36-27b-download Job)
+          - --model
+          - /models/unsloth/Qwen3.6-27B-MTP-GGUF/Qwen3.6-27B-UD-Q4_K_XL.gguf
+
+          # Model name exposed via /v1/models (referenced by LiteLLM config)
+          - --alias
+          - qwen3.6-27b
+
+          # Offload all layers to GPU (weights + KV fit in 24GB, see budget above)
+          - --n-gpu-layers
+          - "999"
+
+          # 64k context, single slot: agentic sessions are long, and the hybrid
+          # DeltaNet KV is cheap (~20KiB/token). Concurrent requests queue inside
+          # llama-server; raise --parallel only if ctx-per-slot tradeoff is acceptable.
+          - --ctx-size
+          - "65536"
+          - --parallel
+          - "1"
+
+          # MTP self-speculative decoding (draft layers bundled in this GGUF)
+          - --spec-type
+          - draft-mtp
+          - --spec-draft-n-max
+          - "2"
+
+          # Qwen3.6 chat template with tool-calling support
+          - --jinja
+
+          # Prometheus /metrics endpoint (scraped via kserve annotation above)
+          - --metrics
+
+          # Server configuration
+          - --host
+          - 0.0.0.0
+          - --port
+          - "8080"
+
+        env:
+          # NVIDIA GPU visibility
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "all"
+          # Writable home for any runtime scratch (image may run non-root)
+          - name: HOME
+            value: "/tmp"
+
+        # Resource requirements
+        # Host RAM stays low: weights are mmap'd from CephFS and uploaded to VRAM;
+        # file-backed pages are reclaimable and won't OOM the cgroup
+        resources:
+          requests:
+            cpu: 4
+            memory: 8Gi
+            nvidia.com/gpu: 1
+          limits:
+            cpu: 8
+            memory: 12Gi
+            nvidia.com/gpu: 1
+
+        ports:
+          - containerPort: 8080
+            name: http1  # Knative requires port name to be 'http1' or 'h2c'
+            protocol: TCP
+
+        # llama-server /health returns 503 while the model is loading, 200 when ready
+        # Cold start ~120-180s (17.9GB from CephFS); liveness must not kill during load:
+        # 90 + (8-1)x15 = 195s before first possible kill
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 90
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 8
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 40  # (40-1)x5=195s after initial delay (~225s total)
+
+        # Volume mounts
+        volumeMounts:
+          - name: model-cache
+            mountPath: /models
+            readOnly: true  # llama.cpp only reads the GGUF, never writes
+
+        # Security context
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false  # llama-server needs writable /tmp
+          capabilities:
+            drop:
+              - ALL
+
+    # NVIDIA container runtime for GPU access
+    runtimeClassName: nvidia
+
+    # Security context (pod-level)
+    # fsGroup for PVC volume read permissions (files owned 1000:1000)
+    securityContext:
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+
+    serviceAccountName: default
+
+    # Volumes
+    volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/kubernetes/apps/ai/kserve/app/qwen36-27b-networkpolicy.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen36-27b-networkpolicy.yaml
@@ -97,6 +97,8 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+            - port: "53"
+              protocol: TCP
           rules:
             dns:
               - matchPattern: "*"

--- a/kubernetes/apps/ai/kserve/app/qwen36-27b-networkpolicy.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen36-27b-networkpolicy.yaml
@@ -1,0 +1,102 @@
+---
+# CiliumNetworkPolicy for Qwen3.6-27B InferenceService
+# Implements zero-trust network segmentation (same posture as qwen-coder)
+#
+# Security Posture:
+# - Ingress: ONLY envoy-internal gateway, Kourier, Knative activator/autoscaler, Prometheus
+# - Egress: DNS resolution only (GGUF pre-cached on model-cache PVC, no internet needed)
+# - Default: DENY all other traffic
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qwen36-27b
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: qwen36-27b
+    app.kubernetes.io/component: networkpolicy
+spec:
+  # Target KServe InferenceService pods
+  # Note: KServe creates pods with serving.kserve.io/inferenceservice label
+  endpointSelector:
+    matchLabels:
+      serving.kserve.io/inferenceservice: qwen36-27b
+
+  # Ingress Rules
+  ingress:
+    # Allow traffic from envoy-internal gateway (HTTPRoute ingress)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy-gateway
+            app.kubernetes.io/component: envoy-gateway
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+    # Allow traffic from Kourier gateway (KServe internal ingress)
+    # Traffic path: LiteLLM → Kourier → queue-proxy → kserve-container
+    # Port 8080: kserve-container (llama-server API)
+    # Port 8012: queue-proxy sidecar (traffic forwarding)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kourier-system
+            app: 3scale-kourier-gateway
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8012"
+              protocol: TCP
+
+    # Allow Knative Serving activator (cold start requests)
+    # During scale-from-zero, activator forwards requests to predictor
+    # Port 8080: kserve-container (llama-server API)
+    # Port 8012: queue-proxy sidecar (activator probes and traffic forwarding)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: knative-serving
+            app: activator
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8012"
+              protocol: TCP
+
+    # Allow Knative Serving autoscaler (metrics scraping)
+    # Autoscaler needs to scrape metrics for scaling decisions
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: knative-serving
+            app: autoscaler
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+    # Allow Prometheus scraping (observability)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+  # Egress Rules
+  egress:
+    # Allow DNS resolution ONLY (required for internal cluster communication)
+    # No internet egress needed - GGUF is pre-cached, llama.cpp never phones home
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -112,6 +112,16 @@ data:
         model_info:
           description: "KServe Qwen2.5-Omni multimodal (~150s cold start)"
 
+      - model_name: "qwen36-27b"
+        litellm_params:
+          # llama.cpp exposes the model under its --alias, not a /models/... path
+          model: "openai/qwen3.6-27b"
+          api_base: "http://qwen36-27b-predictor.ai.svc.cluster.local/v1"
+          api_key: "dummy"
+          timeout: 240        # Cold start ~120-180s (17.9GB GGUF from CephFS)
+        model_info:
+          description: "KServe Qwen3.6-27B llama.cpp + MTP (~150s cold start, tool calling)"
+
       # =====================================================
       # EPIC-030: TTS Models (Text-to-Speech)
       # Use /v1/audio/speech endpoint via mode: audio_speech

--- a/kubernetes/apps/ai/model-cache/app/kustomization.yaml
+++ b/kubernetes/apps/ai/model-cache/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./whisper-download-job.yaml  # STORY-030-3: Whisper model for voice calling
   - ./faster-whisper-download-job.yaml  # STORY-030-4: CTranslate2 format for speaches
   - ./qwen-tts-base-download-job.yaml  # EPIC-030: Qwen TTS Base for voice cloning
+  - ./qwen36-27b-download-job.yaml  # Qwen3.6-27B MTP GGUF for llama.cpp ISVC

--- a/kubernetes/apps/ai/model-cache/app/qwen36-27b-download-job.yaml
+++ b/kubernetes/apps/ai/model-cache/app/qwen36-27b-download-job.yaml
@@ -1,0 +1,151 @@
+---
+# Qwen3.6-27B MTP GGUF Pre-download Job
+# Downloads the Unsloth Dynamic Q4_K_XL GGUF (MTP layers bundled) to the shared cache PVC
+#
+# Model: unsloth/Qwen3.6-27B-MTP-GGUF / Qwen3.6-27B-UD-Q4_K_XL.gguf (~17.9GB disk, ~21GB VRAM incl. KV)
+# Purpose: llama.cpp InferenceService (qwen36-27b) with MTP self-speculative decoding
+#
+# Usage:
+#   kubectl apply -f qwen36-27b-download-job.yaml
+#   kubectl logs -n ai job/qwen36-27b-download -f
+#
+# After download, verify:
+#   kubectl exec -it deploy/litellm -n ai -- ls -la /models/unsloth/Qwen3.6-27B-MTP-GGUF/
+#
+# Note: Job immutability - to re-run, delete first:
+#   kubectl delete job -n ai qwen36-27b-download
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen36-27b-download
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: qwen36-27b-download
+    app.kubernetes.io/component: cache-loader
+    app.kubernetes.io/part-of: kserve
+spec:
+  # Allow 3 retries in case of network failures
+  backoffLimit: 3
+  # NOTE: ttlSecondsAfterFinished intentionally omitted (see model-predownload-job.yaml)
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen36-27b-download
+        app.kubernetes.io/component: cache-loader
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+
+      # Fix PVC permissions for non-root user
+      # Note: initContainer MUST run as root (UID 0) to chown files - this is intentional
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /models/unsloth /models/.cache
+              chown -R 1000:1000 /models/unsloth /models/.cache
+              echo "Permissions fixed: /models/unsloth and /models/.cache owned by user 1000"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+          securityContext:
+            runAsUser: 0  # Required for chown operation
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+
+      containers:
+        - name: huggingface-downloader
+          image: python:3.11-slim
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              echo "Installing huggingface-hub CLI..."
+              pip install --no-cache-dir 'huggingface-hub[cli]>=0.27,<0.28'
+              export PATH="/tmp/.local/bin:$PATH"
+
+              echo ""
+              echo "=== Qwen3.6-27B MTP GGUF Download ==="
+              echo "Single-file GGUF, Unsloth Dynamic Q4_K_XL with bundled MTP layers"
+              echo ""
+
+              # Download only the UD-Q4_K_XL quant (~17.9GB); the repo also
+              # carries other quants we don't want on the PVC
+              echo "=== Downloading unsloth/Qwen3.6-27B-MTP-GGUF (UD-Q4_K_XL, ~17.9GB) ==="
+              huggingface-cli download \
+                unsloth/Qwen3.6-27B-MTP-GGUF \
+                Qwen3.6-27B-UD-Q4_K_XL.gguf \
+                --local-dir /models/unsloth/Qwen3.6-27B-MTP-GGUF \
+                --local-dir-use-symlinks False
+              echo "Download complete: unsloth/Qwen3.6-27B-MTP-GGUF"
+              echo ""
+
+              # Verify download
+              echo "=== Verifying download ==="
+              ls -la /models/unsloth/Qwen3.6-27B-MTP-GGUF/
+              du -sh /models/unsloth/Qwen3.6-27B-MTP-GGUF/
+              echo ""
+
+              echo "=== Qwen3.6-27B GGUF download complete ==="
+              echo "Model: unsloth/Qwen3.6-27B-MTP-GGUF (UD-Q4_K_XL)"
+              echo "Location: /models/unsloth/Qwen3.6-27B-MTP-GGUF/Qwen3.6-27B-UD-Q4_K_XL.gguf"
+              echo "VRAM: ~21GB total (17.9GB weights + MTP buffers + KV at 64k ctx)"
+              echo "Use case: general/agentic chat + tool calling via llama.cpp with MTP"
+
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2
+              memory: 2Gi
+
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: huggingface-token
+                  key: HF_TOKEN
+                  optional: true  # Model is not gated
+            - name: HOME
+              value: /tmp
+            - name: HF_HOME
+              value: /models/.cache
+            - name: HF_HUB_DISABLE_TELEMETRY
+              value: "1"
+
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache


### PR DESCRIPTION
## What

Adds a new scale-to-zero LLM InferenceService to the `ai` namespace, following the existing `qwen-coder` pattern:

- `qwen36-27b-inferenceservice.yaml` — Qwen3.6-27B served by **llama.cpp** (`ghcr.io/ggml-org/llama.cpp:server-cuda-b9917`), custom-container predictor, pinned to `k8s-work-10` (RTX A5000)
- `qwen36-27b-networkpolicy.yaml` — zero-trust CiliumNetworkPolicy, same posture as the other ISVCs
- `qwen36-27b-download-job.yaml` (model-cache) — pre-downloads `unsloth/Qwen3.6-27B-MTP-GGUF` UD-Q4_K_XL (~17.9 GB, single file) to the model-cache PVC
- LiteLLM registration as `qwen36-27b`

## Why this model / engine

- Qwen3.6-27B is the strongest open-weight Qwen for agentic/coding use (SWE-bench Verified 77.2 vs 73.4 for the 35B-A3B MoE, per Qwen's published evals) and the UD-Q4_K_XL GGUF is the 4-bit format that actually fits a 24 GB card with context headroom.
- Qwen3.6 ships trained MTP layers (bundled in this GGUF). llama.cpp ≥ b9180 supports them via self-speculative decoding (`--spec-type draft-mtp`), community-verified at ~1.5–1.7× decode speedup on 24 GB cards (3090/4090). First llama.cpp ISVC in the cluster — vLLM can't serve this quant.

## VRAM budget (24 GB)

17.9 GB weights + ~1–2 GB MTP draft buffers + ~1.3 GB KV at 64k ctx (hybrid DeltaNet — only 10/64 layers carry KV) ≈ **21–22 GB**. KV stays f16 deliberately.

## Ops notes

- Run the download Job **before** first request (`kubectl logs -n ai job/qwen36-27b-download -f`); Jobs are immutable — delete to re-run.
- Cold start ~120–180 s (17.9 GB from CephFS); probes and the LiteLLM 240 s timeout are sized for it.
- Same GPU-contention model as the other A5000 ISVCs: scale-to-zero, one resident model at a time, `maxReplicas: 1`.

## Validation

- `kustomize build` passes for all three touched apps.
- `flux-local test --enable-helm --all-namespaces` (v8.0.1, same as CI): **151 passed, 13 failed — identical counts and failure set on a clean `main` worktree** (all pre-existing `media/*` HelmRelease failures, unrelated to this change). No new failures introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Qwen 3.6 27B model endpoint.
  * Preloads the model into shared cache storage for faster startup.
  * Exposes the model through the app’s existing AI routing layer.

* **Bug Fixes**
  * Improved handling for slow cold starts with longer readiness checks and timeouts.
  * Added stricter network restrictions to limit access to only required internal services and DNS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->