### PR TITLE
fix(ai/kserve): redirect kube-rbac-proxy from sunset gcr.io to quay.io/brancz

### DIFF
--- a/kubernetes/apps/ai/kserve/app/kustomization.yaml
+++ b/kubernetes/apps/ai/kserve/app/kustomization.yaml
@@ -61,6 +61,15 @@ configMapGenerator:
       # These values point to Kourier but are not actually used when disableIstioVirtualHost is enabled
       - ingress={"ingressClassName":"kourier.ingress.networking.knative.dev","ingressDomain":"svc.cluster.local","domainTemplate":"{{.Name}}.{{.Namespace}}.svc.cluster.local","urlScheme":"http","disableIstioVirtualHost":true,"ingressGateway":"knative-serving/knative-ingress-gateway","ingressService":"kourier.kourier-system.svc.cluster.local"}
 
+# gcr.io/kubebuilder was sunset; redirect kube-rbac-proxy to the upstream canonical mirror.
+# quay.io/brancz/kube-rbac-proxy:v0.13.1 is the source-of-truth image (same digest, multi-arch).
+# This unblocks the kserve-controller-manager pod (1/2 ImagePullBackOff for ~3 days) and
+# restores the kserve-webhook-server-service endpoints so InferenceService webhooks function.
+images:
+  - name: gcr.io/kubebuilder/kube-rbac-proxy
+    newName: quay.io/brancz/kube-rbac-proxy
+    newTag: v0.13.1
+
 patches:
   # Add resource limits to controller manager
   - target:


### PR DESCRIPTION
## Summary

The `kserve-controller-manager` pod has been `1/2 (ImagePullBackOff)` for ~3 days because `gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1` is no longer pullable — Google sunset the `gcr.io/kubebuilder` registry. With the manager pod not Ready, the `kserve-webhook-server-service` has empty endpoints, causing every `InferenceService` and `ClusterServingRuntime` apply via Flux to fail with:

```
no endpoints available for service "kserve-webhook-server-service"
```

This blocks the `ai/kserve` Flux Kustomization and prevents the newly merged `qwen36-27b` InferenceService from being applied.

## Root Cause

KServe v0.13.1 upstream manifest hardcodes `gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1` as the sidecar for the controller-manager Deployment. That registry was sunset by Google; the image is no longer pullable from any node.

KServe v0.14.0 resolved this by switching to `quay.io/brancz/kube-rbac-proxy:v0.18.0` natively, but upgrading KServe carries a larger blast radius (CRD changes, new storage-initializer image, 10 running InferenceServices).

## Fix

Add a Kustomize `images:` override in `kubernetes/apps/ai/kserve/app/kustomization.yaml` to redirect the dead image to its canonical upstream source:

```yaml
images:
  - name: gcr.io/kubebuilder/kube-rbac-proxy
    newName: quay.io/brancz/kube-rbac-proxy
    newTag: v0.13.1
```

`quay.io/brancz/kube-rbac-proxy` is the authoritative registry for this image (authored by Frederic Branczyk, @brancz). Tag `v0.13.1` on quay.io is verified present with a multi-arch manifest (`sha256:738c854322f56d63ebab75de5210abcdd5e0782ce2d30c0ecd4620f63b24694d`). This was confirmed via the quay.io API before implementing.

`kubectl kustomize` confirms the rendered Deployment uses `quay.io/brancz/kube-rbac-proxy:v0.13.1` after this change.

## Why not upgrade to KServe v0.14.x?

- 10 InferenceServices currently running and healthy in the `ai` namespace
- v0.14.0 changes CRD schemas and the `storage-initializer` image (already overridden to v0.18.0 in this repo — mismatched with a v0.14.0 controller)
- The image override is surgical: one field change, zero blast radius, same KServe semantics
- A KServe minor-version upgrade is a separate planned effort; unblocking the webhook is the immediate goal

## Changes

- `kubernetes/apps/ai/kserve/app/kustomization.yaml` — add `images:` override block (9 lines)

## Validation Plan

After Flux reconciles (~10 minutes after merge):

1. **Pod becomes Ready**: `kubectl get pod -n kserve` → `kserve-controller-manager-* 2/2 Running`
2. **Webhook endpoints populate**: `kubectl get endpoints -n kserve kserve-webhook-server-service` → shows pod IP
3. **Flux Kustomization recovers**: `flux get kustomization -n flux-system ai-kserve` → `Ready True`
4. **qwen36-27b InferenceService applies**: `kubectl get inferenceservice -n ai qwen36-27b` appears
5. **Existing InferenceServices unaffected**: all 10 current entries remain in their existing state

## Security Review

- Security-guardian agent: APPROVED — no secrets, no credentials, no sensitive paths; quay.io/brancz confirmed as canonical upstream source; pinned tag (not latest)

## Notes

Surfaced while investigating why the `qwen36-27b` InferenceService from PR #1213 was not applying after merge. The download Job is running fine; only the webhook was the blocker.

Renovate will pick up future `quay.io/brancz/kube-rbac-proxy` updates automatically once this is in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deployed image source for a required Kubernetes proxy component to use a reliable upstream mirror and pinned version.
  * Helped prevent controller startup issues caused by image pull failures.
  * Restored webhook connectivity so `InferenceService` resources can function properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->