### PR TITLE
fix(network): scope unifi-dns to envoy-internal HTTPRoutes only

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -79,6 +79,35 @@ spec:
       - gateway-httproute
       - service
 
+    # Gateway API scoping (CRITICAL): only watch HTTPRoutes attached to the
+    # envoy-internal Gateway, mirroring how network/cloudflare-dns is scoped
+    # to --gateway-name=envoy-external.
+    #
+    # Without this filter, unifi-dns also watches HTTPRoutes attached to
+    # envoy-external. Apps that publish both an "-internal" and "-external"
+    # HTTPRoute for the same hostname (e.g. overseerr.homelab0.org) then have
+    # two candidate CNAME targets registered against this single UniFi/UDM
+    # DNS provider: envoy-internal's target (internal.homelab0.org) and
+    # envoy-external's target (external.homelab0.org). external-dns cannot
+    # publish two CNAMEs for one name, so its planner arbitrarily drops one
+    # candidate every sync interval, logging:
+    #   "Only one CNAME per name — <host> CNAME external.homelab0.org and
+    #    <host> CNAME internal.homelab0.org is invalid DNS."
+    # The surviving answer flaps between internal and external on every
+    # ~5m reconcile. When the external answer wins, LAN/UDM resolver
+    # (10.20.65.1) serves a CNAME to external.homelab0.org, which is
+    # out-of-zone for this resolver (it's a Cloudflare-only name) and
+    # therefore resolves as a dangling CNAME with no A record. glibc-based
+    # clients tolerate this (they issue a follow-up query); Android's
+    # resolver does not, and fails outright ("Address Not Found").
+    #
+    # Confirmed live via unifi-dns pod logs on 2026-07-09/10 for the exact
+    # set of apps that expose both an internal and external HTTPRoute:
+    # overseerr, tautulli, wizarr, bookstack (guides.homelab0.org),
+    # authentik.
+    extraArgs:
+      - --gateway-name=envoy-internal
+
     # Policy
     policy: sync
 


### PR DESCRIPTION
## Summary

Fixes intermittent/broken WiFi access to apps that have both an internal and
external HTTPRoute for the same hostname (overseerr, tautulli, wizarr,
bookstack, authentik).

**Status update:** #1217 adds a LAN-local A record for `external.homelab0.org`
itself, which means both candidate targets this PR's fix disambiguates
(`internal.homelab0.org` -> `.22` and `external.homelab0.org` -> `.23`) are
now complete, LAN-reachable answers regardless of which one `unifi-dns`
picks. This PR is **no longer strictly required** to fix the Android/WiFi
bug - #1217 is now the primary, comprehensive fix (it also covers
external-only apps like grafana/voice-bridge/glycemicgpt, which this PR
alone does not). Keeping this PR anyway as a correct, already-reviewed,
complementary fix for the actual non-determinism at its source (`unifi-dns`
should never have been able to see `envoy-external` HTTPRoutes at all).

**Update:** a competing hypothesis (that `k8s-gateway`, not `unifi-dns`, was
the actual DNS authority for LAN clients) was raised and investigated in
depth. It does not hold up - see "Ruling out k8s-gateway" below for the
decisive, reproducible evidence. `unifi-dns` is confirmed as the correct fix
target.

## Root cause

`unifi-dns` (the external-dns instance that publishes DNS records into the
UniFi UDM's **Local DNS Records** for LAN resolution) had no `--gateway-name`
filter, so it watched HTTPRoutes on **both** `envoy-internal` and
`envoy-external`.

Several apps expose the same hostname on both gateways, e.g.
`overseerr.homelab0.org` via `overseerr-internal` (parented to
`envoy-internal`, target `internal.homelab0.org`) and `overseerr-external`
(parented to `envoy-external`, target `external.homelab0.org`). Since
unifi-dns watched both, it registered two conflicting CNAME targets for one
DNS name and pushed one into the UDM's Local DNS Records, non-deterministically,
on every ~5 minute sync - confirmed directly from the running pod:

```
"Only one CNAME per name - overseerr.homelab0.org CNAME external.homelab0.org
 and overseerr.homelab0.org CNAME internal.homelab0.org is invalid DNS."
```

The surviving answer flaps between `internal.homelab0.org` and
`external.homelab0.org` across syncs. When external wins, the UDM serves a
CNAME to `external.homelab0.org`, which is out-of-zone for that resolver (a
Cloudflare-only name) - a dangling CNAME with no A record. glibc-based
resolvers tolerate this (they issue a follow-up query and succeed via the
UDM's normal upstream forwarding); Android's resolver rejects the incomplete
answer outright ("Address Not Found"), breaking WiFi access to these apps
from phones.

## Ruling out k8s-gateway (decisive evidence)

A parallel theory held that the UDM merely *forwards* `homelab0.org` queries
to `k8s-gateway` (10.20.67.21, the in-cluster CoreDNS-based resolver), and
that `k8s-gateway` itself was non-deterministically choosing between the
internal/external Gateway targets and emitting the dangling CNAME. This was
investigated directly against the running cluster and disproven:

1. **`k8s-gateway`'s own source (the exact running version, `ghcr.io/k8s-gateway/k8s_gateway:1.7.0`,
   confirmed via image digest) has no code path that emits a CNAME for
   HTTPRoute/Gateway-derived answers at all.** `lookupGateways()` in
   `kubernetes.go` only ever returns `Gateway.Status.Addresses` as A/AAAA
   records (`gateway.go`'s `ServeDNS` only ever builds `dns.TypeA`/`TypeAAAA`
   answers from that path - there is no CNAME-emitting branch in the
   HTTPRoute/Gateway resolution code at all).
2. **Live confirmation, in-cluster (bypassing the LAN/UDM entirely):**
   querying the k8s-gateway pod directly, its Service ClusterIP, and the
   kube-system CoreDNS `dns://homelab0.org:53 { forward . 10.20.67.21 }`
   stub (the actual in-cluster consumer of k8s-gateway) all return the
   **same clean, complete answer**: `overseerr.homelab0.org` ->
   `A 10.20.67.22` + `A 10.20.67.23` (both VIPs, no CNAME, no dangling
   record). k8s-gateway has been working correctly the entire time.
3. **Live confirmation that the UDM does NOT actually forward to k8s-gateway
   for unmanaged names:** querying `k8s-gateway.network.homelab0.org` (the
   plugin's own synthetic self-address record - never touched by
   `unifi-dns`, since it isn't a real Kubernetes resource) against both
   `10.20.65.1` and `10.20.67.21` **from a LAN-routed client** returns
   `NXDOMAIN` on both, while the identical query answered in-cluster
   correctly returns `A 10.20.67.21`. If the UDM genuinely relayed
   unmatched `homelab0.org` queries to k8s-gateway, this name would resolve
   fine from the LAN too. It doesn't - meaning LAN clients querying
   `10.20.67.21` (routed through the UDM, since that VIP is on a different
   VLAN than LAN client devices) never actually reach the real k8s-gateway
   backend; they only ever see whatever `unifi-dns` has pushed as a Local
   DNS Record. The earlier "TTL lockstep between 10.20.65.1 and
   10.20.67.21" observation is explained by both queries being served by
   the *same* UDM-local-record engine, not by two independent hops
   converging on the same upstream k8s-gateway answer.

Net: k8s-gateway is correct and unaffected; it is used only for in-cluster
pod resolution of `homelab0.org` via the kube-system CoreDNS forward stub,
not by real LAN/WiFi clients. `unifi-dns`'s Local DNS Records are the sole
source of what LAN/WiFi clients (including Android) actually see, and its
missing gateway scoping is the real, sufficient root cause.

## Fix

Add `extraArgs: [--gateway-name=envoy-internal]` to the `unifi-dns`
HelmRelease, mirroring the identical, already-proven
`--gateway-name=envoy-external` scoping on the separate `cloudflare-dns`
instance (`kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml`).

This is a one-line, additive scoping change to an existing `extraArgs` list
key already supported by this chart version (same underlying `external-dns`
chart as `cloudflare-dns`, both on `1.21.1`).

## Why public/Cloudflare access is preserved

`cloudflare-dns` is a **completely separate** HelmRelease/Deployment/DNS
provider instance, already scoped to `--gateway-name=envoy-external` and
publishing only to Cloudflare. It is not touched by this change. Public DNS
records for every app are unaffected.

## Expected side effect (not a regression)

A few apps only have an `envoy-external` HTTPRoute with no `-internal`
counterpart (e.g. grafana/kube-prometheus-stack, voice-bridge,
flux-webhook, echo, glycemicgpt-bot). After this merges, unifi-dns will stop
publishing any LAN Local DNS Record for those hostnames. Today those
hostnames already resolve to a dangling `external.homelab0.org` CNAME on the
LAN, so removing the local override should let the UDM's normal upstream DNS
forwarding take over for those names on the LAN - most likely fixing (not
breaking) their LAN resolution. Worth spot-checking after merge (see
validation plan).

## Testing

- Local YAML validation only (`python3 -c "import yaml..."`); no
  `kubectl apply` or cluster mutation performed.
- Live read-only diagnostics against the running cluster: `kubectl logs -n
  network <unifi-dns-pod> -c external-dns` confirmed the exact "Only one
  CNAME per name" conflict/flap for overseerr, tautulli, wizarr, bookstack,
  authentik.
- Live read-only `dig` testing (see above) against the k8s-gateway pod,
  ClusterIP, in-cluster CoreDNS stub, the UDM (10.20.65.1), and the
  k8s-gateway LoadBalancer VIP as seen from a LAN-routed client (10.20.67.21)
  to isolate exactly which component serves LAN clients.
- No `kustomize build`/dry-run needed beyond YAML syntax since this is a
  single HelmRelease values addition using an already-precedented key.

## Validation plan (post-merge, for the user to confirm)

After Flux reconciles (`flux logs --kind=HelmRelease --name=unifi-dns
--follow`), test from an actual LAN-connected client (not from inside the
cluster - the whole point is to reproduce what a phone/laptop on WiFi sees):

```
# Should now consistently return ONE CNAME -> internal.homelab0.org -> A 10.20.67.22
dig overseerr.homelab0.org @10.20.65.1
dig tautulli.homelab0.org @10.20.65.1
dig wizarr.homelab0.org @10.20.65.1
dig guides.homelab0.org @10.20.65.1
dig authentik.homelab0.org @10.20.65.1

# Repeat 3-4 times over a few minutes to confirm no more flapping between
# internal.homelab0.org and external.homelab0.org

# Public/Cloudflare access unaffected:
curl -I https://overseerr.homelab0.org   # from off-LAN / via 1.1.1.1 resolver

# Spot-check an external-only app resolves via normal upstream forwarding:
dig grafana.homelab0.org @10.20.65.1
```

`kubectl logs -n network <unifi-dns-pod> -c external-dns` should no longer
show "Only one CNAME per name" warnings for these hostnames, and its sync
policy (`policy: sync`) should prune the now-stale external-target records
it previously pushed within one reconcile interval (5m) - if any hostname
still shows the old dangling answer after ~10 minutes, check the unifi-dns
pod logs for errors pruning the stale UniFi Local DNS Record.

Relates to: DNS split-horizon investigation (dangling CNAME breaks Android
WiFi resolution). Companion PR #1216 adds the missing internal HTTPRoute for
GlycemicGPT (a separate, external-only app) - see that PR for why it is safe
and deterministic once this PR merges.

