### PR TITLE
feat(health/glycemicgpt): add internal HTTPRoutes for LAN split-horizon access

### DIFF
--- a/kubernetes/apps/health/glycemicgpt/app/httproute-api-internal.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/httproute-api-internal.yaml
@@ -1,0 +1,52 @@
+---
+# Internal API routes - LAN/WiFi split-horizon access, NO Authentik forward auth
+# Uses GlycemicGPT's own JWT auth, same as the external API route.
+# This is the path the mobile app hits on WiFi; without it, resolving
+# glycemicgpt.homelab0.org to the internal VIP would 404 (no internal
+# HTTPRoute previously matched /api on envoy-internal).
+# Mirrors kubernetes/apps/health/glycemicgpt/app/httproute-api.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-api-internal
+  namespace: health
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "glycemicgpt.${SECRET_DOMAIN}"
+  rules:
+    # API endpoints - JWT authenticated by GlycemicGPT
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: glycemicgpt-api
+          port: 8000
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Content-Type-Options
+                value: "nosniff"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: Referrer-Policy
+                value: "no-referrer"
+              - name: Content-Security-Policy
+                value: "default-src 'none'; frame-ancestors 'none'"
+              - name: Permissions-Policy
+                value: "geolocation=(), microphone=(), camera=(), payment=()"
+    # Health endpoints - no auth required
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /health
+      backendRefs:
+        - name: glycemicgpt-api
+          port: 8000

--- a/kubernetes/apps/health/glycemicgpt/app/httproute-internal.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/httproute-internal.yaml
@@ -1,0 +1,42 @@
+---
+# Internal HTTPRoute (WebUI) - LAN/WiFi split-horizon access
+# Protected by Authentik forward auth (SecurityPolicy targets this route too)
+# Mirrors kubernetes/apps/media/overseerr/app/httproute-internal.yaml pattern
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-internal
+  namespace: health
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: glycemicgpt.homelab0.org
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "glycemicgpt.${SECRET_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: glycemicgpt-web
+          port: 3000
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: X-Content-Type-Options
+                value: "nosniff"
+              - name: Referrer-Policy
+                value: "strict-origin-when-cross-origin"
+              - name: Content-Security-Policy
+                value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+              - name: Permissions-Policy
+                value: "geolocation=(), microphone=(), camera=(), payment=()"

--- a/kubernetes/apps/health/glycemicgpt/app/httproute-outpost-internal.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/httproute-outpost-internal.yaml
@@ -1,0 +1,40 @@
+---
+# Authentik outpost route (internal gateway) - handles login/callback flow
+# for the internal WebUI route (glycemicgpt-internal). Required because that
+# route is protected by the glycemicgpt-auth SecurityPolicy; without a
+# matching outpost route on envoy-internal, the login redirect would 404 on
+# the LAN VIP (no auth loop protection route on this parentRef).
+# NO SecurityPolicy on this route (would create an auth loop).
+# Mirrors kubernetes/apps/media/wizarr/app/httproute-outpost.yaml (internal)
+# and kubernetes/apps/health/glycemicgpt/app/httproute-outpost.yaml (external)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glycemicgpt-outpost-internal
+  namespace: health
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "glycemicgpt.${SECRET_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io/
+      backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains"
+              - name: X-Frame-Options
+                value: "DENY"
+              - name: X-Content-Type-Options
+                value: "nosniff"

--- a/kubernetes/apps/health/glycemicgpt/app/kustomization.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/kustomization.yaml
@@ -9,5 +9,8 @@ resources:
   - httproute.yaml
   - httproute-api.yaml
   - httproute-outpost.yaml
+  - httproute-internal.yaml
+  - httproute-api-internal.yaml
+  - httproute-outpost-internal.yaml
   - securitypolicy.yaml
   - networkpolicy.yaml

--- a/kubernetes/apps/health/glycemicgpt/app/securitypolicy.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/securitypolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # SecurityPolicy for Authentik forward auth via Envoy ext_authz
-# Attached to the main 'glycemicgpt' HTTPRoute (WebUI only)
+# Attached to the WebUI HTTPRoutes only (external + internal)
 # API routes use GlycemicGPT's own JWT authentication
 # ReferenceGrant in security namespace allows cross-namespace backendRef
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -13,6 +13,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: glycemicgpt
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: glycemicgpt-internal
   extAuth:
     headersToExtAuth:
       - accept


### PR DESCRIPTION
## Summary

Companion to #1215 (unifi-dns internal-gateway scoping). Fixes the diabetes
mobile app failing to reach `https://glycemicgpt.homelab0.org/api/...` on
WiFi ("backend not reachable" / Android DNS "Address Not Found").

**Update:** a concern was raised that giving GlycemicGPT both an internal and
external HTTPRoute would put it in the same "non-deterministic" bucket as
overseerr, risking intermittent (flapping) resolution for a health-data app
- unacceptable for this use case. That concern was investigated directly
against the running cluster (see "Why this is deterministic, not flapping"
below) and is resolved once #1215 merges: the ambiguity is removed
structurally, not just made less likely.

## Root cause

GlycemicGPT is external-only today: `glycemicgpt`, `glycemicgpt-api`, and
`glycemicgpt-outpost` are all parented to `envoy-external`, and there is no
`envoy-internal` HTTPRoute at all. `unifi-dns` (which publishes LAN-facing
"Local DNS Records" into the UniFi UDM - see #1215 for how this was
confirmed to be the actual mechanism LAN/WiFi clients resolve against, not
`k8s-gateway`) currently manages `glycemicgpt.homelab0.org` off the single
`envoy-external`-parented route, pushing a CNAME to `external.homelab0.org`
- out-of-zone for the UDM, hence dangling, hence Android failure. Confirmed
live: `dig glycemicgpt.homelab0.org @10.20.65.1` returns
`CNAME external.homelab0.org` with no A record.

Once #1215 scopes `unifi-dns` to only watch `envoy-internal` HTTPRoutes,
`glycemicgpt.homelab0.org` would simply stop resolving on the LAN entirely
(no record at all, since its only route today is on `envoy-external`) unless
it gets its own internal route - same failure mode for the mobile app, just
NXDOMAIN instead of a dangling CNAME.

## Fix

Add three new HTTPRoutes on `envoy-internal`, mirroring the existing
external ones file-for-file:

| New route | Mirrors | Path | Auth |
|---|---|---|---|
| `glycemicgpt-internal` | `glycemicgpt` | `/` (WebUI) | Authentik (added as 2nd targetRef on existing `glycemicgpt-auth` SecurityPolicy) |
| `glycemicgpt-api-internal` | `glycemicgpt-api` | `/api/*`, `/health` | App's own JWT (unchanged - not in SecurityPolicy, same as external) |
| `glycemicgpt-outpost-internal` | `glycemicgpt-outpost` | `/outpost.goauthentik.io/*` | None (required to avoid auth redirect loop, matches external + wizarr's existing internal/external outpost pair) |

## Why this is deterministic, not flapping

The flapping risk exists specifically in `unifi-dns`'s HTTPRoute-source
resolver: when it watches HTTPRoutes on *both* gateways for the same
hostname (its current, unscoped, unfixed state), it has two candidate CNAME
targets and non-deterministically picks one per sync - proven live via its
own logs ("Only one CNAME per name ... external.homelab0.org and ...
internal.homelab0.org") for overseerr/tautulli/wizarr/bookstack/authentik.

**#1215 removes this ambiguity structurally, not probabilistically.** After
#1215 merges, `unifi-dns` is scoped with `--gateway-name=envoy-internal` and
will no longer even observe HTTPRoutes attached to `envoy-external` - it
literally cannot see `glycemicgpt` (the external WebUI route),
`glycemicgpt-api`, or `glycemicgpt-outpost` anymore. For
`glycemicgpt.homelab0.org`, the *only* HTTPRoute it will ever see is the new
`glycemicgpt-internal` one added in this PR, parented to `envoy-internal`
with target `internal.homelab0.org`. There is no second candidate to race
against, so there is nothing to flap between. This is the same reasoning
that already applies to `homepage.homelab0.org` (internal-route-only today)
which has never shown flapping behavior.

**Merge order matters:** this PR should merge together with or after #1215.
If #1216 merges alone first (before #1215), `unifi-dns` would briefly see
*three* candidate routes for `glycemicgpt.homelab0.org` (the pre-existing
external WebUI/API/outpost routes plus the new internal one) and could flap
during that window. Once #1215 is also merged, the ambiguity is permanently
closed.

## Why nothing is newly exposed

- `/api/*` and `/health` on the internal route are byte-for-byte identical
  in auth posture to the external route - JWT-authenticated by the app
  itself, not covered by Authentik either way.
- The WebUI internal route is explicitly added to the existing
  `glycemicgpt-auth` SecurityPolicy's `targetRefs`, so Authentik
  forward-auth is enforced on the LAN path exactly as it is externally -
  no unauthenticated WebUI access is introduced.
- No NetworkPolicy change: `kubernetes/apps/health/glycemicgpt/app/networkpolicy.yaml`
  already allows ingress from `envoy-internal` on ports 8000/3000 (added
  previously, unrelated to this change).
- No new ReferenceGrant: the existing `security/allow-health-namespace-extauth`
  grant already authorizes any `health`-namespace SecurityPolicy/HTTPRoute
  to reference `authentik-server`, regardless of route name.
- `envoy-internal`'s `https` listener already carries the wildcard
  `homelab0.org` cert (same as `envoy-external`), so no TLS wiring changes
  are needed.

## Testing

- Local YAML validation (`python3 -c "import yaml..."`) on all changed/new
  files.
- `kubectl kustomize kubernetes/apps/health/glycemicgpt/app` (local,
  read-only render, no cluster mutation) confirms all 6 HTTPRoutes and the
  updated SecurityPolicy render correctly with the expected
  `targetRefs`/`backendRefs`.
- Live read-only `dig` testing against the k8s-gateway pod/ClusterIP,
  in-cluster CoreDNS, the UDM, and the k8s-gateway LB VIP from a LAN-routed
  client to determine exactly which component LAN clients actually resolve
  against (see #1215 for the full writeup) - confirmed `unifi-dns`'s Local
  DNS Records, not `k8s-gateway`, are what a phone on WiFi sees.
- No `kubectl apply` performed.

## Validation plan (post-merge, for the user to confirm - after #1215 also merges)

Test from an actual LAN-connected client (reproducing what the mobile app
sees on WiFi), repeated several times to confirm no flapping:

```
# LAN should now resolve to the internal VIP, reliably, every time:
for i in 1 2 3 4 5; do dig +noall +answer glycemicgpt.homelab0.org @10.20.65.1; done
# expect: CNAME internal.homelab0.org -> A 10.20.67.22, identical every run

# WebUI still requires Authentik login on LAN:
curl -I https://glycemicgpt.homelab0.org --resolve glycemicgpt.homelab0.org:443:10.20.67.22 -k
# expect redirect/401 to Authentik, not a direct 200

# API/health reachable without Authentik on LAN (mirrors external behavior):
curl -k https://glycemicgpt.homelab0.org/health --resolve glycemicgpt.homelab0.org:443:10.20.67.22

# Public/Cloudflare path unaffected:
curl -I https://glycemicgpt.homelab0.org   # from off-LAN, real DNS resolution

# Mobile app: connect phone to WiFi, confirm the diabetes app can reach
# https://glycemicgpt.homelab0.org/api/... without "Address Not Found".
```

Relates to: DNS split-horizon investigation (dangling CNAME / missing
internal route breaks Android WiFi resolution). Depends on #1215 merging
first (or concurrently) for the LAN CNAME to resolve deterministically.
