### PR TITLE
fix(network): publish external.homelab0.org LAN-local A record

### DIFF
--- a/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml
@@ -61,8 +61,36 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      # NOTE: external.${SECRET_DOMAIN} DNS is managed by DNSEndpoint (CNAME to tunnel)
-      # Do NOT add external-dns hostname annotation here - it conflicts with tunnel routing
+      # PUBLIC DNS: external.${SECRET_DOMAIN} is managed by the DNSEndpoint in
+      # network/cloudflare-tunnel (CNAME to the Cloudflare tunnel). cloudflare-dns
+      # (the public/Cloudflare external-dns instance) does NOT have "service" in
+      # its `sources` list (only crd + gateway-httproute - see
+      # network/cloudflare-dns/app/helmrelease.yaml), so it never watches this
+      # Service and the hostname annotation below cannot conflict with or
+      # override the public tunnel CNAME.
+      #
+      # LAN DNS (this annotation): unifi-dns DOES have "service" as a source
+      # and has no gateway-name scoping on it, so it publishes a LAN-only
+      # UniFi Local DNS Record: external.${SECRET_DOMAIN} -> A 10.20.67.23
+      # (this Service's real address). This closes a real bug: every
+      # HTTPRoute parented to this Gateway inherits the
+      # `external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}`
+      # annotation above as its CNAME target. On the LAN/UDM resolver,
+      # external.${SECRET_DOMAIN} was previously out-of-zone (Cloudflare-only)
+      # with no local A record, so every external-only app (grafana,
+      # voice-bridge, flux-webhook, ...) and the "losing" side of every
+      # dual-route app's non-deterministic unifi-dns pick resolved to a
+      # dangling CNAME on the LAN - glibc tolerates this (follow-up query
+      # reaches the real public Cloudflare IP and round-trips back through
+      # the tunnel), Android's resolver rejects it outright ("Address Not
+      # Found"). Giving external.${SECRET_DOMAIN} its own complete, LAN-local,
+      # LAN-reachable A record fixes every affected hostname in one place,
+      # and keeps dual-route apps working (and now flap-immune) regardless
+      # of which HTTPRoute unifi-dns's gateway-httproute source currently
+      # prefers, since both candidate targets (internal.${SECRET_DOMAIN} ->
+      # .22, external.${SECRET_DOMAIN} -> .23) are now complete and
+      # LAN-reachable.
+      external-dns.alpha.kubernetes.io/hostname: external.${SECRET_DOMAIN}
       lbipam.cilium.io/ips: "10.20.67.23"
   listeners:
     - name: http


### PR DESCRIPTION
## Summary

Comprehensive fix for LAN/WiFi (specifically Android) DNS resolution failures
across **every** app that has an `envoy-external`-parented HTTPRoute -
external-only apps (grafana, voice-bridge, flux-webhook, glycemicgpt) and the
external side of every dual-route app (overseerr, tautulli, wizarr, bookstack,
authentik). One annotation, one root cause, one fix.

This supersedes the narrower per-provider/per-app approach in #1215/#1216 as
the primary fix - see "Disposition of #1215 and #1216" below.

## Root cause (full chain)

Every HTTPRoute parented to the `envoy-external` Gateway inherits its
`external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}`
annotation as the CNAME target external-dns publishes for that route's
hostname. Two separate external-dns instances read this:

- `cloudflare-dns` publishes it to **public Cloudflare DNS**, where
  `external.homelab0.org` is itself a real CNAME to the Cloudflare tunnel
  (managed by a separate `DNSEndpoint` object) - this works fine, always has.
- `unifi-dns` publishes it to the **UniFi UDM's Local DNS Records** (LAN-only).
  Here, `external.homelab0.org` was **out-of-zone** - the UDM has no local
  record for it, so it's a dangling CNAME (present, but with no A record).

Confirmed live: `dig grafana.homelab0.org @10.20.65.1` (the LAN resolver)
returns only `CNAME external.homelab0.org` - nothing else. glibc-based
resolvers tolerate this (they issue a follow-up query, which happens to
succeed via the UDM's normal internet-DNS forwarding, reaching the real
public Cloudflare IP and round-tripping back in through the tunnel).
Android's resolver rejects the incomplete answer outright ("Address Not
Found"), which is what breaks WiFi access - including the GlycemicGPT mobile
app's `/api` calls.

Dual-route apps (overseerr, tautulli, wizarr, bookstack, authentik) have an
*additional* layer of the same bug: `unifi-dns` has no `--gateway-name`
filter (see #1215), so it also non-deterministically flip-flops between
publishing `internal.homelab0.org` (complete, works) or
`external.homelab0.org` (dangling, was broken) for the same hostname.

## Fix

Add `external-dns.alpha.kubernetes.io/hostname: external.${SECRET_DOMAIN}`
to the `envoy-external` Gateway's `spec.infrastructure.annotations` in
`kubernetes/apps/network/envoy-gateway-config/app/envoy.yaml` - a 1:1 mirror
of the already-working pattern `envoy-internal` already uses for
`internal.${SECRET_DOMAIN}`.

Envoy Gateway propagates `infrastructure.annotations` onto the Gateway's
auto-generated backing Service (verified live by comparing to
`envoy-internal`'s Service, which already carries this exact pattern).
`unifi-dns` (which has `"service"` as a source) picks this up and publishes
a LAN-only UniFi Local DNS Record: `external.homelab0.org -> A 10.20.67.23`
(the Service's real, already-LAN-reachable address).

## Why public/Cloudflare access is preserved

`cloudflare-dns`'s `sources` list is `["crd", "gateway-httproute"]` - it does
**not** include `"service"`. Since the new annotation lives on a Service (via
`infrastructure.annotations` propagation), cloudflare-dns never sees or
processes this Service at all, regardless of its annotations. The public
`external.homelab0.org -> CNAME -> <tunnel-uuid>.cfargotunnel.com` record
continues to come exclusively from the pre-existing `DNSEndpoint` object
(`kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml`) via
cloudflare-dns's `"crd"` source - completely untouched by this change.

## Why no new exposure / auth is preserved

`10.20.67.23` was already directly LAN-routable and already publicly
reachable via the tunnel before this change - this only shortens LAN
clients' resolution path to the same already-reachable endpoint, it doesn't
make anything newly reachable. There is no Cloudflare Access/Zero Trust
layer in this repo (verified via grep) - auth is enforced entirely by
Authentik `SecurityPolicy` at the Envoy Gateway layer, applied identically
whether traffic arrives via `envoy-internal` or `envoy-external` (confirmed
live: `wizarr`, `glycemicgpt` both still return Authentik login redirects
when hit directly on `10.20.67.23`; `glycemicgpt`'s `/health` and `/api/`
paths remain reachable without Authentik, matching their existing external
behavior exactly).

## Full per-hostname resolution matrix (BEFORE / predicted AFTER)

All BEFORE values captured live via `dig <host> @10.20.65.1` (the real LAN
resolver a phone/laptop on WiFi uses). AFTER is the predicted result of this
fix based on the verified mechanism above - **the exact validation commands
below must be re-run against the real LAN resolver after merge and Flux
reconciliation to confirm**, since this PR does not apply anything to the
cluster.

| Hostname | Class | BEFORE (live, today) | AFTER (predicted) |
|---|---|---|---|
| `overseerr.homelab0.org` | dual-route | `CNAME external.homelab0.org` (dangling) | `CNAME external.homelab0.org` -> `A 10.20.67.23` (complete) - or `CNAME internal.homelab0.org` -> `A 10.20.67.22` if unifi-dns's pick flips; either is now complete |
| `tautulli.homelab0.org` | dual-route | `CNAME internal.homelab0.org` -> `A 10.20.67.22` (already worked) | unchanged (still complete); flap-immune now too |
| `wizarr.homelab0.org` | dual-route | `CNAME external.homelab0.org` (dangling) | complete, same flap-immunity as overseerr |
| `guides.homelab0.org` (bookstack) | dual-route | `CNAME external.homelab0.org` (dangling) | complete, flap-immune |
| `authentik.homelab0.org` | dual-route | `CNAME external.homelab0.org` (dangling) | complete, flap-immune |
| `grafana.homelab0.org` | external-only | `CNAME external.homelab0.org` (dangling) | `CNAME external.homelab0.org` -> `A 10.20.67.23` (complete) |
| `voice-bridge.homelab0.org` | external-only | `CNAME external.homelab0.org` (dangling) | complete |
| `flux-webhook.homelab0.org` | external-only | `CNAME external.homelab0.org` (dangling) | complete |
| `media-status.homelab0.org` (uptime-kuma) | external-only | `CNAME external.homelab0.org` (dangling) | complete (bonus fix, not originally called out but same class) |
| `glycemicgpt.homelab0.org` | external-only | `CNAME external.homelab0.org` (dangling) | complete; `/api` and `/health` confirmed reachable without Authentik interception when hit directly on `.23` (see below) |
| `homepage.homelab0.org` | internal-only (control) | `CNAME internal.homelab0.org` -> `A 10.20.67.22` | unchanged - must stay working |
| `discord.glycemicgpt.org` (glycemicgpt-bot) | external-only, **different zone** | Already resolves cleanly: real Cloudflare `A` records (`104.21.72.15`, `172.67.173.190`) | unchanged - **correction**: this hostname is in the `glycemicgpt.org` zone, which is outside `unifi-dns`'s `domainFilters: [homelab0.org]`. It was never affected by the split-horizon bug at all - it already falls through the UDM's normal internet-DNS forwarding today. No fix needed or applied here. |
| `external.homelab0.org` (the target itself) | n/a | Already resolves via normal internet forwarding to the real public Cloudflare edge (`172.67.202.31`, `104.21.60.233`) - this is *why* glibc clients "work" today (double hop through the internet and back through the tunnel) | `A 10.20.67.23` directly on the LAN (shortens the path to the same backend, no double hop) |

## Live pre-checks already performed (read-only, no cluster mutation)

```
# Confirms envoy-external VIP already serves these apps correctly with proper auth posture
curl -sk --resolve overseerr.homelab0.org:443:10.20.67.23 https://overseerr.homelab0.org/        -> 307
curl -sk --resolve grafana.homelab0.org:443:10.20.67.23 https://grafana.homelab0.org/            -> 302 (login redirect)
curl -sk --resolve glycemicgpt.homelab0.org:443:10.20.67.23 https://glycemicgpt.homelab0.org/    -> 302 (Authentik redirect - WebUI still protected)
curl -sk --resolve glycemicgpt.homelab0.org:443:10.20.67.23 https://glycemicgpt.homelab0.org/health -> 200 (no auth, as designed)
curl -sk --resolve glycemicgpt.homelab0.org:443:10.20.67.23 https://glycemicgpt.homelab0.org/api/   -> 404 (reachable, app-level 404 for bare path, NOT an auth redirect - confirms Authentik bypass preserved)
curl -sk --resolve wizarr.homelab0.org:443:10.20.67.23 https://wizarr.homelab0.org/               -> 302 (Authentik redirect)
curl -sk --resolve voice-bridge.homelab0.org:443:10.20.67.23 https://voice-bridge.homelab0.org/   -> 404 (reachable, app-level)
```

## Disposition of #1215 and #1216

- **#1215** (scope `unifi-dns` to `--gateway-name=envoy-internal`): **keeping
  as-is**, still valid and complementary. It fixes the actual non-determinism
  at its source (unifi-dns should never have been able to see
  `envoy-external` routes in the first place) and further reduces log noise/
  flapping. It is no longer *strictly required* to fix the Android bug once
  this PR merges (both candidate answers for dual-route apps are now
  complete and LAN-reachable either way), but there's no reason to discard a
  correct, already-reviewed, defense-in-depth improvement. No changes made
  to that PR's diff.
- **#1216** (add internal HTTPRoutes to GlycemicGPT): **closing**, superseded
  by this fix. This PR makes `glycemicgpt.homelab0.org` fully LAN-reachable
  (WebUI still Authentik-protected, `/api`/`/health` still bypass Authentik
  exactly as they do externally - confirmed live above) **without adding any
  new HTTPRoute, SecurityPolicy targetRef, or attack surface** to a
  health-data app. Given the user's explicit caution about GlycemicGPT, this
  is strictly lower-risk than #1216's approach for an identical outcome, so
  #1216 will be closed with an explanation rather than merged.

## Correction to the original bug list

`glycemicgpt-bot` (Discord bot) was included in the original list of
apps needing this fix. Investigation found this to be based on an incorrect
assumption: its HTTPRoutes (`discord.glycemicgpt.org`, `verify.glycemicgpt.org`)
are in the `glycemicgpt.org` zone, not `homelab0.org`, and `unifi-dns`'s
`domainFilters` is `[homelab0.org]` only - this app was **never** in the
split-horizon path and already resolves cleanly on the LAN today (confirmed
live, real Cloudflare A records returned, no dangling CNAME). No fix needed
or applied for it.

## Testing

- Local YAML validation (`python3 -c "import yaml..."`).
- `kubectl kustomize kubernetes/apps/network/envoy-gateway-config/app` (local,
  read-only render) confirms `envoy-external` and `envoy-internal` now
  produce structurally identical `infrastructure.annotations` shapes.
- Live read-only `dig`/`curl` testing against the real LAN resolver
  (`10.20.65.1`) and the `envoy-external` VIP (`10.20.67.23`) directly, for
  every hostname in the matrix above, to establish accurate BEFORE state and
  confirm the target backend already serves correctly with the right auth
  posture.
- No `kubectl apply` performed at any point.

## Validation plan (post-merge, for the user to confirm - run from a REAL LAN client, not in-cluster)

```
# Repeat each ~20x over a few minutes to confirm a stable, complete answer with no flap:
for i in $(seq 1 20); do dig +noall +answer overseerr.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer grafana.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer glycemicgpt.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer voice-bridge.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer guides.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer authentik.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer wizarr.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer tautulli.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer flux-webhook.homelab0.org @10.20.65.1; done
for i in $(seq 1 20); do dig +noall +answer media-status.homelab0.org @10.20.65.1; done

# Control - must remain unaffected:
dig +noall +answer homepage.homelab0.org @10.20.65.1

# Public/Cloudflare path unaffected (query a public resolver, not the LAN one):
dig +noall +answer overseerr.homelab0.org @1.1.1.1
dig +noall +answer external.homelab0.org @1.1.1.1
curl -I https://overseerr.homelab0.org      # from off-LAN or via a public resolver

# GlycemicGPT mobile app path specifically:
curl -k https://glycemicgpt.homelab0.org/health   # from a LAN/WiFi client, expect 200
# then: connect phone to WiFi, confirm the GlycemicGPT app can reach
# https://glycemicgpt.homelab0.org/api/... without "Address Not Found".
```

Relates to: DNS split-horizon investigation (dangling CNAME breaks Android
WiFi resolution for external-only and dual-route apps). Supersedes #1216
(closed); complements #1215 (kept, no longer strictly required but still
correct).
