### PR TITLE
fix(ai/litellm): stop default-on guardrails from blocking local models

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -237,28 +237,71 @@ data:
     # Config here serves as bootstrap/fallback definition
     # Primary management: LiteLLM UI > Guardrails page
     # Reference: https://docs.litellm.ai/docs/proxy/guardrails/quick_start
+    #
+    # STORY: Local KServe models / Claude Code must bypass guardrails
+    # ------------------------------------------------------------------
+    # Both guardrails were previously `default_on: true`, meaning they ran
+    # on EVERY request (pre_call/during_call) with no way to exempt local
+    # KServe models. When the OpenAI account backing "openai-mod" hit its
+    # rate limit, the pre_call moderation check 429'd on every single
+    # request - including calls to fully self-hosted models (qwen36-27b,
+    # qwen-coder, dolphin-chat, etc.) and Claude Code - because pre_call
+    # guardrails run BEFORE routing decides which model to call.
+    #
+    # Per LiteLLM docs (https://docs.litellm.ai/docs/proxy/guardrails/quick_start):
+    #   "default_on: true ... will run even if user specifies a different
+    #    guardrail or empty guardrails array" - i.e. default_on guardrails
+    #   CANNOT be excluded per-request, per-model, or per-key while
+    #   default_on remains true.
+    #
+    # The only per-model (`model_list[].litellm_params.guardrails`) and
+    # per-virtual-key (`/key/generate` `guardrails` field) scoping
+    # mechanisms are Enterprise-only features (confirmed in the same doc
+    # under "Model-level Guardrails" and "Control Guardrails per API Key" -
+    # both flagged "Enterprise only feature"). We run the OSS
+    # litellm-database image with no LiteLLM Enterprise license, so those
+    # mechanisms are not available to us.
+    #
+    # Chosen fix: flip both guardrails to `default_on: false`. They stay
+    # fully defined/enabled (API keys, mode, provider all intact) and can
+    # still be enforced by ANY caller - local or external - by explicitly
+    # requesting them per-call, which IS a base OSS feature:
+    #
+    #   curl http://litellm.../v1/chat/completions \
+    #     -d '{"model": "gpt-4", "messages": [...], \
+    #          "guardrails": ["openai-mod", "lakera-guard"]}'
+    #
+    # KServe local models and Claude Code never set this field, so they
+    # bypass both guardrails entirely (no OpenAI moderation call, no
+    # Lakera call). Any future public-facing / external-model route can
+    # opt back in by adding the "guardrails" field to its requests.
     # =====================================================
     guardrails:
       # Lakera AI - Prompt injection detection
       # Uses lakera_v2 API (not lakera_prompt_injection)
-      # default_on: true runs on ALL requests automatically
+      # default_on: false - no longer runs automatically on every request.
+      # Opt in per-request with "guardrails": ["lakera-guard"].
       # Reference: https://docs.litellm.ai/docs/proxy/guardrails/lakera_ai
       - guardrail_name: "lakera-guard"
         litellm_params:
           guardrail: lakera_v2
           mode: "during_call"
-          default_on: true
+          default_on: false
           api_key: os.environ/LAKERA_API_KEY
           api_base: "https://api.lakera.ai"
 
       # OpenAI Moderation - Content policy compliance (free)
-      # default_on: true runs on ALL requests automatically
+      # default_on: false - no longer runs automatically on every request.
+      # This was the guardrail 429'ing on every call once the OpenAI
+      # account hit its moderation rate limit, blocking ALL completions
+      # (including local KServe models) before routing. Opt in per-request
+      # with "guardrails": ["openai-mod"] for public/external model usage.
       # Reference: https://docs.litellm.ai/docs/proxy/guardrails/openai_moderation
       - guardrail_name: "openai-mod"
         litellm_params:
           guardrail: openai_moderation
           mode: "pre_call"
-          default_on: true
+          default_on: false
           api_key: os.environ/OPENAI_API_KEY
 
     general_settings:

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -57,6 +57,10 @@ spec:
       security.homelab/purpose: "OpenAI-compatible API gateway for Ollama"
       # Restart pods when any ExternalSecret-backed secret is updated
       secret.reloader.stakater.com/reload: "litellm-masterkey,litellm-oidc,litellm-openai,litellm-graphiti-mcp,litellm-n8n-mcp,firecrawl-secrets,litellm-valkey,litellm-lakera"
+      # config.yaml is mounted via subPath (see proxyConfigMap below), so it does NOT
+      # auto-propagate or auto-restart on ConfigMap changes by default. Reloader watches
+      # the litellm-config ConfigMap and restarts the pod whenever it changes.
+      configmap.reloader.stakater.com/reload: "litellm-config"
 
     # Pod security context
     # Note: litellm-database image specifies USER as text "root" in Dockerfile,


### PR DESCRIPTION
## Summary

LiteLLM's two configured guardrails (`lakera-guard`, `openai-mod`) were both `default_on: true`, meaning they ran on every single request - including calls to fully self-hosted KServe models (qwen36-27b, qwen-coder, dolphin-chat, etc.) and Claude Code traffic that never touches OpenAI or Lakera at all.

When the OpenAI account backing `openai-mod` started returning 429 (rate-limited/out of quota) from `/v1/moderations`, the pre_call guardrail blocked **all** LiteLLM completions cluster-wide, since pre_call guardrails run before the router even picks a model. Verified: 3/3 requests to `qwen36-27b` 429'd against `api.openai.com/v1/moderations` with no model pod ever spinning up.

## Why this approach

Per LiteLLM's guardrails docs (https://docs.litellm.ai/docs/proxy/guardrails/quick_start):

> `default_on: true` ... "will run even if user specifies a different guardrail or empty guardrails array"

So a `default_on: true` guardrail cannot be scoped out per-request while it stays `default_on`. The two documented mechanisms that *could* exclude specific models/keys are both explicitly flagged **"Enterprise only feature"** in the same docs:
- Per-model guardrails (`model_list[].litellm_params.guardrails`)
- Per-virtual-key guardrails (`/key/generate` `guardrails` field)

We run the OSS `litellm-database` image with no LiteLLM Enterprise license, so neither is available to us.

**Chosen fix**: flip both guardrails to `default_on: false`. Nothing about the guardrail definitions is removed - same provider, same mode, same `api_key: os.environ/...` references. They become **opt-in per request** instead of automatic, which *is* a base OSS feature:

```
curl http://litellm.../v1/chat/completions \
  -d '{"model": "gpt-4", "messages": [...], "guardrails": ["openai-mod", "lakera-guard"]}'
```

Local KServe models and Claude Code never set this field, so they bypass both guardrails going forward. Any future public-facing or external-model route can opt back in by adding the `guardrails` field to its requests.

**Important caveat to call out explicitly**: today, *no* caller in this repo sets the `guardrails` request field (verified via grep across `kubernetes/`), so the practical effect of this change is that guardrails are now off for 100% of current traffic, not "on for external, off for local." If/when a public-facing route is added, its requests need to explicitly pass `"guardrails": [...]` for moderation/prompt-injection checks to apply to it.

## Changes

- `kubernetes/apps/ai/litellm/app/configmap.yaml`: `default_on: true` → `false` for both `lakera-guard` and `openai-mod`, plus explanatory comments documenting the mechanism and the Enterprise-only alternatives that were ruled out.
- `kubernetes/apps/ai/litellm/app/helmrelease.yaml`: added `configmap.reloader.stakater.com/reload: "litellm-config"` pod annotation (same pattern as `authentik` and `toolhive-registry` in this repo). `config.yaml` is mounted via `subPath`, so ConfigMap edits do not auto-propagate or restart the pod without Reloader watching it.

## Manual restart needed after merge?

**No manual restart required for this specific merge.** Adding the `configmap.reloader.stakater.com/reload` annotation itself changes the pod template (`podAnnotations`), which triggers a normal Kubernetes rollout as soon as Flux applies the updated HelmRelease - independent of Reloader. That new pod will read the already-updated ConfigMap at startup via the subPath mount.

For any *future* config-only changes that don't also touch pod annotations, Reloader will now detect the ConfigMap hash change and roll the deployment automatically - no more manual `kubectl rollout restart` needed going forward.

## Validation performed

- YAML parsed and validated locally (both files parse cleanly; the embedded `config.yaml` block also parses as valid YAML with the expected `guardrails` structure).
- Confirmed via a read-only call to the running proxy's `/guardrails/list` endpoint that both guardrails currently report `"guardrail_definition_location": "config"` (not `"db"`), meaning there is no pre-existing database record that would override or ignore this ConfigMap change on restart.
- Confirmed Stakater Reloader is running cluster-wide (`kube-system/reloader`, long-running) and that the `configmap.reloader.stakater.com/reload` pattern is already used successfully elsewhere in this repo.
- Confirmed via grep that no current component in the repo passes a `guardrails` field on requests, so this change fully unblocks local-model traffic without any other code path being affected.
- security-guardian review: **PASS** - no secrets/credentials touched, diff scope limited to the two `default_on` flags plus the one new annotation, Reloader annotation matches the ConfigMap name correctly, no residual always-on protection (PII masking, etc.) exists elsewhere in this config.

## Post-merge test plan (for maintainer to run/confirm)

- [ ] Confirm the litellm pod rolled to a new pod after merge (`kubectl get pods -n ai -l app.kubernetes.io/name=litellm`)
- [ ] Send a completion request to `qwen36-27b` and confirm it succeeds without any call to `api.openai.com/v1/moderations` (no 429, normal cold-start/response behavior)
- [ ] Optionally confirm a request with `"guardrails": ["openai-mod"]` explicitly set still enforces the OpenAI moderation check (i.e. the guardrail is still fully functional, just no longer automatic) - expect this to still surface the underlying OpenAI 429 until that account's quota/rate-limit is resolved separately
- [ ] Check the LiteLLM UI Guardrails page shows `default_on` as off for both entries, consistent with the ConfigMap

## Notes

Does not touch the OpenAI API key/account - moderation capability is intentionally kept available for future public/external usage, just no longer automatic on the hot path for local models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guardrails can now be enabled selectively per request instead of running automatically for every request.
  * Local model and Claude Code requests can bypass guardrails unless explicitly opted in.

* **Bug Fixes**
  * Prevented guardrails from running before request routing, improving compatibility with supported model workflows.
  * Configuration updates now automatically trigger service restarts so changes are applied reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->