### PR TITLE
feat(ai/kserve): extend qwen36-27b scale-to-zero retention to 30m

### DIFF
--- a/kubernetes/apps/ai/kserve/app/qwen36-27b-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen36-27b-inferenceservice.yaml
@@ -18,7 +18,10 @@
 # Performance expectations (extrapolated from 3090/4090 community reports):
 # - Cold start: ~120-180s (17.9GB single file from CephFS is the bottleneck)
 # - Decode: ~35-40 t/s baseline, ~55-70 t/s with MTP accepted drafts
-# - Scale-to-zero: 5 minutes idle timeout (global Knative config)
+# - Scale-to-zero: 30 minute idle retention (predictor-level override below;
+#   cluster-wide Knative default is 5 min - see kubernetes/apps/kube-system/
+#   knative-serving/app/kustomization.yaml). Still minReplicas=0 (GPU freed
+#   when idle), just stays warm longer to survive gaps in a coding session.
 # - Single GPU: maxReplicas=1 enforced (only 1 RTX A5000 available)
 #
 # Usage:
@@ -47,6 +50,27 @@ spec:
     # Scale-to-zero configuration (Knative Serving)
     minReplicas: 0  # Enable scale-to-zero (GPU freed when idle)
     maxReplicas: 1  # Single GPU workload - only 1 pod can run at a time
+
+    # Predictor-level Knative autoscaling override: this component (and only
+    # this component) stays warm for 30 minutes after the last request before
+    # scaling to zero, instead of the cluster-wide 5 minute default in
+    # kubernetes/apps/kube-system/knative-serving/app/kustomization.yaml
+    # (config-autoscaler: scale-to-zero-pod-retention-period=5m). Placed here
+    # (spec.predictor.annotations) rather than top-level metadata.annotations
+    # so it only affects this InferenceService's predictor Knative Revision -
+    # KServe merges isvc-level and predictor-level annotations (predictor
+    # wins) into the Revision template before handing off to Knative; this
+    # key is not in KServe's serviceAnnotationDisallowedList so it propagates
+    # untouched. The per-revision value overrides (does not get clamped by)
+    # the global config-autoscaler default; the effective idle window is
+    # max(scale-to-zero-grace-period, scale-to-zero-pod-retention-period),
+    # so this cleanly wins over the 5m cluster grace period too.
+    # Used interactively from Claude Code/BMad on a dev VM - cold start is
+    # ~120-180s (17.9GB model), so keeping it warm ~30m avoids re-paying that
+    # cost on every gap in a coding session while still freeing the GPU when
+    # truly idle.
+    annotations:
+      autoscaling.knative.dev/scale-to-zero-pod-retention-period: "30m"
 
     # CRITICAL: GPU and Node Targeting
     # Target ONLY k8s-work-10 (RTX A5000 24GB)


### PR DESCRIPTION
## Summary

Give the `qwen36-27b` KServe InferenceService a longer scale-to-zero idle
window so its predictor pod stays warm for 30 minutes after the last
request instead of the cluster-wide 5 minute default, without disabling
scale-to-zero (minReplicas stays 0).

## Why

`qwen36-27b` is a 17.9GB GGUF model loaded from CephFS with a ~120-180s
cold start. It's used interactively from Claude Code/BMad on a dev VM, so
gaps of a few minutes between requests during a coding session were
repeatedly forcing a full reload. A longer idle retention avoids that
while still freeing the GPU once the model is truly idle.

## Changes

- `kubernetes/apps/ai/kserve/app/qwen36-27b-inferenceservice.yaml`:
  - Added `spec.predictor.annotations` with
    `autoscaling.knative.dev/scale-to-zero-pod-retention-period: "30m"`.
  - Updated the header comment describing scale-to-zero behavior.

No other InferenceService and no global Knative/KServe config
(`config-autoscaler`, etc.) is touched - this is scoped entirely to this
one model's predictor.

## Mechanism / verification

- Annotation key confirmed against Knative Serving source
  (`ScaleToZeroPodRetentionPeriodKey` in
  `pkg/apis/autoscaling/register.go`):
  `autoscaling.knative.dev/scale-to-zero-pod-retention-period`.
- Placement confirmed against KServe source
  (`pkg/controller/v1beta1/inferenceservice/components/predictor.go`,
  `pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go`):
  KServe unions InferenceService-level and `spec.predictor.annotations`
  (predictor wins on conflict) and copies the result onto the Knative
  Revision template's annotations. `spec.predictor.annotations` scopes the
  override to this component only.
- Confirmed this key is **not** in KServe's default
  `serviceAnnotationDisallowedList` (`min-scale`, `max-scale`,
  `internal.serving.kserve.io/storage-initializer-sourceuri`,
  `kubectl.kubernetes.io/last-applied-configuration`, `modelFormat`), so it
  propagates to the Revision untouched. Verified live cluster
  `inferenceservice-config` ConfigMap has no local override of that list.
- Inspected the live `config-autoscaler` ConfigMap in `knative-serving`:
  this cluster runs `scale-to-zero-grace-period: 5m` and
  `scale-to-zero-pod-retention-period: 5m` globally (matches
  `kubernetes/apps/kube-system/knative-serving/app/kustomization.yaml`).
  Per-revision annotations **override**, not clamp, the global default -
  there is no documented/coded maximum in Knative. The effective idle
  window is `max(grace-period, retention-period)`, so a 30m per-revision
  retention override cleanly dominates the 5m global grace period. No
  global config change is required or made.
- Validated with `kubectl apply --dry-run=client` against the live CRD
  schema (read-only, no cluster mutation).

## Testing Plan

- [x] YAML syntax + CRD schema validated locally (`kubectl apply
      --dry-run=client`, read-only)
- [ ] After merge, Flux reconciles the InferenceService
- [ ] Hit `qwen36-27b`, confirm the predictor pod is `Running`
- [ ] Stop sending traffic, confirm the pod stays `Running` for ~30
      minutes then scales to zero (`kubectl get ksvc -n ai
      qwen36-27b-predictor` / `kubectl get pods -n ai -w`)
- [ ] Confirm the other InferenceServices in `ai` namespace (qwen-coder,
      dolphin-chat, flux-klein, hermes-jarvis, etc.) still scale to zero on
      the unchanged 5 minute default

## Security Review

- [x] security-guardian reviewed the staged diff - PASS, no findings
      (single file, comments + one annotation, no secrets, no
      RBAC/NetworkPolicy/securityContext changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Qwen 3.6 27B inference service to keep its model pod warm for up to 30 minutes after inactivity.
  * Added documentation clarifying the service-specific scale-to-zero behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->