### PR TITLE
feat(network): install agentgateway as additional GatewayClass

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -353,6 +353,14 @@
       ]
     },
     {
+      "description": "FULLY MANUAL: agentgateway — no automerge for any update type (all CRDs are v1alpha1 with real breaking changes on a monthly cadence; version pin is load-bearing on the cluster's Gateway API CRD version, see WI-034-1-version-decision.md — every bump needs a release-note read before merge, not just a soak window)",
+      "matchDatasources": ["docker", "helm"],
+      "automerge": false,
+      "matchPackageNames": [
+        "/agentgateway/"
+      ]
+    },
+    {
       "description": "Require manual review for critical-infra minor and major (cert-manager, cilium, external-secrets, cloudnative-pg)",
       "matchDatasources": ["docker", "helm"],
       "automerge": false,

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -52,6 +52,13 @@
       "separateMinorPatch": true
     },
     {
+      "description": "Network - agentgateway (v1alpha1 CRDs, release-note review required - see autoMerge.json5)",
+      "groupName": "🌐 Network: agentgateway",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": ["agentgateway"],
+      "separateMinorPatch": true
+    },
+    {
       "description": "Network - Cloudflare (Tunnel & DNS)",
       "groupName": "🌐 Network: Cloudflare",
       "matchDatasources": ["docker"],

--- a/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
@@ -29,7 +29,15 @@ spec:
       port: 443
       allowedRoutes:
         namespaces:
-          from: All
+          # Deliberately NOT "from: All" (unlike the envoy Gateways): this
+          # Gateway carries the AI/MCP auth perimeter (EPIC-034), so route
+          # attachment is restricted to the namespaces that own that traffic.
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values: ["ai", "mcp", "network"]
       tls:
         certificateRefs:
           - kind: Secret

--- a/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
@@ -1,0 +1,36 @@
+---
+# GatewayClass "agentgateway" is created automatically by the agentgateway
+# control-plane chart (agentgateway-operator) - it is NOT declared here.
+# This is the third GatewayClass in the cluster, alongside "envoy" and
+# "cilium" (EPIC-034 R6): non-AI ingress stays on Envoy Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway
+spec:
+  gatewayClassName: agentgateway
+  infrastructure:
+    annotations:
+      # LAN-only VIP from the shared Cilium LBIPAM pool (10.20.66.0/23).
+      # No external-dns hostname annotation: this Gateway must stay off
+      # both cloudflare-dns (public) and unifi-dns (LAN record) until a
+      # later story explicitly publishes it (EPIC-034 non-negotiable #2 -
+      # private by default, reached via WireGuard, no public tunnel hostname).
+      lbipam.cilium.io/ips: "10.20.67.27"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: homelab0-org-production-tls

--- a/kubernetes/apps/network/agentgateway-config/app/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gateway.yaml

--- a/kubernetes/apps/network/agentgateway-config/ks.yaml
+++ b/kubernetes/apps/network/agentgateway-config/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-config
+spec:
+  dependsOn:
+    - name: agentgateway-operator
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/network/agentgateway-config/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: false

--- a/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentgateway-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: agentgateway-crds
+  interval: 1h
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentgateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: agentgateway
+  dependsOn:
+    - name: agentgateway-crds
+      namespace: network
+  interval: 1h

--- a/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
@@ -25,3 +25,10 @@ spec:
     - name: agentgateway-crds
       namespace: network
   interval: 1h
+  values:
+    # kube-prometheus-stack selects ALL ServiceMonitors cluster-wide
+    # (serviceMonitorSelectorNilUsesHelmValues: false, no label scoping -
+    # see observability/kube-prometheus-stack/app/helmrelease.yaml:64), so
+    # no extra release-label matching is needed here.
+    monitoring:
+      enabled: true

--- a/kubernetes/apps/network/agentgateway-operator/app/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/agentgateway-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/ocirepository.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentgateway-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway-crds
+  # NOTE: agentgateway tags carry a leading "v" (v1.3.1), unlike envoy-gateway's
+  # bare "1.5.3" - do not strip it, the OCI registry only serves v-prefixed tags.
+  # PINNED to the 1.3.x line: cluster Gateway API CRDs are bundle v1.3.0
+  # (owned by envoy-gateway-operator, see envoy-gateway-operator/app/ocirepository.yaml)
+  # and agentgateway 1.4.x requires Gateway API 1.4-1.6 - see
+  # .claude/.ai-docs/stories/WI-034-1-version-decision.md for the full evidence trail.
+  # Renovate will still propose 1.4.x/1.5.x bumps; they must NOT be merged until a
+  # separate Gateway API CRD upgrade story lands (see autoMerge.json5 manual-review rule).
+  ref:
+    tag: v1.3.1
+  url: oci://cr.agentgateway.dev/charts/agentgateway-crds
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentgateway
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway
+  # See agentgateway-crds OCIRepository above for the version-pin rationale.
+  ref:
+    tag: v1.3.1
+  url: oci://cr.agentgateway.dev/charts/agentgateway

--- a/kubernetes/apps/network/agentgateway-operator/ks.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-operator
+spec:
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: agentgateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/network/agentgateway-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+  timeout: 15m

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway-operator/ks.yaml
   - ./envoy-gateway-config/ks.yaml
+  - ./agentgateway-operator/ks.yaml
+  - ./agentgateway-config/ks.yaml
   - ./k8s-gateway/ks.yaml
   - ./wireguard-gateway/ks.yaml
   - ./network-attachments/ks.yaml


### PR DESCRIPTION
## Summary
Installs agentgateway (OSS) as a third Kubernetes Gateway API GatewayClass, alongside the existing `envoy` and `cilium` classes. This is EPIC-034 Story 34.1 (Phase 0 spike, P0-0) — a reversible, zero-consumer-impact install with no existing routes or ingress touched.

## Version-path decision
Pinned agentgateway `v1.3.1` on the cluster's existing Gateway API v1.3.0 CRD bundle, instead of the prerequisite chain (Envoy Gateway ≥1.8 + Gateway API CRDs → v1.6 + Cilium tolerance verification), which would touch all cluster ingress for no benefit this story needs.

Evidence gathered against live cluster state and upstream release notes/CRD manifests (not just docs pages, which are known to straddle versions):
- Live cluster Gateway API CRD bundle confirmed `v1.3.0` (owned by the envoy-gateway-operator chart).
- Upstream support matrix: agentgateway 1.3.x supports Gateway API 1.3–1.5; 1.4.x requires 1.4–1.6 (incompatible with today's CRDs).
- Cross-checked a doc/release-note discrepancy: v1.3.0's release notes mention a Gateway API client-library bump to v1.6.0-rc.1 (PR #2165). Inspected the actual PR diff — it's a Go dependency/schema-doc update, not a hard CRD version gate in controller logic. No related compatibility issues found in upstream issues.
- Confirmed at the pinned tag (v1.3.1) that all CRD/policy surfaces this epic depends on exist: `AgentgatewayBackend`, `AgentgatewayPolicy` (jwtAuthentication, apiKeyAuthentication), `AgentgatewayParameters.rawConfig`, MCP static targets.

Full evidence trail: `.claude/.ai-docs/stories/WI-034-1-version-decision.md` (local, not committed — see file-organization policy).

## Changes
- `kubernetes/apps/network/agentgateway-operator/`: OCIRepository + HelmRelease pair for the `agentgateway-crds` and `agentgateway` charts (`oci://cr.agentgateway.dev/charts/*:v1.3.1`)
- `kubernetes/apps/network/agentgateway-config/`: one LAN-only `Gateway` (`gatewayClassName: agentgateway`), Cilium LBIPAM VIP `10.20.67.27` (free address in the existing `10.20.66.0/23` pool), no public DNS or external-dns annotations
- `kubernetes/apps/network/kustomization.yaml`: wires both new Kustomizations into the network app group
- `.github/renovate/autoMerge.json5`, `.github/renovate/groups.json5`: agentgateway added to fully-manual-review tier (all CRDs are v1alpha1, monthly breaking-change cadence) with a matching dashboard group, mirroring the existing envoy-gateway rule

## Testing
- [x] `kubectl kustomize` builds clean for both new app dirs and the full `network` kustomization
- [x] VIP collision-checked against every existing `lbipam.cilium.io/ips` value in the repo and live LoadBalancer services
- [x] security-guardian review: approved, no findings
- [ ] Post-merge (PM/Josh, not this session): `kubectl get gatewayclass` shows `agentgateway` Accepted; controller + proxy Deployment Running; existing envoy-internal/external routes still serve

## Security Review
- [x] security-guardian approval received — no plaintext secrets, no public exposure, no RBAC changes, no IP collision
- [x] No secrets in this PR body

## Notes
Relates to EPIC-034 Story 34.1. Hard constraints respected: no changes to cloudflare-dns, cloudflare-tunnel, or envoy-external; no changes to existing Gateways/HTTPRoutes; GitOps only, no `kubectl apply`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agent Gateway infrastructure and configuration to the network environment.
  * Enabled HTTP and HTTPS routing with TLS termination and LAN-only access.
  * Added support for same-namespace HTTP routes and cross-namespace HTTPS routes.
  * Configured automated reconciliation and health checks for the gateway components.

* **Chores**
  * Grouped Agent Gateway updates for easier maintenance.
  * Required manual review for related container and Helm updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->