### PR TITLE
fix(network): rename agentgateway Gateway to avoid controller name collision

### DIFF
--- a/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/gateway.yaml
@@ -6,7 +6,12 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: agentgateway
+  # This name must NEVER be "agentgateway": the agentgateway deployer names
+  # per-Gateway proxy Deployment/Service resources after the Gateway, which
+  # collides with the controller chart's own Deployment/Service in this
+  # namespace (post-merge incident, 2026-08-01 - the proxy data plane was
+  # never created and the controller's own Service got mutated).
+  name: ai-gateway
 spec:
   gatewayClassName: agentgateway
   infrastructure:

--- a/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
@@ -25,6 +25,13 @@ spec:
     - name: agentgateway-crds
       namespace: network
   interval: 1h
+  # The old "agentgateway"-named Gateway (fixed in this same change) caused
+  # the deployer to merge its per-Gateway proxy Service into this chart's own
+  # controller Service; drift detection makes Helm actively restore any such
+  # out-of-band mutation instead of silently drifting (post-merge incident,
+  # 2026-08-01).
+  driftDetection:
+    mode: enabled
   values:
     # kube-prometheus-stack selects ALL ServiceMonitors cluster-wide
     # (serviceMonitorSelectorNilUsesHelmValues: false, no label scoping -


### PR DESCRIPTION
## Summary
Post-merge incident fix for EPIC-034 Story 34.1 (PR #1221, merged as `02be1b3`). The Gateway object was named `agentgateway` — the same name as the agentgateway Helm chart's own controller Deployment/Service in the `network` namespace. The agentgateway deployer names per-Gateway proxy Deployment/Service resources after the Gateway, so this collided with the controller's own resources.

## Root cause
Controller logs showed a retry loop: `failed to apply object apps/v1, Kind=Deployment network/agentgateway ... spec.selector: field is immutable`. The proxy data plane was never created, and the deployer also merged the per-Gateway proxy Service's listeners (80/443) and gateway-name selector into the chart's own controller Service.

## Changes
- `kubernetes/apps/network/agentgateway-config/app/gateway.yaml`: rename the Gateway from `agentgateway` to `ai-gateway`. `gatewayClassName`, VIP annotation, listeners, namespace selector, and TLS `secretRef` are unchanged.
- `kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml`: add `driftDetection.mode: enabled` to the `agentgateway` controller HelmRelease, so Helm actively restores any future out-of-band mutation of its chart-managed resources (like the Service that got clobbered in this incident) instead of silently drifting.

## Testing
- [x] `kubectl kustomize` renders both changed app dirs clean
- [x] Repo-wide grep confirms no HTTPRoute or other manifest references the old Gateway name (none exist yet - no routes attach to this Gateway per Story 34.1 scope)
- [x] security-guardian review: approved, no findings

## Security Review
- [x] security-guardian approval received - rename introduces no new exposure (same VIP, same LAN-only posture, same TLS secret reference, same namespace selector); `driftDetection.mode: enabled` confirmed as a genuine Flux HelmRelease v2 field, no `force` alongside it
- [x] No secrets in this PR body

## Notes
Relates to EPIC-034 Story 34.1. Fixes the post-merge defect found in PM validation of PR #1221.