### PR TITLE
fix(network,ai): request-log PVC write access + agentgateway-pilot SOPS decryption

### DIFF
--- a/kubernetes/apps/ai/agentgateway-pilot/ks.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/ks.yaml
@@ -17,7 +17,12 @@ spec:
     namespace: flux-system
   targetNamespace: ai
   wait: false
+  # No explicit secretRef: the ai/ tree's namespace: ai kustomize transform
+  # places this Kustomization CR in ns ai, but sops-age only exists in
+  # flux-system - an explicit secretRef.name looks up the secret in this
+  # CR's OWN namespace and fails ("secrets \"sops-age\" not found",
+  # discovered live in Phase 2). Omitting secretRef matches
+  # wireguard-gateway/ks.yaml's working pattern (ns network, same secret,
+  # no explicit ref) and resolves correctly.
   decryption:
     provider: sops
-    secretRef:
-      name: sops-age

--- a/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
@@ -4,9 +4,15 @@
 # equivalent set via rawConfig (CodeRabbit item carried over from 34.1).
 #
 # `spec.database.url` slash count follows the sqlx-sqlite absolute-path
-# convention (`sqlite:///` + path); this is unverified against the pinned
-# v1.3.1 runtime until Phase 2's live request-log check - see the story's
-# completion report DEVIATIONS section.
+# convention (`sqlite:///` + path); still pending final confirmation from
+# Phase 2's live request-log check once this fsGroup fix rolls out.
+#
+# fsGroup is required: the proxy container runs runAsNonRoot/runAsUser
+# 10101 (chart default) with no matching group, and a freshly-provisioned
+# ceph-block PVC is root-owned - without this the container can't create
+# the sqlite file (SQLITE_CANTOPEN, discovered live in Phase 2: the new
+# ReplicaSet pod crash-looped while the old one kept serving traffic
+# through the rolling update, so no consumer impact during the fix).
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayParameters
 metadata:
@@ -23,6 +29,8 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 10101
           volumes:
             - name: request-log
               persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Two live-verification bugfixes for Story 34.2 (agentgateway cloud pilot
route, merged in #1223), both found during Phase 2 testing against the
real cluster.

## Fix 1: request-log PVC write permissions

The proxy's new ReplicaSet pod crash-looped after the request-log PVC
rolled out. The agentgateway proxy container runs `runAsNonRoot: true,
runAsUser: 10101` (chart default). A freshly-provisioned ceph-block PVC
is root-owned by default, so the container had no write access to
create the sqlite request-log file (`SQLITE_CANTOPEN`). The rolling
update kept the previous pod serving traffic throughout - no
consumer-facing impact.

Fix: add `securityContext.fsGroup: 10101` under the pod spec in the
`AgentgatewayParameters` strategic-merge patch. This is a
volume-ownership directive, not a privilege grant - it doesn't touch
`runAsNonRoot`, capabilities, or `readOnlyRootFilesystem`.

## Fix 2: agentgateway-pilot Kustomization SOPS decryption

The `agentgateway-pilot` Flux Kustomization (namespace `ai`) failed to
reconcile entirely: `secrets "sops-age" not found`. It had an explicit
`decryption.secretRef.name: sops-age`, which makes Flux look up that
secret in the Kustomization CR's own namespace (`ai`) - but the actual
age-key secret only exists in `flux-system`.

Fix: drop the explicit `secretRef`, matching the exact working pattern
already used by `kubernetes/apps/network/wireguard-gateway/ks.yaml`
(also lands outside `flux-system` via a namespace transform, also with
no explicit `secretRef`, and reconciles successfully). `provider: sops`
stays - decryption is still required, this only changes where the key
is looked up.

## Testing

- `kubectl kustomize` renders clean on both touched app dirs.
- `kubectl apply --dry-run=server` validates against the live cluster's CRDs.
- Security-guardian reviewed both changes independently: no secrets in
  either diff, no privilege escalation, no weakened decryption enforcement.

## Security Review

- [x] security-guardian PASS on both commits.

## Notes

Relates to STORY-034-2 (EPIC-034). Both found during Phase 2 live
verification; neither caused consumer-facing downtime (rolling update
kept the prior pod serving; the Kustomization failure only blocked this
brand-new pilot route's own resources from ever being created).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQLite request-log database write access for the non-root proxy on persistent storage.
  * Updated database path documentation to reflect the current SQLite convention and storage ownership requirements.
  * Simplified secret decryption configuration while preserving SOPS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->