### PR TITLE
feat(ai): add wake-from-zero gate spike route for qwen36-27b

### DIFF
--- a/kubernetes/apps/ai/agentgateway-wake-gate/app/backends.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/app/backends.yaml
@@ -1,0 +1,114 @@
+---
+# STORY-034-4 (KILL GATE): three AI-typed backend variants for the
+# wake-from-zero test against qwen36-27b. All three are deployed; only the
+# variant selected by the `x-wake-variant` request header receives traffic
+# (see httproute.yaml), so activating V2/V3 needs no redeploy.
+#
+# Shared facts (verified live 2026-08-01, read-only kubectl):
+#   svc/qwen36-27b-predictor (ns ai)   = ExternalName -> kourier-internal.kourier-system.svc.cluster.local
+#   svc/kourier-internal (ns kourier-system) = ClusterIP 10.43.101.155, port 80 (name "http2") -> targetPort 8081
+#   Kourier virtual-host selection is PURE Host/authority matching; the
+#   activator is on-path at 0 replicas (target-burst-capacity=200) and is
+#   what actually wakes the revision. Getting the right Host to Kourier IS
+#   the wake mechanism - nothing else in this file matters if that fails.
+#
+# Model id + base path mirror LiteLLM exactly (kubernetes/apps/ai/litellm/
+# app/configmap.yaml:115-121): model "openai/qwen3.6-27b" -> provider openai
+# + model "qwen3.6-27b" (llama-server --alias, isvc line 96-97);
+# api_base ".../v1" -> provider default pathPrefix (NOT set here; the
+# OpenAI provider default is already /v1).
+#
+# No `policies.auth`: llama-server runs without --api-key (isvc args
+# 90-127), matching LiteLLM's `api_key: "dummy"`.
+#
+# No `policies.health` on ANY of these - deliberate. Per the v1.3.1 CRD,
+# eviction is opt-in and absent-policy means "never evicted"; active health
+# probing against a predictor hostname would either wake the GPU on every
+# probe or hold it warm forever, destroying scale-to-zero economics on the
+# shared A5000 (inv-kserve.md sec 5 "health-check gotcha",
+# verify-kserve-serverless.md sec 3.2).
+#
+# No `policies.http.version` either - the v1.3.1 CRD documents that
+# plaintext-in/HTTPS-in traffic resolves to HTTP1 automatically, and
+# forcing it would mask what the defaults actually do. If V3 misbehaves,
+# `policies.http.version: HTTP1` is its first diagnostic lever (kourier's
+# port 80 is *named* http2 - verify-kserve-serverless.md sec 3.7).
+
+# ---------------------------------------------------------------------
+# V1 - the prescribed pattern. AI-typed backend, host-form target pointed
+# straight at the predictor hostname, everything else defaulted.
+#
+# The open question this variant answers: what :authority does the proxy
+# put on the wire? The installed v1.3.1 AgentgatewayPolicy CRD documents
+# `traffic.hostRewrite.mode` as defaulting to `Auto` ("automatically set
+# the Host header based on the destination") for hostname-based backends,
+# which would produce exactly the Host Kourier needs - but that default is
+# asserted by a CRD doc-string, not by any published behaviour for AI-typed
+# backends, and this story exists to establish it live rather than assume
+# it. If V1 fails, the first lever before moving to V2 is an explicit
+# AgentgatewayPolicy `traffic.hostRewrite: {mode: Auto}` on the route (see
+# WI-034-4 for the diagnostic ladder).
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: wake-gate-v1
+  namespace: ai
+spec:
+  ai:
+    provider:
+      openai:
+        model: qwen3.6-27b
+      host: qwen36-27b-predictor.ai.svc.cluster.local
+      port: 80
+---
+# ---------------------------------------------------------------------
+# V2 - identical backend to V1; the difference lives entirely on the route
+# (an HTTPRoute URLRewrite.hostname filter pinning Host to the predictor
+# hostname). Kept as a separate object rather than reusing V1 so the two
+# results can never be confused, and so either can be removed without
+# touching the other.
+#
+# Why this is a real question and not belt-and-braces: the upstream
+# URLRewrite host example uses a `spec.static` backend, NOT `spec.ai`
+# (verify-kserve-serverless.md sec 2.2). Whether a route-level rewrite runs
+# before or after the AI-provider machinery sets its own upstream authority
+# is undocumented. The v1.3.1 CRD gives one piece of supporting evidence:
+# `traffic.hostRewrite`'s doc-string says "If the HTTPRoute urlRewrite
+# filter already specifies a host rewrite, this setting is ignored" - i.e.
+# the filter is expected to win over the automatic rewrite.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: wake-gate-v2
+  namespace: ai
+spec:
+  ai:
+    provider:
+      openai:
+        model: qwen3.6-27b
+      host: qwen36-27b-predictor.ai.svc.cluster.local
+      port: 80
+---
+# ---------------------------------------------------------------------
+# V3 - AI-typed backend aimed at kourier-internal directly, with the Host
+# pinned back to the predictor hostname by the route's URLRewrite filter.
+#
+# This sidesteps the ExternalName-resolution unknown entirely (kourier-
+# internal is an ordinary ClusterIP Service with real endpoints) at the
+# cost of depending on the same undocumented rewrite-ordering question as
+# V2. Host-form is still used rather than a Service backendRef: a Service
+# backendRef would resolve to endpoints and could bypass the activator,
+# and Gateway API discourages ExternalName refs outright
+# (res-kserve.md sec 4 "two traps").
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: wake-gate-v3
+  namespace: ai
+spec:
+  ai:
+    provider:
+      openai:
+        model: qwen3.6-27b
+      host: kourier-internal.kourier-system.svc.cluster.local
+      port: 80

--- a/kubernetes/apps/ai/agentgateway-wake-gate/app/httproute.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/app/httproute.yaml
@@ -1,0 +1,169 @@
+---
+# STORY-034-4 (KILL GATE): the wake-from-zero spike route.
+#
+# Hostname is deliberately SINGLE-level: the homelab0.org wildcard cert
+# (`homelab0-org-production-tls`, dnsNames ["homelab0.org",
+# "*.homelab0.org"] - verified live) does not cover two-level subdomains.
+# No DNS record is published for it (private-by-default, EPIC-034
+# non-negotiable #2); LAN tests use
+# `curl --resolve ai-gateway-spike.homelab0.org:443:10.20.67.27` and
+# Claude Code uses the /etc/hosts approach proven in Story 34.2.
+#
+# VARIANT SELECTION - all four variants are live simultaneously and are
+# picked by the `x-wake-variant` request header. Gateway API ranks a
+# rule with a header match above an otherwise-identical rule without one,
+# so V1 (no header) is the default path and V2/V3/degraded only ever see
+# traffic when a test explicitly asks for them. This keeps them inert in
+# the only sense that matters (they carry zero traffic) while making
+# activation a curl flag rather than a redeploy - important because each
+# escalation happens mid-gate, between timed cold-start runs.
+#
+# TIMEOUTS/RETRIES on every model-bound rule:
+#   timeouts.request: 240s  - mirrors LiteLLM's qwen36-27b client timeout
+#                             (configmap.yaml:121) and sits under Knative's
+#                             300s revision ceiling. Measured wake baseline
+#                             is 133-139s, so this leaves ~100s of headroom
+#                             for generation.
+#   retry.attempts: 0       - explicit. LiteLLM sets num_retries: 0
+#                             cluster-wide precisely so concurrent cold
+#                             starts can't multiply GPU pressure on the
+#                             single A5000 (inv-kserve.md sec 7). Note the
+#                             load-bearing guarantee is actually the ABSENCE
+#                             of an AgentgatewayPolicy `traffic.retry` block
+#                             (whose `attempts` has minimum: 1 in the v1.3.1
+#                             CRD and so cannot express zero); this field is
+#                             the Gateway-API-native statement of the same
+#                             intent, honoured or harmlessly ignored.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-wake-gate
+  namespace: ai
+spec:
+  parentRefs:
+    - name: ai-gateway
+      namespace: network
+  hostnames:
+    - ai-gateway-spike.homelab0.org
+  rules:
+    # -----------------------------------------------------------------
+    # /v1/models stub. NOT a convenience: a bodyless GET would otherwise
+    # fall through to the catch-all V1 rule and cold-start the A5000 on
+    # every CLI startup probe (verify-kserve-serverless.md sec 3.5). The
+    # 24h idle soak (G5) depends on this rule existing - without it, any
+    # monitoring or client probe against this hostname invalidates the
+    # "no spurious wakes" result. Answered by a directResponse policy
+    # (policy.yaml); the backendRef only satisfies HTTPRoute's schema.
+    - name: models-stub
+      matches:
+        - path:
+            type: Exact
+            value: /v1/models
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: wake-gate-v1
+
+    # -----------------------------------------------------------------
+    # V2: V1's backend + URLRewrite.hostname Host pin.
+    - name: v2
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: x-wake-variant
+              value: v2
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: qwen36-27b-predictor.ai.svc.cluster.local
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: wake-gate-v2
+      timeouts:
+        request: 240s
+      retry:
+        attempts: 0
+
+    # -----------------------------------------------------------------
+    # V3: AI backend aimed at kourier-internal, Host pinned back to the
+    # predictor hostname (Kourier routes on Host alone, so this is what
+    # selects the qwen36-27b virtual host).
+    - name: v3
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: x-wake-variant
+              value: v3
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: qwen36-27b-predictor.ai.svc.cluster.local
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: wake-gate-v3
+      timeouts:
+        request: 240s
+      retry:
+        attempts: 0
+
+    # -----------------------------------------------------------------
+    # DEGRADED - measured for the record, explicitly NOT a pass.
+    #
+    # Plain HTTP proxying to the kourier-internal Service (cross-namespace,
+    # hence the ReferenceGrant in referencegrant.yaml) with the same Host
+    # pin. If this is the ONLY thing that works, the gate outcome is
+    # STOP-FOR-JOSH, not PASS: a raw proxy drops Anthropic-Messages ->
+    # OpenAI-chat translation (so external Claude Code can no longer reach
+    # qwen36-27b, a flow that works today through LiteLLM) and drops token
+    # accounting for every local model
+    # (verify-kserve-serverless.md sec 2.1).
+    #
+    # It is shipped live so the NO-GO evidence trail is complete in one
+    # deploy rather than needing a second PR at the worst possible moment.
+    - name: degraded
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: x-wake-variant
+              value: degraded
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: qwen36-27b-predictor.ai.svc.cluster.local
+      backendRefs:
+        - kind: Service
+          name: kourier-internal
+          namespace: kourier-system
+          port: 80
+      timeouts:
+        request: 240s
+      retry:
+        attempts: 0
+
+    # -----------------------------------------------------------------
+    # V1 (DEFAULT): the prescribed pattern, no header, no filters, no
+    # rewrite - whatever the proxy does on its own is the answer G1 is
+    # after. Listed last only for readability; Gateway API precedence,
+    # not list order, is what makes the header-matched rules above win.
+    - name: v1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: wake-gate-v1
+      timeouts:
+        request: 240s
+      retry:
+        attempts: 0

--- a/kubernetes/apps/ai/agentgateway-wake-gate/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backends.yaml
+  - httproute.yaml
+  - policy.yaml
+  - referencegrant.yaml

--- a/kubernetes/apps/ai/agentgateway-wake-gate/app/policy.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/app/policy.yaml
@@ -1,0 +1,62 @@
+---
+# STORY-034-4: inbound auth for the wake-gate spike route.
+#
+# Reuses Story 34.2's spike-key Secret rather than minting a second one:
+# `agentgateway-pilot-spike-key` already lives in this namespace, is
+# already SOPS-encrypted in Git, is already proven to decrypt and
+# authenticate (34.2 post-merge validation), and its plaintext is already
+# on the dev box at ~/.config/agw-spike-key. Adding a second throwaway
+# credential would put more key material in Git for no gain. The cost is a
+# Flux dependency on the agentgateway-pilot Kustomization, declared in
+# ks.yaml. Production keys with real scoping are Story 34.10's job.
+#
+# Same v1.3.1 shape as 34.2: `apiKeyAuthentication.secretRef` takes a
+# plaintext key in a Secret - the SHA-256/ConfigMap "virtual key" form is a
+# 1.4.x feature and does not exist in the pinned CRD.
+#
+# Scoped to the whole HTTPRoute (no sectionName), so every rule including
+# the /v1/models stub requires the key - matching 34.2 and keeping the
+# spike hostname closed even though no DNS record points at it.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agentgateway-wake-gate-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-wake-gate
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-pilot-spike-key
+---
+# STORY-034-4: the /v1/models stub that keeps bodyless GET probes off the
+# GPU. Lists only qwen36-27b - this spike route fronts exactly one model,
+# and the merged production catalog is Story 34.9's problem.
+#
+# The id advertised is the upstream llama-server alias `qwen3.6-27b`
+# (isvc line 96-97), which is also what the backends pin via
+# provider.openai.model, so a client that reads this list and echoes the
+# id back gets a request that routes and resolves identically.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agentgateway-wake-gate-models-stub
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-wake-gate
+      sectionName: models-stub
+  traffic:
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"object":"list","data":[{"id":"qwen3.6-27b","object":"model","owned_by":"kserve"}]}

--- a/kubernetes/apps/ai/agentgateway-wake-gate/app/referencegrant.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/app/referencegrant.yaml
@@ -1,0 +1,31 @@
+---
+# STORY-034-4: required only by the DEGRADED variant, whose backendRef is
+# a Service in another namespace. Gateway API requires the grant to live in
+# the *target* namespace (kourier-system), which is why this Kustomization
+# does not set `targetNamespace` and every resource carries an explicit
+# `namespace:` instead.
+#
+# Scope is as narrow as the API allows: HTTPRoutes from namespace `ai`
+# only, to Services only, and `to.name` pins it to kourier-internal so it
+# cannot be used to reach any other Service in kourier-system. It grants
+# reference permission, not connectivity - Kourier's listener is already
+# reachable from any pod that can resolve a predictor hostname, which is
+# how LiteLLM has worked all along.
+#
+# Removed by `git revert` along with the rest of the story. If the gate
+# outcome is PASS on an AI-typed variant, the degraded rule and this grant
+# should be dropped rather than carried into Phase 2.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: agentgateway-wake-gate-kourier
+  namespace: kourier-system
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: ai
+  to:
+    - group: ""
+      kind: Service
+      name: kourier-internal

--- a/kubernetes/apps/ai/agentgateway-wake-gate/ks.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/ks.yaml
@@ -23,7 +23,12 @@ spec:
   # must live in kourier-system, so every resource in app/ carries an
   # explicit `namespace:` instead of being force-placed in ai.
   #
-  # No `decryption:` block either - this Kustomization ships no SOPS files
-  # (it borrows 34.2's already-decrypted Secret), so it sidesteps the
-  # secretRef-resolves-in-the-CR's-own-namespace trap 34.2 hit live.
+  # No `decryption:` block here on purpose. The cluster-apps parent patches
+  # `decryption: {provider: sops}` into EVERY child Kustomization
+  # (kubernetes/flux/cluster/ks.yaml:19-28), so the rendered object gets
+  # provider-only decryption for free - which is exactly the shape that
+  # works. Declaring one locally is what invites the trap 34.2 hit live: an
+  # explicit `secretRef.name` resolves in the CR's OWN namespace (ai), but
+  # sops-age lives in flux-system. This Kustomization ships no SOPS files
+  # anyway (it borrows 34.2's already-decrypted Secret).
   wait: false

--- a/kubernetes/apps/ai/agentgateway-wake-gate/ks.yaml
+++ b/kubernetes/apps/ai/agentgateway-wake-gate/ks.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-wake-gate
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: agentgateway-config
+      namespace: network
+    # The apiKeyAuthentication policy references Story 34.2's spike-key
+    # Secret, which that Kustomization owns (see app/policy.yaml).
+    - name: agentgateway-pilot
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/ai/agentgateway-wake-gate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  # Deliberately NO targetNamespace: the degraded variant's ReferenceGrant
+  # must live in kourier-system, so every resource in app/ carries an
+  # explicit `namespace:` instead of being force-placed in ai.
+  #
+  # No `decryption:` block either - this Kustomization ships no SOPS files
+  # (it borrows 34.2's already-decrypted Secret), so it sidesteps the
+  # secretRef-resolves-in-the-CR's-own-namespace trap 34.2 hit live.
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -42,3 +42,4 @@ resources:
   #
   # EPIC-034: AgentGateway Consolidation
   - ./agentgateway-pilot/ks.yaml  # STORY-034-2: cloud pilot route (auth/streaming/observability)
+  - ./agentgateway-wake-gate/ks.yaml  # STORY-034-4: wake-from-zero KILL GATE spike (qwen36-27b)


### PR DESCRIPTION
## Summary

EPIC-034 Story 34.4 — the **kill gate** for the agentgateway consolidation. If no AI-typed backend variant can cold-start a scaled-to-zero KServe model through the gateway, the epic verdict flips to NO-GO. This PR ships the spike manifests only; the gate protocol itself runs post-merge.

Kourier selects a Knative virtual host by **Host/authority header alone**, so the only question that matters is what `:authority` the agentgateway proxy puts on the wire. Three AI-typed variants are deployed to answer it, plus a degraded plain-proxy variant that is measured for the record but is explicitly **not** a pass — it would drop Anthropic-Messages→OpenAI-chat translation (breaking a flow that works today through LiteLLM) and local-model token accounting.

LiteLLM is untouched. The Story 34.2 pilot backend/route is untouched. Everything here is additive.

## Changes

- New Flux Kustomization `agentgateway-wake-gate` (`kubernetes/apps/ai/agentgateway-wake-gate/`).
- Three `AgentgatewayBackend` variants, all `provider.openai` + host-form target:
  - **V1** → `qwen36-27b-predictor.ai.svc.cluster.local:80`, pure defaults. The prescribed pattern.
  - **V2** → same backend, plus an `URLRewrite.hostname` Host pin on the route.
  - **V3** → `kourier-internal.kourier-system.svc.cluster.local:80` with the Host pinned back to the predictor hostname.
- **Degraded** rule: plain `Service` backendRef to `kourier-internal` + the same Host pin, with a narrowly-scoped `ReferenceGrant`. Present so the NO-GO evidence trail is complete in one deploy.
- HTTPRoute on `ai-gateway-spike.homelab0.org` (single-level — the `*.homelab0.org` wildcard cert does not cover two-level subdomains). No DNS record published.
- Two `AgentgatewayPolicy` objects: route-wide API-key auth, and a `/v1/models` directResponse stub.

**Variant selection is by the `x-wake-variant` request header, not by path.** An AI-typed backend constructs its own upstream path from the provider config, so a path-prefix trick would have muddied the thing under test. Gateway API ranks a header-matched rule above an otherwise-identical one, so V1 (no header) is the default and the others carry zero traffic until a test asks for them. Escalation V1→V2→V3 is a `curl -H` flag rather than a redeploy — which matters because it happens between timed cold-start runs.

Config mirrors LiteLLM's live `qwen36-27b` entry (`litellm/app/configmap.yaml:115-121`) so the gate tests the gateway and not a config difference: model `qwen3.6-27b`, no upstream auth (llama-server runs without `--api-key`), 240s route timeout, `retry.attempts: 0`.

**No health policy on any backend** — active probing against a predictor hostname would either wake the shared A5000 on every probe or hold it warm forever.

**The `/v1/models` stub is hazard control, not convenience.** A bodyless GET has no model in its body, so it would fall through to the catch-all rule and cold-start the GPU on every client startup probe — which would also invalidate the 24h idle-soak result.

Auth reuses Story 34.2's existing spike-key Secret (referenced by name) rather than minting a second throwaway credential, so this PR introduces **no new secret material**. Consequently the Kustomization ships no SOPS files and deliberately carries no `decryption:` block.

## Testing

Pre-merge (no cluster mutation — read-only kubectl only):

- [x] Renders clean: 7 objects, namespaces `ai` ×6 + `kourier-system` ×1.
- [x] Every rendered object validated against the **live cluster's own CRD OpenAPI schemas** (7/7 pass), plus a hand review of every CEL `x-kubernetes-validations` rule that applies.
- [x] v1.3.1 behaviour confirmed at the source tag, not assumed from 1.4.x docs: `retry.attempts: 0` short-circuits to "emit no retry policy"; `timeouts.request` and the `URLRewrite` filter are both translated.
- [x] Addressing chain re-verified live: predictor Service is `ExternalName` → `kourier-internal`; `kourier-internal` port 80 (named `http2`) → targetPort 8081; qwen36-27b currently at 0 replicas.
- [x] Wildcard cert `dnsNames` confirmed as `["homelab0.org", "*.homelab0.org"]`.
- [x] Flux `dependsOn` targets confirmed live (`agentgateway-config` in `network`, `agentgateway-pilot` in `ai`, both Ready).
- [x] Network pre-flight: the `ai-gateway` proxy pod is selected by **zero** CiliumNetworkPolicies and zero native NetworkPolicies, so egress is unrestricted today and **no policy is added** (per-backend hardening is Phase 2 work). Predictor-side policies already allow Kourier and the activator — verified, not modified.

Post-merge (the gate itself, run serially — ~10 models share one A5000):

- [ ] G1 — V1 cold-start through the gateway; wake time correlated with the pod 0→1 transition and the predictor log timeline, compared against the 133-139s baseline.
- [ ] G2 — SSE streaming end-to-end from Claude Code (Messages→chat translation), and whether `usage` reaches the request log on streamed responses.
- [ ] G3 — passive-health check, only if a 5xx occurs naturally during a cold start.
- [ ] G4 — predictor scales to zero on the 30m retention schedule with the gateway path in place.
- [ ] G5 — 24h idle soak: no spurious wakes.
- [ ] Request-log persistence across this PR's proxy roll (the natural restart CodeRabbit asked about).

## Security Review

- [x] security-guardian review passed — **APPROVED**, no CRITICAL or HIGH findings.
- [x] No secrets in the diff; the existing 34.2 spike key is referenced by name only.
- [x] No `external-dns` annotations, no tunnel hostname — private by default, LAN-only VIP.
- [x] No route path escapes the API-key policy (precedence traced across every rule/header/method combination).
- [x] Every object carries an explicit namespace; Flux pruning is inventory-scoped and cannot touch objects owned by `knative-serving`.

## Notes

**One security-guardian finding taken deliberately rather than fixed** — the `ReferenceGrant` is as tight as the Gateway API allows on the `to` side (pinned to the single Service `kourier-internal`), but the `from` side only supports namespace granularity, so it authorises *any* HTTPRoute in namespace `ai` — present or future — to backendRef `kourier-internal`, not just this spike's degraded rule. It is also the first `ai`-tree Kustomization to write an object into `kourier-system`.

The reviewer recommended deferring the grant and the degraded rule to a follow-up PR opened only if V1/V2/V3 all fail. It is shipped here instead because escalation to the degraded variant happens mid-gate, when a second PR round-trip is at its most expensive. Mitigating facts: the L3 path is already open regardless (LiteLLM's own CNP permits `ai` → `kourier-system:8081`, and no CNP guards kourier ingress), and the degraded rule sits behind the same route-wide auth as everything else — so the grant widens *reference* permission, not reachability. **Flagging it for an explicit call at merge time.** If the gate passes on an AI-typed variant, the degraded rule and the grant should be dropped rather than carried into Phase 2.

Rollback is `git revert` + Flux reconcile. LiteLLM's path to qwen36-27b is untouched throughout, so the instant fallback is the status quo.

Relates to EPIC-034 Story 34.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a wake-gate endpoint for the AI gateway.
  * Added API-key authentication and a `/v1/models` response for the supported model.
  * Added multiple routing variants for testing backend hostname handling and a degraded service path.
  * Enabled automated deployment and reconciliation of the wake-gate configuration.
  * Added controlled access to the internal gateway service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->