### PR TITLE
feat(ai): add auth-mechanics spike route for EPIC-034

### DIFF
--- a/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-backends.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-backends.yaml
@@ -1,0 +1,79 @@
+---
+# STORY-034-3 (auth-mechanics spike): backends used only by the auth-matrix
+# route. Additive; nothing here is referenced by 34.2's pilot route or by
+# 34.4's wake-gate route.
+#
+# ---------------------------------------------------------------------
+# JWKS source for Q1 (remote JWKS validation against Authentik).
+#
+# Why a static AgentgatewayBackend and not a direct cross-namespace Service
+# ref: `jwks.remote.backendRef` DOES accept `kind: Service` on the pinned
+# v1.3.1 CRD, but the CRD's own doc-string for that field's `namespace`
+# says a ReferenceGrant is required in the referent namespace, and the
+# agentgateway-pilot Kustomization sets `targetNamespace: ai` - so it
+# cannot place a grant into ns `security` at all. A static Backend keeps
+# the whole reference inside ns `ai` and needs no grant.
+#
+# Clear-text on purpose. Verified against the pinned version's own
+# testdata (controller/pkg/agentgateway/remotehttp/resolver.go:119,127 at
+# tag v1.3.1): the URL is built as `http://<host:port>/<path>` unless a TLS
+# policy is attached, and the upstream fixtures name the no-TLS case
+# `gw-with-backend-clear-text.yaml` while `gw-with-backend-default-tls.yaml`
+# has to add an explicit `policies.tls: {}`. So omitting TLS is not an
+# oversight - it is the documented clear-text shape, which is what an
+# in-cluster ClusterIP hop to Authentik wants.
+#
+# Reachability pre-verified live (read-only, 2026-08-01) with a throwaway
+# curl pod in ns security:
+#   GET http://authentik-server.security.svc.cluster.local:80\
+#       /application/o/toolhive-mcp-gateway/jwks/  -> HTTP 200 application/json
+#   (RS256 key, kid dbcc2396...). No Host header needed; Authentik serves
+#   the JWKS on the Service port regardless of the external hostname.
+# Also verified: ns `security` has ZERO CiliumNetworkPolicies and only a
+# postgresql-scoped native NetworkPolicy, so authentik-server ingress is
+# unrestricted - no policy work is required by this story.
+#
+# NOTE for later stories: the JWKS is fetched by the agentgateway
+# CONTROLLER (ns network), not by the proxy pod, and is inlined into the
+# xDS config (traffic_plugin.go:738-748 resolves RemoteJWKS to an Inline
+# JwksSource at translation time). Any future egress restriction therefore
+# has to allow the controller, not the data plane, to reach Authentik.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: auth-matrix-authentik-jwks
+  namespace: ai
+spec:
+  static:
+    host: authentik-server.security.svc.cluster.local
+    port: 80
+---
+# ---------------------------------------------------------------------
+# Q3's real-model target: a byte-for-byte copy of Story 34.4's winning V1
+# shape (WI-034-4 sec 8), used ONLY to prove that a per-key CEL denial
+# returns 403 *before* any backend contact - i.e. without waking the A5000.
+#
+# Why a duplicate rather than a backendRef to `wake-gate-v1`: the
+# agentgateway-wake-gate Kustomization already declares `dependsOn`
+# agentgateway-pilot, so pilot cannot depend on wake-gate without creating
+# a Flux dependency cycle. Duplicating the (tiny, proven) backend keeps
+# both Kustomizations independent and makes this story revert cleanly on
+# its own - which matters because 34.11 is scheduled to delete the
+# wake-gate app entirely.
+#
+# No policies.health, no URLRewrite, no hostRewrite - exactly as 34.4
+# established. The route rule that references this backend is auth'd AND
+# authorization-gated, and every other rule on the auth-matrix route is a
+# directResponse, so no unauthenticated path can reach a GPU.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: auth-matrix-qwen36
+  namespace: ai
+spec:
+  ai:
+    provider:
+      openai:
+        model: qwen3.6-27b
+      host: qwen36-27b-predictor.ai.svc.cluster.local
+      port: 80

--- a/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-httproute.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-httproute.yaml
@@ -1,0 +1,158 @@
+---
+# STORY-034-3 (auth-mechanics spike): the auth-matrix route.
+#
+# A SEPARATE HTTPRoute rather than extra rules on 34.2's pilot route,
+# because the pilot's apiKeyAuthentication policy targets that whole
+# HTTPRoute with no sectionName - so every rule added there inherits the
+# API key requirement and Q1 (JWT alone) and Q2 (per-rule auth types)
+# would be untestable by construction.
+#
+# Hostname is single-level so the existing wildcard cert
+# (`homelab0-org-production-tls`, dnsNames ["homelab0.org","*.homelab0.org"])
+# covers it - same constraint 34.4 hit. No external-dns annotation and no
+# tunnel entry; note per 34.4's finding F2 that unifi-dns publishes a LAN
+# record for every HTTPRoute hostname on any Gateway regardless, so this
+# name WILL resolve on the LAN and must not be treated as unreachable.
+# Public DNS remains structurally impossible (cloudflare-dns is scoped
+# --gateway-name=envoy-external).
+#
+# EVERY rule is an Exact path match and there is deliberately NO
+# `PathPrefix: /` catch-all. That is a direct application of 34.4's
+# finding F3 (a catch-all lets any authenticated request on any path reach
+# a backend, and here one rule fronts a GPU model). Unmatched paths get a
+# 404 from the gateway, which also makes "did the rule match?" and "did the
+# policy reject?" distinguishable in every test below: 404 = wrong rule,
+# 401/403 = the policy did its job.
+#
+# Rule -> question map (the whole story in one table):
+#   jwt-only     Q1  JWT via remote JWKS, no API key anywhere
+#   apikey-only  Q2a + Q4  API key only; also the x-api-key negative test
+#   both-auth    Q2b  BOTH policies on the SAME rule - semantics probe
+#   scope-meta   Q3   does apiKey.* metadata reach authorization CEL?
+#   scope-body   Q3   GPU-free fallback: model scoping from the request body
+#   qwen-live    Q3   the real qwen36 backend: 403 side now, allow side
+#                     gated on the 34.4 soak
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-auth-matrix
+  namespace: ai
+spec:
+  parentRefs:
+    - name: ai-gateway
+      namespace: network
+  hostnames:
+    - ai-gateway-auth.homelab0.org
+  rules:
+    # -----------------------------------------------------------------
+    # Q1: JWT validation via remote JWKS against Authentik.
+    # Answered by a directResponse (see auth-matrix-policies.yaml), so a
+    # forged, expired or wrong-audience token costs nothing and a valid
+    # one wakes nothing. There is no backend behind this rule at all.
+    - name: jwt-only
+      matches:
+        - path:
+            type: Exact
+            value: /spike/jwt
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-authentik-jwks
+
+    # -----------------------------------------------------------------
+    # Q2a: an API-key-authenticated rule living on the SAME Gateway and
+    # the SAME HTTPRoute as the JWT rule above. Also carries Q4's negative
+    # test (key sent as `x-api-key` with no Authorization header).
+    - name: apikey-only
+      matches:
+        - path:
+            type: Exact
+            value: /spike/apikey
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-authentik-jwks
+
+    # -----------------------------------------------------------------
+    # Q2b: both an apiKeyAuthentication policy and a jwtAuthentication
+    # policy attached to THIS rule, from two separate AgentgatewayPolicy
+    # objects. The API-key policy here reads a non-default header
+    # (`x-spike-key`) precisely so the two credentials can coexist on one
+    # request - both auth types default to `Authorization: Bearer`, and a
+    # single Authorization header cannot be both a valid API key and a
+    # valid JWT, which would make "both required" trivially unsatisfiable
+    # and the experiment meaningless.
+    - name: both-auth
+      matches:
+        - path:
+            type: Exact
+            value: /spike/both
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-authentik-jwks
+
+    # -----------------------------------------------------------------
+    # Q3 part 1: does key metadata reach authorization CEL at all?
+    # `apiKey.scope` is metadata carried on the key itself, so this needs
+    # no request body and no backend - the cleanest possible allow-vs-403
+    # pair (scoped key 200, broad key 403) with zero GPU exposure.
+    - name: scope-meta
+      matches:
+        - path:
+            type: Exact
+            value: /spike/scope
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-authentik-jwks
+
+    # -----------------------------------------------------------------
+    # Q3 part 2: the GPU-free fallback mechanism. Scopes by the model in
+    # the request body via `json(request.body).model` instead of
+    # `llm.requestModel`, so the identical allow-vs-403 pair can be proven
+    # against a directResponse with no model ever contacted. This is the
+    # shape Story 34.10 falls back to if `llm.*` turns out not to be
+    # populated at authorization time.
+    - name: scope-body
+      matches:
+        - path:
+            type: Exact
+            value: /spike/scope-body
+          method: POST
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-authentik-jwks
+
+    # -----------------------------------------------------------------
+    # Q3 part 3: the same scoping question against the REAL qwen36-27b
+    # backend, using `llm.requestModel`.
+    #
+    # SOAK CONSTRAINT (34.4 Checkpoint B, ~2026-08-02T07:04Z): only the
+    # DENY direction may be exercised before soak clearance. A 403 is
+    # returned by the authorization policy before the upstream call, so it
+    # cannot wake the A5000 - verified in 34.4, where a 401 on this same
+    # Gateway cost 1ms and woke nothing. The ALLOW direction would cold-
+    # start the GPU and is explicitly held for PM soak-clearance.
+    #
+    # Route shape is 34.4's proven standard: 240s request timeout,
+    # retry.attempts 0, no filters, no health policy.
+    - name: qwen-live
+      matches:
+        - path:
+            type: Exact
+            value: /v1/chat/completions
+          method: POST
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: auth-matrix-qwen36
+      timeouts:
+        request: 240s
+      retry:
+        attempts: 0

--- a/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-keys.sops.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-keys.sops.yaml
@@ -1,0 +1,46 @@
+# STORY-034-3: TWO throwaway spike API keys for the auth-matrix route
+# (openssl-rand generated, 24 bytes hex each). Plaintext lives only at
+# ~/.config/agw-spike-key-scoped and ~/.config/agw-spike-key-broad on the
+# dev box - outside the repo, never in 1Password, never in a PR body.
+# Production keys and their real scoping are Story 34.10's job.
+#
+# Both entries use the v1.3.1 metadata-carrying form. The CRD documents it
+# ("A JSON object with two fields, `key` and `metadata`... you may write an
+# authorization policy allowing `apiKey.group == 'sales'`") and the pinned
+# controller implements it (APIKeyEntry{Key,Metadata} in
+# controller/pkg/agentgateway/plugins/traffic_plugin.go:840-843 at tag
+# v1.3.1, which falls back to a raw-string key only when the value does not
+# start with '{'). Story 34.2's single key used the raw-string form and so
+# carries no metadata at all - which is exactly why this story needs its
+# own Secret rather than reusing it.
+#
+# The two keys differ ONLY in metadata, so every allow-vs-403 pair in this
+# story isolates the authorization policy and nothing else:
+#   scoped -> scope=qwen-only, models=qwen3.6-27b   (the claude-code-qwen36
+#             successor's restriction, reproduced)
+#   broad  -> scope=all,       models=any           (the control)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentgateway-auth-matrix-keys
+  namespace: ai
+type: Opaque
+stringData:
+  scoped: ENC[AES256_GCM,data:ZNIuZMxUUAkxUSVSjp1qyq0Gc2+96DNpmOEtNQRpOvxoFN76Yc17utL88KZ8Qa98n6UXKglab+Vw+5eEtVUE02ZZxDjrgKk2ZaeaLR8qePFKNve2K+m5UuOqyhsvZ/UYKomgeF2+FdbUPGexLukL7l2W4dDLLBo+PQ8wBWU6nUfFSNckf8xuPm4MbImtu/rV85lFawAW9KQTJySml5th404oPg==,iv:wrboloTWl4nvfnwJSZRqcgnMkq7uBfDYjrdd6xWfLmE=,tag:0pmdEQSRa+QbjWJhGcA+dA==,type:str]
+  broad: ENC[AES256_GCM,data:QcfFiEityKG9JsX7G/OxX6tSipIwkNlsDyba2+bn+X+mE9VIT+Hh/yLZnEB4cDSQpW5lDmyCIgkc+aJmnUYVvN4KEYAiMCZE4IIz6M7U2yvY5a/mpEm2weXR/YHrLL/nvVsCiI6F+ZY+0l+4bTsox4OP32sTLt8UqaVZOwENuE3S1MicnxlucrJUtXUPyGNkGzMY4A==,iv:wTmkQzt6n0/lSG8NwRm7FclwGrrKOt/cILMnZ6sbwLg=,tag:lq6IOWcCYLmyz8qosQtDug==,type:str]
+sops:
+  age:
+    - recipient: age1metxlry78wefrmm5ny2zjavtucsmdvw2r3ctexu6h05ak4x2vc7qa02drd
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVSUxxa2MwUloyV0t0M2Ux
+        ZXZ5UVMzZXhITGQ3endOcGpYbUgzWGEyUXpFCnJoMFArVExiYW55S050cVN3cjYz
+        NUsycmgzOExVQ05uMTQ2bkJPUy9Zd2sKLS0tIFdXcXZzWEY5WU5aMUMxQmtTaGN2
+        M2lab0FLOFJReTF0RldMUUJTbjNvbHMKk4FHltwfpFKHm4mNelQ8xWs5CO9oxhqS
+        NjsoipovuXx8plFOGG600DXLbZ2cDaB7KkHFtPGgoXLml3XxphoOxg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-01T07:30:45Z"
+  mac: ENC[AES256_GCM,data:Udt1412wTb+8rw01y8uawaax3452RbONDjzrKyAikKVquPv8OJLH9c8l+WtjI+VjBk46pdHpWpTi2bjVmegkNrfSv5uDjSFuzrGYTEp1T3sRN5zNS6auA+TGjuOglf69E1WzlzdGYD2jx856WicFzfJ9TcJ/PC0Yf5iJ1bwCcEI=,iv:k5GI1telWJ+mRn/p1Oyvt+34HlV1EApEB8YnpgxSdBY=,tag:a1rk5TiTjztBDo1wrnozhA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-policies.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/auth-matrix-policies.yaml
@@ -1,0 +1,384 @@
+---
+# STORY-034-3 (auth-mechanics spike): every policy in this file targets a
+# NAMED RULE of the agentgateway-auth-matrix HTTPRoute. Nothing here
+# targets the Gateway, 34.2's pilot route, or 34.4's wake-gate route.
+#
+# ===================================================================
+# WHY ONE CONCERN PER POLICY OBJECT
+# ===================================================================
+# The pinned v1.3.1 CRD documents the merge rule (AgentgatewayPolicy
+# spec.traffic doc-string): "When multiple policies are selected for a
+# given request, they are merged on a field-level basis, but not a deep
+# merge. Precedence is given to more precise policies: Gateway < Listener
+# < Route < Route Rule."
+#
+# Two consequences this file is built around:
+#
+# 1. Splitting authentication and authorization into separate objects is
+#    safe (disjoint fields merge cleanly) AND it is a safety property:
+#    the authorization policies below are the only ones carrying CEL, and
+#    CEL is the only thing here that can fail to compile. Keeping
+#    `apiKeyAuthentication` in its own CEL-free object means a bad
+#    expression can never leave a rule unauthenticated - which matters
+#    most for `qwen-live`, the one rule with a GPU behind it.
+# 2. It gives Q2 more evidence than the headline test: rules
+#    scope-meta / scope-body / qwen-live each have two policies attached
+#    at the same point setting disjoint fields, so the field-level merge
+#    claim is exercised three extra times.
+#
+# ===================================================================
+# WHAT IS *NOT* TESTED HERE, AND WHY (Q2c)
+# ===================================================================
+# Gateway-scoped and listener-`sectionName`-scoped policies are NOT
+# shipped. Two independent reasons, both structural rather than a choice
+# to skip work:
+#
+#   (a) The v1.3.1 CRD requires a policy's targetRef to be in the SAME
+#       NAMESPACE as the policy ("Selects one same-namespace object..."),
+#       and Gateway `ai-gateway` lives in ns `network` while this
+#       Kustomization is pinned to `targetNamespace: ai`. A Gateway- or
+#       listener-scoped policy is therefore not expressible from here at
+#       all - it would have to live in the network-tree app.
+#   (b) Any Gateway-scoped auth policy would merge DOWN into 34.2's pilot
+#       route and 34.4's wake-gate route, both of which are live spike
+#       surfaces the story is forbidden to touch.
+#
+# (a) is itself a finding worth carrying: auth-policy ownership splits
+# across namespaces the moment anything is Gateway-scoped.
+
+# ===================================================================
+# Q1 - JWT validation via remote JWKS against Authentik
+# ===================================================================
+# Provider contract copied from the live Authentik discovery document
+# (read-only GET, 2026-08-01):
+#   https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/\
+#     .well-known/openid-configuration
+#     issuer   = https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/
+#     jwks_uri = https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/jwks/
+# The trailing slash on `issuer` is significant - Authentik runs
+# `issuer_mode: per_provider` (inv-network.md sec 7) and emits exactly
+# this string in the `iss` claim.
+#
+# `audiences: [toolhive-mcp-gateway]` is what the blueprint's "MCP Gateway
+# Audience" scope mapping injects for the `mcp` scope
+# (configmap-blueprints.yaml:123-133). This is also the free
+# wrong-audience test: a token requested WITHOUT the `mcp` scope carries
+# Authentik's default aud (the client_id) instead, and must be rejected.
+#
+# jwksPath is given with a leading slash. Verified equivalent either way:
+# the resolver does `strings.TrimPrefix(input.Path, "/")` before building
+# `http://<host>/<path>` (remotehttp/resolver.go:94,119 at tag v1.3.1),
+# and upstream ships a `jwkspath-starts-with-slash.yaml` fixture.
+#
+# cacheDuration is left at its default (5m, which is also the CRD's
+# enforced minimum).
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-jwt-only
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: jwt-only
+  traffic:
+    jwtAuthentication:
+      mode: Strict
+      providers:
+        - issuer: https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/
+          audiences:
+            - toolhive-mcp-gateway
+          jwks:
+            remote:
+              backendRef:
+                group: agentgateway.dev
+                kind: AgentgatewayBackend
+                name: auth-matrix-authentik-jwks
+              jwksPath: /application/o/toolhive-mcp-gateway/jwks/
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"spike":"jwt-only","result":"jwt accepted"}
+---
+# ===================================================================
+# Q2a + Q4 - API-key-only rule, on the same Gateway and the same route
+# as the JWT rule above
+# ===================================================================
+# Default credential location on purpose: the v1.3.1 CRD says of
+# `apiKeyAuthentication.location`, "If omitted, credentials are read from
+# the `Authorization` header with the `Bearer ` prefix." That default is
+# exactly what makes Claude Code's ANTHROPIC_AUTH_TOKEN work (34.4 sec 3.6,
+# proven live in 34.2 and 34.4), and it is what Q4's negative test probes:
+# the same key sent as `x-api-key` with no Authorization header must be
+# rejected, because nothing is configured to look there.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-apikey-only
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: apikey-only
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-auth-matrix-keys
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"spike":"apikey-only","result":"api key accepted"}
+---
+# ===================================================================
+# Q2b - BOTH auth types on the SAME route rule, from two policy objects
+# ===================================================================
+# Object 1 of 2: the API key half. `location.header.name: x-spike-key`
+# with no prefix is deliberate and is what makes the experiment
+# meaningful - see the HTTPRoute comment on this rule. It also
+# demonstrates that the credential location is configurable, which is the
+# escape hatch if a client ever genuinely cannot send Authorization.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-both-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: both-auth
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      location:
+        header:
+          name: x-spike-key
+      secretRef:
+        name: agentgateway-auth-matrix-keys
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"spike":"both-auth","result":"all configured auth passed"}
+---
+# Object 2 of 2: the JWT half, same attachment point, disjoint field.
+# Expected per the documented field-level merge: the effective policy for
+# this rule carries BOTH `apiKeyAuthentication` and `jwtAuthentication`,
+# both in Strict mode, so both credentials are required (AND, not OR).
+# The live 3-way test (both / JWT only / key only) is what settles it.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-both-jwt
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: both-auth
+  traffic:
+    jwtAuthentication:
+      mode: Strict
+      providers:
+        - issuer: https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/
+          audiences:
+            - toolhive-mcp-gateway
+          jwks:
+            remote:
+              backendRef:
+                group: agentgateway.dev
+                kind: AgentgatewayBackend
+                name: auth-matrix-authentik-jwks
+              jwksPath: /application/o/toolhive-mcp-gateway/jwks/
+---
+# ===================================================================
+# Q3 part 1 - does apiKey.* metadata reach authorization CEL?
+# ===================================================================
+# This is Q3's actual question, isolated so it can be answered with a
+# single string comparison and no GPU, no body parsing and no LLM
+# context. Both spike keys authenticate here; only the scoped one carries
+# `scope: qwen-only`, so:
+#   scoped key -> 200   broad key -> 403
+# and a 403 for BOTH would mean `apiKey.*` never reaches this context.
+#
+# Source-level expectation (v1.3.1, crates/agentgateway/src/http/apikey.rs
+# :44-56): the API key Claims struct is `{ key, #[dynamic(flatten)]
+# metadata }`, i.e. each key's JSON `metadata` object is flattened onto
+# the `apiKey` CEL root - so `apiKey.scope` is addressable directly.
+# schema/cel.md at the same tag lists `apiKey` in the single shared CEL
+# context. The live test is what turns that into evidence.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-scope-meta-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: scope-meta
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-auth-matrix-keys
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"spike":"scope-meta","result":"authorized by apiKey metadata"}
+---
+# The authorization half. `action: Allow` gives deny-by-default semantics
+# per the CRD: "If at least one Allow rule is configured, requests are
+# denied unless at least one allow rule matches." A CEL expression that
+# fails to evaluate does not match, so an unavailable `apiKey.*` context
+# degrades to 403 - i.e. this policy fails CLOSED, never open.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-scope-meta-authz
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: scope-meta
+  traffic:
+    authorization:
+      action: Allow
+      policy:
+        matchExpressions:
+          - apiKey.scope == 'qwen-only'
+---
+# ===================================================================
+# Q3 part 2 - per-key MODEL scoping, proven with zero GPU exposure
+# ===================================================================
+# Reproduces claude-code-qwen36's "this key may only reach qwen3.6-27b"
+# restriction, but reads the requested model from the request body
+# (`json(request.body).model`) instead of from the LLM context, so the
+# whole allow-vs-403 pair runs against a directResponse:
+#   scoped key + {"model":"qwen3.6-27b"}  -> 200
+#   scoped key + {"model":"gpt-4o-mini"}  -> 403
+#   broad  key + either                   -> 200   (models: "any")
+#
+# `json()` and the strings-extension `split()` are both confirmed present
+# at the pinned version (schema/cel-functions.md at tag v1.3.1). Cost to
+# note for Story 34.11: touching `request.body` in CEL buffers the body
+# (documented in the same reference), which interacts with the PreRouting
+# model-extraction transformation planned in 34.5 - so this fallback is
+# not free, it is just GPU-free.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-scope-body-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: scope-body
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-auth-matrix-keys
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+      body: |
+        {"spike":"scope-body","result":"model allowed for this key"}
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-scope-body-authz
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: scope-body
+  traffic:
+    authorization:
+      action: Allow
+      policy:
+        matchExpressions:
+          - apiKey.models == 'any' || apiKey.models.split(',').exists(m, m == json(request.body).model)
+---
+# ===================================================================
+# Q3 part 3 - the same scoping against the REAL qwen36-27b backend
+# ===================================================================
+# Authentication only in this object; no CEL, so it cannot fail to
+# compile. This is the guarantee that the one rule with a GPU behind it
+# is never reachable without a key even if the authorization policy below
+# is rejected.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-qwen-live-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: qwen-live
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-auth-matrix-keys
+---
+# The model restriction expressed the way Story 34.10 would prefer to
+# write it - against `llm.requestModel` rather than by parsing the body.
+# Whether `llm.*` is populated at authorization time on an AI route is the
+# open half of Q3; if it is not, the expression cannot evaluate, does not
+# match, and the request is denied - so the failure mode is a 403, never a
+# GPU wake.
+#
+# That fail-closed behaviour is also why the DENY direction can be tested
+# immediately while the ALLOW direction waits for 34.4's soak clearance:
+# a 403 alone cannot distinguish "correctly denied" from "llm.* was
+# unavailable". The scope-body rule above is the disambiguator that does
+# not need a GPU, and the single allow-side run against this rule after
+# soak clearance is what closes it completely.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: auth-matrix-qwen-live-authz
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-auth-matrix
+      sectionName: qwen-live
+  traffic:
+    authorization:
+      action: Allow
+      policy:
+        matchExpressions:
+          - apiKey.models == 'any' || apiKey.models.split(',').exists(m, m == llm.requestModel)

--- a/kubernetes/apps/ai/agentgateway-pilot/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/kustomization.yaml
@@ -2,8 +2,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # STORY-034-2: cloud pilot route
   - externalsecret.yaml
   - spike-key.sops.yaml
   - backend.yaml
   - httproute.yaml
   - policy.yaml
+  # STORY-034-3: auth-mechanics spike (additive - separate HTTPRoute,
+  # separate hostname, separate Secret; nothing above is modified).
+  # Lives here rather than in agentgateway-wake-gate because this
+  # Kustomization already carries `decryption: {provider: sops}` and owns
+  # the only other spike credential, while wake-gate deliberately ships no
+  # SOPS files at all and is scheduled for deletion in Story 34.11.
+  - auth-matrix-keys.sops.yaml
+  - auth-matrix-backends.yaml
+  - auth-matrix-httproute.yaml
+  - auth-matrix-policies.yaml


### PR DESCRIPTION
## Summary

EPIC-034 Story 34.3. Establishes the auth matrix the whole consolidation design assumes — JWT via Authentik, API-key/JWT coexistence, per-key CEL scoping, and the inbound header form — as an **additive** spike on the existing `ai-gateway` Gateway.

Nothing existing is modified. Story 34.2's pilot route, Story 34.4's wake-gate route, LiteLLM and the KServe tree are all untouched; the only edit to a pre-existing file is four added `resources:` entries in the pilot's `kustomization.yaml`.

## Changes

All under `kubernetes/apps/ai/agentgateway-pilot/app/` (chosen over the wake-gate dir because that Kustomization already carries `decryption: {provider: sops}`, while wake-gate deliberately ships no SOPS files and is scheduled for deletion in 34.11).

- **`auth-matrix-httproute.yaml`** — new HTTPRoute on `ai-gateway-auth.homelab0.org`, six rules, **all Exact-path, no `PathPrefix: /` catch-all** (34.4's finding F3 applied, not just noted). Five rules are answered by `directResponse` and can never reach a backend; the sixth is the only one with a model behind it.
- **`auth-matrix-policies.yaml`** — ten AgentgatewayPolicies, every one scoped to a named route rule. No Gateway- or listener-scoped policy is shipped, so nothing can merge down into the two live spike routes.
- **`auth-matrix-backends.yaml`** — a `static` Backend for the Authentik JWKS hop, and an AI Backend in 34.4's proven V1 shape aimed at the qwen36-27b predictor.
- **`auth-matrix-keys.sops.yaml`** — one SOPS-encrypted Secret holding two throwaway spike keys in the v1.3.1 metadata-carrying entry form (34.2's key uses the raw-string form and therefore carries no metadata, which is why a second Secret is needed).

### Safety properties built into the design

- The one GPU-backed rule carries **two** policies: authentication (no CEL, cannot fail to compile) and authorization (CEL) as separate objects — so a bad expression can never leave that path unauthenticated.
- All authorization rules use `action: Allow`, which is deny-by-default; a CEL expression that cannot evaluate does not match, so every failure mode is a 403, never an open path or a GPU wake.
- No cloud provider is referenced anywhere in the spike, so the live tests cost nothing against the zero-credit OpenAI account (open decision 7).

### Credentials

Two throwaway keys, generated with `openssl rand`, SOPS-encrypted with the repo's age recipient. Plaintext exists only on the dev box outside the repo, is never placed in 1Password, and is never distributed. Production keys and their real scoping remain Story 34.10's job. The Authentik side uses the **existing** blueprint-managed `toolhive-mcp-gateway` public client and its already-registered localhost redirect regex — no new client, no blueprint change.

## Testing

Phase 1 (this PR) is manifests plus design evidence; the live answers are Phase 2, after merge and PM validation.

- `kubectl kustomize` renders clean — 20 objects, 12 new, all in ns `ai`.
- All 13 new CRD-typed objects validated against the **live cluster's own CRD OpenAPI schemas**: 13/13 OK.
- `kubectl apply --dry-run=server` accepts all 12 new objects. Non-mutating, and stronger than a local schema pass because it also evaluates the CRDs' `x-kubernetes-validations` CEL rules (targetRef kind/uniformity, backend exactly-one-of, secretRef-xor-secretSelector, jwks remote-xor-inline, location exactly-one-of).
- Decrypted Secret verified structurally without exposing key values; both entries parse as `{key, metadata}` matching the pinned controller's `APIKeyEntry`.
- The repo's own CI SOPS validator run locally against the new file: OK.
- Read-only pre-flight against the live cluster confirmed the Authentik JWKS endpoint answers over plain in-cluster HTTP and that ns `security` has no CiliumNetworkPolicy — so this story needs no network-policy change.

## Security Review

- [x] security-guardian: **APPROVED**, no CRITICAL or HIGH findings
- [x] Both API keys SOPS-encrypted; no plaintext key material in Git or in this description
- [x] Every route rule traced for auth coverage — no path reaches any backend without a credential
- [x] All objects namespace `ai`; no cross-namespace writes, no ReferenceGrant
- [x] No public DNS path (the Gateway is off the tunnel and off `envoy-external`)

## Notes

Design decisions and the full Phase-2 protocol are recorded in `WI-034-3-auth-matrix.md`.

Three Phase-1 findings worth carrying forward:

- **F4** — AgentgatewayPolicy `targetRefs` selects a *same-namespace* object, so any Gateway- or listener-scoped policy must live in the `network` tree next to the Gateway. This also means Story 34.5's planned `PreRouting` model-extraction transformation cannot be authored from `kubernetes/apps/ai/`.
- **F5** — a remote JWKS is fetched by the **controller** and inlined into the xDS config, not fetched by the proxy at request time. IdP reachability is a control-plane concern, and a JWKS failure surfaces at translation time rather than on a request.
- **F6** — `res-agentgateway-eval` §3 is out of date at the pinned version on two points: API-key policies do target routes (already contradicted by 34.2), and a remote JWKS `backendRef` *can* be a Service. Same doc-site-vs-1.3.1 skew class as the SHA-256 virtual-key finding.

One Phase-2 test — the single allow-side request against the real qwen36-27b backend — is held for PM soak clearance after Story 34.4's Checkpoint B. Everything else, including the whole deny side, runs immediately because a denial returns before any upstream call.

Relates to EPIC-034 Story 34.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authentication testing gateway with dedicated routes for JWT, API key, combined authentication, metadata scoping, request-body model scoping, and live Qwen access.
  * Added secure, encrypted API keys with separate authorization scopes.
  * Added strict authentication and authorization policies, including model-based access controls and fail-closed behavior.
  * Added backend connectivity for Authentik JWKS and an OpenAI-compatible Qwen model endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->