### PR TITLE
feat(mcp): federate MCP servers through agentgateway for EPIC-034

### DIFF
--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/app/backends.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/app/backends.yaml
@@ -1,0 +1,195 @@
+---
+# STORY-034-6 (MCP federation spike): the MCP backends.
+#
+# ===================================================================
+# THE PREFIX CONTRACT, READ FROM THE PINNED SOURCE
+# ===================================================================
+# Today's clients depend on tool names rendering exactly
+# `{workload}_<tool>` (VirtualMCPServer `conflictResolution: prefix`,
+# `prefixFormat: "{workload}_"` - virtualmcpserver.yaml:18-20). At
+# agentgateway v1.3.1 that shape is reproduced by the target `name:`
+# field, and the delimiter is not configurable:
+#
+#   crates/agentgateway/src/mcp/handler.rs:31
+#     const DELIMITER: &str = "_";
+#   crates/agentgateway/src/mcp/handler.rs:33-38
+#     fn resource_name(default_target_name, target, name) {
+#         if default_target_name.is_none() { format!("{target}_{name}") }
+#         else { name.to_string() }
+#     }
+#
+# So `targets[].name` IS the prefix, verbatim. The five names below are
+# byte-identical to today's MCPServer metadata.name values, which is what
+# makes the federated names byte-identical to vmcp's.
+#
+# ------------------------------------------------------------------
+# THE ONE-TARGET TRAP (why `mcp-federation-single` exists below)
+# ------------------------------------------------------------------
+#   crates/agentgateway/src/mcp/upstream/mod.rs:272-279
+#     let default_target_name = if backend.targets.len() != 1 {
+#         is_multiplexing = true; None
+#     } else if backend.targets[0].always_use_prefix { None }
+#       else { Some(backend.targets[0].name.to_string()) };
+#
+# With exactly ONE target the prefix is DROPPED. `always_use_prefix` is
+# driven by the xDS `MCPBackend.prefix_mode` field
+# (crates/protos/proto/resource.proto:1659-1670,
+# crates/agentgateway/src/types/agent_xds.rs:1457-1460), and the
+# Kubernetes controller NEVER sets it - grep for PrefixMode across
+# controller/ at tag v1.3.1 returns nothing, and
+# backend_plugin.go:355-370 builds api.MCPBackend with only Targets,
+# StatefulMode and FailureMode. It therefore stays CONDITIONAL (=0).
+#
+# Consequence for Story 34.16: a single-server MCP backend serves
+# UNPREFIXED tool names, and there is no knob to change that. Federating
+# servers one at a time, or ever dropping to one target, silently breaks
+# every client. The `mcp-federation-single` backend below exists purely
+# to demonstrate that live rather than assert it.
+#
+# ===================================================================
+# WHY `static.backendRef` AND NOT `static.host`
+# ===================================================================
+# `backendRef` is a namespace-local Service reference
+# (backend_plugin.go:270-289 resolves it to a
+# BackendReference_Service{hostname, namespace}), which is why this whole
+# app lives in ns `mcp` next to the proxyrunner Services. It keeps the
+# manifests free of hand-written FQDNs and lets the gateway route through
+# the Service's EndpointSlices.
+#
+# Cost, recorded because it is a real CRD constraint:
+#   "mcp target policies may not be used with backendRef"
+# (AgentgatewayBackend CEL validation). No per-target policies are needed
+# here - none of the five proxyrunner endpoints requires backend auth or
+# TLS - so the constraint is free today. If a future target ever needs
+# backend credentials, that target (and only that target) must switch to
+# the `host`/`port` form.
+#
+# `path: /mcp` and `protocol: StreamableHTTP` are stated explicitly rather
+# than relying on the CRD default ("Defaults to /sse for SSE or /mcp for
+# StreamableHTTP"), because all five MCPServer CRs advertise
+# `.../mcp` in their own registry-url annotations and an accidental
+# protocol default flip would be a silent SSE downgrade.
+#
+# ===================================================================
+# failureMode: FailOpen - A DELIBERATE CHOICE, NOT THE DEFAULT
+# ===================================================================
+# The CRD default is FailClosed: "fails the entire session if any target
+# fails". Measured state of this estate on 2026-08-02 (read-only, see
+# WI-034-6 sec 3): graphiti returns HTTP 421 to every non-loopback Host
+# (an upstream graphiti/FastMCP defect, NOT a gateway problem, and it
+# breaks vmcp identically today), and the three stdio proxyrunners have a
+# demonstrated habit of losing their exec stream to the backend pod.
+# Under FailClosed a single sick target would take down tools/list for all
+# five. FailOpen keeps the healthy targets serving and is the only setting
+# consistent with what vmcp does today (it logged "Successfully queried
+# 1/5 backends" and still served n8n's 20 tools).
+#
+# sessionRouting is left at its default (Stateful). Accepted consequence,
+# and the constraint the brief calls out: the MCP data plane is capped at
+# ONE proxy replica while stateful. Recorded in WI-034-6 sec 7.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-federation
+  namespace: mcp
+spec:
+  mcp:
+    failureMode: FailOpen
+    targets:
+      # Target names are the prefix. Do not rename without renaming the
+      # tools every client has bound to.
+      - name: graphiti
+        static:
+          backendRef:
+            name: mcp-graphiti-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+      - name: n8n
+        static:
+          backendRef:
+            name: mcp-n8n-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+      - name: unifi
+        static:
+          backendRef:
+            name: mcp-unifi-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+      - name: truenas-baldar
+        static:
+          backendRef:
+            name: mcp-truenas-baldar-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+      - name: truenas-heimdall
+        static:
+          backendRef:
+            name: mcp-truenas-heimdall-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+---
+# The one-target control. Same n8n target, alone, so the conditional-prefix
+# behaviour documented above is proven by observation rather than by
+# reading Rust: `/mcp-single` must return `tools_documentation`, while
+# `/mcp` must return `n8n_tools_documentation` for the same upstream tool.
+#
+# n8n is the control because it is the one server measured healthy
+# end-to-end on 2026-08-02 (20 tools, fresh backend response), so a
+# difference between the two routes can only be the prefix rule.
+#
+# This backend is spike-only and must be deleted with the rest of this
+# Kustomization; it must NEVER become the production shape.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-federation-single
+  namespace: mcp
+spec:
+  mcp:
+    failureMode: FailOpen
+    targets:
+      - name: n8n
+        static:
+          backendRef:
+            name: mcp-n8n-proxy
+          port: 8080
+          path: /mcp
+          protocol: StreamableHTTP
+---
+# JWKS source for Authentik, reached over plain in-cluster HTTP.
+#
+# Same shape and same reasoning as Story 34.3's
+# `auth-matrix-authentik-jwks` (WI-034-3 sec 3.2), restated here because
+# this Kustomization is in ns `mcp` and cannot reference an object in
+# ns `ai`:
+#   - a static Backend, not a cross-namespace `kind: Service` ref, because
+#     the latter needs a ReferenceGrant in ns `security` which this app
+#     cannot place;
+#   - no TLS policy, which is the documented clear-text shape at v1.3.1
+#     (remotehttp/resolver.go builds http://<host:port>/<path> unless a
+#     TLS policy is attached);
+#   - reachability and content already verified live in 34.3: the endpoint
+#     answers HTTP 200 with an RS256 key over plain HTTP on the Service
+#     port, and ns `security` has no CiliumNetworkPolicies at all.
+#
+# Carried forward from 34.3 finding F5: the JWKS is fetched by the
+# agentgateway CONTROLLER in ns `network`, not by the proxy pod, and is
+# inlined into the xDS config at translation time. A controller that
+# cannot reach Authentik shows up as a policy that fails to translate, not
+# as a request-time error - so deploy validation must check policy status,
+# not just curl.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-federation-authentik-jwks
+  namespace: mcp
+spec:
+  static:
+    host: authentik-server.security.svc.cluster.local
+    port: 80

--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/app/httproute.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/app/httproute.yaml
@@ -1,0 +1,204 @@
+---
+# STORY-034-6 (MCP federation spike): the federated MCP route.
+#
+# Hostname is single-level so the existing wildcard cert
+# (`homelab0-org-production-tls`, dnsNames ["homelab0.org","*.homelab0.org"])
+# covers it - the same constraint 34.4 and 34.3 hit. No external-dns
+# annotation here, but per 34.4 finding F2 `unifi-dns` runs
+# `--source=gateway-httproute` with no `--gateway-name` filter, so it will
+# publish a LAN A record for this hostname automatically. That is expected,
+# not a leak: public DNS stays impossible because cloudflare-dns is scoped
+# `--gateway-name=envoy-external`. Every rule below requires a real
+# Authentik JWT except the two public OAuth metadata documents, which RFC
+# 8414 / RFC 9728 require to be unauthenticated.
+#
+# vmcp is untouched. `mcp-gateway.homelab0.org` (envoy-internal ->
+# vmcp-homelab-gateway:4483) keeps serving throughout; this is a second,
+# parallel endpoint on a different hostname and a different Gateway.
+#
+# ===================================================================
+# EVERY RULE IS AN EXPLICIT PATH MATCH (34.4 finding F3)
+# ===================================================================
+# No `PathPrefix: /` catch-all anywhere. F3 was written about GPU wakes,
+# and no GPU is reachable from this route at all - but the same property
+# buys the diagnostic that every Phase-2 test below relies on: on this
+# hostname `404` means "no rule matched", `401` means "the JWT policy did
+# its job", and `403` means "the MCP authorization CEL did its job".
+#
+# The two PathPrefix rules that do exist are pinned under
+# `/.well-known/oauth-*`, which the gateway's own MCP auth layer terminates
+# (crates/agentgateway/src/mcp/auth.rs:19-22, 65-96) - they cannot reach a
+# tool.
+#
+# ===================================================================
+# METHOD PINNING ON THE METADATA RULES IS A SAFETY PROPERTY
+# ===================================================================
+# `oauth-as-metadata` is deliberately the ONE rule with no
+# jwtAuthentication policy (see policies.yaml for why it must not have
+# one). Its backendRef is a schema filler that a working directResponse
+# never reaches - but if that policy ever failed to attach, the rule would
+# fall through to the MCP backend with no authentication at all, and an
+# MCP `initialize` + `tools/list` would then succeed anonymously.
+# `method: GET` closes that structurally: MCP JSON-RPC is POST, and a
+# bare GET to a streamable-HTTP endpoint without a session id is rejected
+# by the transport. The same pinning is applied to the other metadata
+# rules for consistency.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-mcp-federation
+  namespace: mcp
+spec:
+  parentRefs:
+    - name: ai-gateway
+      namespace: network
+  hostnames:
+    - ai-gateway-mcp.homelab0.org
+  rules:
+    # -----------------------------------------------------------------
+    # The federated endpoint: all five MCP servers behind one URL, tool
+    # names prefixed `{workload}_` exactly as vmcp renders them today.
+    # Requires a real Authentik JWT (aud toolhive-mcp-gateway) and is
+    # subject to the MCP tool-RBAC CEL in policies.yaml.
+    - name: federated
+      matches:
+        - path:
+            type: Exact
+            value: /mcp
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation
+      # 60s is the longest per-workload timeout vmcp configures today
+      # (truenas-baldar / truenas-heimdall, virtualmcpserver.yaml:28-32).
+      # Per-target timeouts inside one MCP Backend do not exist at
+      # v1.3.1, so the route timeout must be the MAX of the workloads it
+      # fronts, not the default 30s - otherwise the two TrueNAS servers
+      # regress relative to vmcp. Story 34.16 inherits this decision.
+      timeouts:
+        request: 60s
+      # Explicitly zero, matching 34.4's shape. A retried tools/call is a
+      # retried side effect; MCP is not safe to replay blindly.
+      retry:
+        attempts: 0
+    # -----------------------------------------------------------------
+    # The one-target control (see backends.yaml). Exists ONLY to prove
+    # live that a single-target MCP backend drops the prefix. Expected
+    # Phase-2 result: this endpoint returns `tools_documentation` where
+    # /mcp returns `n8n_tools_documentation`.
+    - name: single
+      matches:
+        - path:
+            type: Exact
+            value: /mcp-single
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation-single
+      timeouts:
+        request: 60s
+      retry:
+        attempts: 0
+    # -----------------------------------------------------------------
+    # RFC 9728 protected-resource metadata. Public by specification, and
+    # the gateway's MCP auth layer exempts it from JWT validation before
+    # serving it (agent.rs:2560-2568 skips `jwt.apply` for well-known
+    # paths, then hands off to `handle_mcp_request`).
+    #
+    # PathPrefix, not Exact: clients append the resource path, so the real
+    # request is `/.well-known/oauth-protected-resource/mcp`.
+    #
+    # This is the endpoint today's vmcp gets wrong - it 401s its own
+    # discovery document and advertises an in-cluster
+    # `http://homelab-gateway.mcp.svc.cluster.local:4483/...` URL that no
+    # external client can resolve (measured 2026-08-02, WI-034-6 sec 6).
+    - name: oauth-protected-resource
+      matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/oauth-protected-resource
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation
+    # -----------------------------------------------------------------
+    # RFC 8414 authorization-server metadata, served as a directResponse.
+    #
+    # This is the DCR-proxy hinge of Part B. Authentik has NO
+    # `registration_endpoint` (verified live: its
+    # openid-configuration omits the key entirely), so a strict MCP client
+    # cannot register and cannot obtain a token. agentgateway ships the
+    # remedy - a mock DCR responder keyed on
+    # `jwtAuthentication.mcp.clientId` - but that responder is only ever
+    # reached if the advertised `registration_endpoint` points back at the
+    # gateway. Nothing in the v1.3.1 CRD can inject that key into a
+    # proxied document (the `provider: Keycloak` branch that would rewrite
+    # it hard-fails when the upstream document lacks the key -
+    # mcp/auth.rs:280-298 - so it is unusable against Authentik).
+    #
+    # Hence: serve the document ourselves. See policies.yaml for the body
+    # and the field-by-field justification.
+    - name: oauth-as-metadata
+      matches:
+        - path:
+            type: Exact
+            value: /.well-known/oauth-authorization-server
+          method: GET
+      # Schema filler only - the directResponse policy answers first.
+      # See the METHOD PINNING note above for what guards this.
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation
+    # -----------------------------------------------------------------
+    # Diagnostic twin of the rule above: the gateway's OWN proxied view of
+    # Authentik's authorization-server metadata, reached by letting the
+    # MCP auth layer handle a well-known path normally.
+    #
+    # Worth one rule because it proves two things Phase 2 would otherwise
+    # have to assume: (i) the agentgateway data plane can actually reach
+    # Authentik at the RFC 8414 path-inserted URL
+    # `https://authentik.homelab0.org/.well-known/oauth-authorization-server/application/o/toolhive-mcp-gateway/`
+    # (that exact URL was verified to return 200 from the dev box on
+    # 2026-08-02 - and 404 WITHOUT the trailing slash, which is why the
+    # issuer's trailing slash is load-bearing here too); and (ii) it gives
+    # a byte-level diff target for the synthesized document above, so any
+    # future drift in Authentik's real metadata is visible rather than
+    # silently masked.
+    - name: oauth-as-upstream
+      matches:
+        - path:
+            type: Exact
+            value: /.well-known/oauth-authorization-server/upstream
+          method: GET
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation
+    # -----------------------------------------------------------------
+    # The mock Dynamic Client Registration endpoint.
+    #
+    # `handle_mcp_request` matches `path.ends_with("client-registration")`
+    # BEFORE either well-known prefix arm (mcp/auth.rs:71-96), and with
+    # `clientId` set it short-circuits to `build_mock_dcr_response`
+    # (mcp/auth.rs:316-323, 370-403) instead of proxying a registration
+    # request to an IdP that has no such endpoint. The response echoes the
+    # client's requested `redirect_uris` and returns
+    # `token_endpoint_auth_method: "none"` + `grant_types:
+    # ["authorization_code"]`, which is exactly what the existing public
+    # PKCE provider expects.
+    #
+    # Still under the `/.well-known/oauth-authorization-server` prefix, so
+    # JWT validation is skipped - which is required: registration happens
+    # before the client has any token.
+    - name: oauth-dcr
+      matches:
+        - path:
+            type: Exact
+            value: /.well-known/oauth-authorization-server/client-registration
+          method: POST
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-federation

--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/app/kustomization.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # STORY-034-6: MCP federation spike. All additive; no file owned by the
+  # toolhive / toolhive-gateway / toolhive-registry Kustomizations is
+  # touched, and vmcp keeps serving on mcp-gateway.homelab0.org throughout.
+  - backends.yaml
+  - httproute.yaml
+  - policies.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/app/networkpolicy.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/app/networkpolicy.yaml
@@ -1,0 +1,68 @@
+---
+# STORY-034-6: the one piece of this story that is NOT optional plumbing.
+#
+# ===================================================================
+# WHY THIS IS REQUIRED (34.4 needed no CNP; this story does)
+# ===================================================================
+# Story 34.4 could skip network policy entirely because ns `ai`'s KServe
+# predictors are reached through Kourier, and the ai-gateway proxy pod in
+# ns `network` is selected by ZERO CiliumNetworkPolicies (so its egress is
+# default-allow). That reasoning covers the SOURCE side only, and it still
+# holds - nothing here touches ns `network`.
+#
+# The DESTINATION side is different. Verified live 2026-08-02:
+# `toolhive-gateway/app/networkpolicy-mcpservers.yaml` declares
+# CiliumNetworkPolicy `toolhive-mcpservers` with
+# `endpointSelector: {matchLabels: {toolhive: "true"}}`, and the
+# proxyrunner Deployments' pods DO carry `toolhive=true` (confirmed via
+# `kubectl get pods -n mcp --show-labels`: e.g. `graphiti-554fc9ffd7-*`
+# has both `app.kubernetes.io/name=mcpserver` and `toolhive=true`).
+#
+# In Cilium, once ANY policy selects an endpoint, that endpoint's ingress
+# is default-deny for everything not explicitly allowed. That policy's
+# ingress allowlist is exactly three sources - the vmcp pods
+# (`app.kubernetes.io/name: virtualmcpserver`), the ToolHive operator, and
+# the proxyrunners themselves. The agentgateway proxy is none of them, so
+# without this file the federated backend cannot reach a single MCP
+# target and every tools/list would come back empty.
+#
+# ===================================================================
+# WHY A SEPARATE POLICY OBJECT INSTEAD OF EDITING THE EXISTING ONE
+# ===================================================================
+# Cilium evaluates the UNION of all policies selecting an endpoint, so an
+# additive policy grants the same access as an extra `ingress:` entry
+# would. Keeping it separate means this story modifies no file owned by
+# the `toolhive-gateway` Kustomization, and `git revert` of this PR
+# removes the grant completely and atomically. vmcp's own reachability is
+# unaffected either way.
+#
+# ===================================================================
+# SCOPE: AS TIGHT AS THE LABELS ALLOW
+# ===================================================================
+# Destination is the PROXYRUNNER pods only
+# (`app.kubernetes.io/name: mcpserver`), not every `toolhive=true`
+# endpoint - so the stdio backend StatefulSets (`graphiti-0`, `unifi-0`,
+# `truenas-*-0`, which also carry `toolhive=true`) are NOT opened up.
+# Source is pinned to the single Gateway by
+# `gateway.networking.k8s.io/gateway-name: ai-gateway`, which is narrower
+# than the namespace and narrower than the GatewayClass - a second
+# agentgateway Gateway in ns `network` would not inherit this grant.
+# Port is the single proxyPort every MCPServer CR declares (8080).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: agentgateway-mcp-federation
+  namespace: mcp
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcpserver
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            gateway.networking.k8s.io/gateway-name: ai-gateway
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/app/policies.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/app/policies.yaml
@@ -1,0 +1,461 @@
+---
+# STORY-034-6 (MCP federation spike): auth + tool RBAC + the DCR proxy.
+#
+# Every policy here targets either a NAMED RULE of
+# `agentgateway-mcp-federation` or one of this story's own
+# AgentgatewayBackends. Nothing targets the Gateway, and nothing targets
+# 34.2's pilot route, 34.3's auth-matrix route or 34.4's wake-gate route.
+#
+# One concern per policy object, for the reason 34.3 established: policies
+# merge on a FIELD-LEVEL basis (AgentgatewayPolicy spec.traffic
+# doc-string), so disjoint fields compose safely, and keeping CEL in its
+# own object means a CEL compile failure can never strip authentication
+# off a rule.
+#
+# ===================================================================
+# TOPOLOGY NOTE (34.3 finding F4, still binding)
+# ===================================================================
+# A policy's targetRef selects a SAME-NAMESPACE object. This app is in ns
+# `mcp` and Gateway `ai-gateway` is in ns `network`, so nothing here can
+# be Gateway-scoped even if it wanted to be. Per-route scoping is what
+# 34.3 recorded as the standing rule for Phases 1-5 anyway.
+
+# ===================================================================
+# 1. JWT AUTHENTICATION + MCP OAUTH DISCOVERY
+# ===================================================================
+# `traffic.jwtAuthentication` with the `.mcp` sub-object, NOT the
+# deprecated `backend.mcp.authentication`. The CRD says so explicitly:
+# "This field is deprecated; prefer to use traffic policy
+# `jwtAuthentication.mcp`, which ensures authentication runs before other
+# policies such as transformation and rate limiting." The two are also
+# mutually exclusive by CRD validation, and the deprecated form actively
+# rejects a request whose JWT was already validated upstream
+# ("MCP backend authentication configured but JWT token already validated
+# and stripped by Gateway or Route level policy" - mcp/auth.rs:33-40).
+#
+# What `.mcp` buys beyond plain JWT validation (agent.rs:2553-2574):
+#   1. `/.well-known/oauth-*` paths are EXEMPTED from JWT validation, then
+#      handed to `handle_mcp_request` which serves the discovery documents.
+#   2. A 401 carries
+#      `WWW-Authenticate: Bearer resource_metadata="<base>/.well-known/oauth-protected-resource<path>"`,
+#      which is the RFC 9728 handshake every strict MCP client starts from.
+# Both are things today's vmcp gets wrong (it 401s its own discovery
+# document and advertises an in-cluster URL) - see WI-034-6 sec 6.
+#
+# CRD constraints satisfied: `.mcp` requires exactly one provider, and
+# requires mode Strict (both CEL-validated).
+#
+# `provider` is deliberately UNSET. The enum only offers Auth0 / Keycloak /
+# Okta, and Authentik is none of them:
+#   - Keycloak mode fetches `{issuer}/.well-known/openid-configuration`
+#     (which Authentik DOES serve) but then hard-fails with
+#     "registration_endpoint missing" when the upstream document lacks
+#     that key - and Authentik's does (verified live). Unusable.
+#   - Unset mode fetches the RFC 8414 path-inserted URL, which Authentik
+#     serves at
+#     .../.well-known/oauth-authorization-server/application/o/toolhive-mcp-gateway/
+#     - verified HTTP 200 live on 2026-08-02, and 404 without the trailing
+#     slash. The issuer's trailing slash (Authentik runs
+#     `issuer_mode: per_provider`) is what makes the derived URL correct.
+#
+# `clientId` is the literal OAuth client_id of the EXISTING
+# blueprint-managed public PKCE provider. It is not a credential: OAuth
+# client IDs for public clients are published by definition, this exact
+# string is already in Git at
+# `toolhive-gateway/app/virtualmcpserver.yaml:47`, and the provider is
+# `client_type: public` with no secret. It is what the mock DCR responder
+# hands back to clients.
+#
+# DRIFT HAZARD (security-guardian, 2026-08-02). The blueprint does not
+# hardcode this value - it reads `!Env
+# AUTHENTIK_TOOLHIVE_MCP_GATEWAY_CLIENT_ID` from 1Password
+# (`security/authentik/app/externalsecret.yaml:80-83`). Verified live on
+# 2026-08-02 that the 1Password value IS currently the literal string
+# `toolhive-mcp-gateway` (it appears as `client_id=` in the authorize URL
+# Authentik accepts). But if that item is ever rotated, this file and
+# `virtualmcpserver.yaml:47` both drift silently and MCP auth breaks with
+# no compile-time signal. Pre-existing to this story - flagged for a
+# follow-up that resolves the ID from the Secret instead of duplicating
+# it. Do not "fix" it here by inventing a new indirection: the CRD field
+# takes a literal string, and 34.16 owns the production shape.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: mcp-federation-jwt
+  namespace: mcp
+spec:
+  targetRefs:
+    # Every rule EXCEPT `oauth-as-metadata`. That omission is load-bearing,
+    # not an oversight: this policy's MCP layer terminates any path
+    # starting with `/.well-known/oauth-authorization-server` by proxying
+    # Authentik's document as a DirectResponse, which would pre-empt the
+    # synthesized document in section 2 below and silently drop the
+    # `registration_endpoint` that the whole DCR flow depends on.
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: federated
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: single
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: oauth-protected-resource
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: oauth-as-upstream
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: oauth-dcr
+  traffic:
+    jwtAuthentication:
+      mode: Strict
+      providers:
+        - issuer: https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/
+          # Same audience vmcp validates today
+          # (virtualmcpserver.yaml:49), injected by the blueprint's "MCP
+          # Gateway Audience" scope mapping on the `mcp` scope
+          # (configmap-blueprints.yaml:123-133).
+          #
+          # Recorded because it corrects an assumption in WI-034-3 sec 3.4:
+          # Authentik's fallback audience when the `mcp` scope is omitted
+          # is the client_id, and the client_id here IS the literal string
+          # `toolhive-mcp-gateway`. So a token requested WITHOUT the `mcp`
+          # scope carries the SAME `aud` and will be ACCEPTED. 34.3's
+          # `--no-mcp` "wrong-audience negative test" therefore does not
+          # test what it claims to; a genuine wrong-audience token has to
+          # come from a different provider.
+          audiences:
+            - toolhive-mcp-gateway
+          jwks:
+            remote:
+              backendRef:
+                group: agentgateway.dev
+                kind: AgentgatewayBackend
+                name: mcp-federation-authentik-jwks
+              jwksPath: /application/o/toolhive-mcp-gateway/jwks/
+      mcp:
+        clientId: toolhive-mcp-gateway
+        # These keys are camelCase here and emitted snake_case in the RFC
+        # 9728 document (`to_rfc_json` runs `to_snake_case` over every
+        # user-supplied key, and user keys override the computed ones).
+        #
+        # `resource` is pinned rather than derived so the WWW-Authenticate
+        # challenge is deterministic: the code uses this value's origin as
+        # the base for the resource_metadata URL it advertises, and
+        # deriving it from the request would make the challenge depend on
+        # proxy/Host handling.
+        #
+        # `authorizationServers` points at THIS GATEWAY, not at Authentik.
+        # That is what routes the client's RFC 8414 discovery to the
+        # synthesized document in section 2, which is the only document in
+        # this chain that carries a `registration_endpoint`.
+        resourceMetadata:
+          resource: https://ai-gateway-mcp.homelab0.org/mcp
+          authorizationServers:
+            - https://ai-gateway-mcp.homelab0.org
+          scopesSupported:
+            - openid
+            - profile
+            - email
+            - mcp
+          bearerMethodsSupported:
+            - header
+---
+# ===================================================================
+# 2. THE SYNTHESIZED AUTHORIZATION-SERVER METADATA (the DCR proxy)
+# ===================================================================
+# Authentik does not implement Dynamic Client Registration
+# (goauthentik#8751 is still open, and the epic lists MCP-spec OAuth with
+# DCR as future work). Its discovery document has no
+# `registration_endpoint` at all - verified live 2026-08-02 against
+# https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/.well-known/openid-configuration
+#
+# agentgateway already ships the missing half: with
+# `jwtAuthentication.mcp.clientId` set, a POST to any path ending
+# `client-registration` returns a deterministic registration response
+# naming the pre-registered client instead of creating one upstream. What
+# it does NOT ship is a way to advertise that endpoint when the upstream
+# document omits it (the only rewrite path, `provider: Keycloak`, hard
+# -fails on exactly that condition).
+#
+# So this document is served locally. Every endpoint below is copied
+# verbatim from Authentik's live discovery document; only
+# `registration_endpoint` is added, and it points back at this gateway.
+#
+# Two deliberate divergences from Authentik's own document, both
+# corrections rather than fabrications:
+#
+#   * `token_endpoint_auth_methods_supported: ["none"]`. Authentik
+#     advertises `client_secret_post` / `client_secret_basic` globally,
+#     but THIS provider is `client_type: public` with no secret
+#     (configmap-blueprints.yaml). A strict client reading Authentik's
+#     global list would try to authenticate with a secret it cannot have.
+#     `none` is the correct value for a public PKCE client.
+#   * `grant_types_supported` and `response_types_supported` are narrowed
+#     to the authorization-code + refresh flows. Authentik also advertises
+#     `implicit`, `password` and `client_credentials`; none is appropriate
+#     for an MCP client, and `password` in particular should never be
+#     advertised to one.
+#
+# RFC 8414 nuance, recorded rather than glossed: `issuer` names Authentik
+# while this document is served from the gateway's metadata URL, so a
+# maximally strict client could object. This is not a shortcut - it is
+# exactly what agentgateway itself does when it proxies the upstream
+# document (mcp/auth.rs:217-312 returns the upstream body, issuer
+# included, under the gateway's own URL). The `oauth-as-upstream`
+# diagnostic rule exists so Phase 2 can diff the two documents and confirm
+# they agree on everything except `registration_endpoint`.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: mcp-federation-as-metadata
+  namespace: mcp
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-mcp-federation
+      sectionName: oauth-as-metadata
+  traffic:
+    directResponse:
+      status: 200
+      headers:
+        - name: content-type
+          value: application/json
+        - name: cache-control
+          value: "no-store"
+        # RFC 8414 metadata is fetched cross-origin by browser-based
+        # clients; agentgateway sets these itself on the documents it
+        # serves, so the locally-served one matches.
+        - name: access-control-allow-origin
+          value: "*"
+      # KEEP THIS PRETTY-PRINTED - do not collapse it back onto one line.
+      # The repo's own `authentik-token` Gitleaks rule
+      # (`.gitleaks.toml:205-209`) is line-anchored:
+      #   (?i)authentik[^\n]*(token|secret|key)[^\n]*[A-Za-z0-9_-]{32,}
+      # A single-line form of this document puts "authentik",
+      # "token_endpoint" and a 32-character identifier
+      # (`code_challenge_methods_supported`) on the same line and trips it -
+      # confirmed on the first CI run of this PR. There is no secret here;
+      # every value is a public OAuth discovery URL. Splitting the lines is
+      # the right fix because it keeps the detection rule at full strength
+      # rather than adding a `.gitleaks.toml` allowlist entry that would
+      # weaken it for every future file.
+      body: |
+        {
+          "issuer": "https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/",
+          "authorization_endpoint": "https://authentik.homelab0.org/application/o/authorize/",
+          "token_endpoint": "https://authentik.homelab0.org/application/o/token/",
+          "userinfo_endpoint": "https://authentik.homelab0.org/application/o/userinfo/",
+          "jwks_uri": "https://authentik.homelab0.org/application/o/toolhive-mcp-gateway/jwks/",
+          "registration_endpoint": "https://ai-gateway-mcp.homelab0.org/.well-known/oauth-authorization-server/client-registration",
+          "scopes_supported": ["openid", "profile", "email", "offline_access", "mcp"],
+          "response_types_supported": ["code"],
+          "response_modes_supported": ["query"],
+          "grant_types_supported": ["authorization_code", "refresh_token"],
+          "code_challenge_methods_supported": ["S256"],
+          "token_endpoint_auth_methods_supported": ["none"],
+          "id_token_signing_alg_values_supported": ["RS256"],
+          "subject_types_supported": ["public"]
+        }
+---
+# ===================================================================
+# 3. MCP TOOL RBAC - the Cedar rule, re-expressed in CEL
+# ===================================================================
+# Today's rule (virtualmcpserver.yaml:62-93), three Cedar statements:
+#   permit call_tool when principal.claim_email == "<admin>"
+#   permit call_tool when !resource.name like "unifi_*"
+#   forbid call_tool when resource.name like "unifi_*" && email != "<admin>"
+#
+# ------------------------------------------------------------------
+# THE FINDING THAT DECIDES HOW THIS IS WRITTEN
+# ------------------------------------------------------------------
+# The brief asked whether `mcp.tool.name` carries the PREFIXED name under
+# federation. It does NOT. Verified three ways at tag v1.3.1:
+#
+#   * tools/list - handler.rs:317-346: authorization runs inside
+#     `merge_tools` on `ResourceId::new(server_name, t.name)` where
+#     `t.name` is still the RAW upstream name; `resource_name()` applies
+#     the prefix afterwards, in a later `.map()`.
+#   * tools/call - session.rs:453-470: the client sends the prefixed name,
+#     `parse_resource_name` splits it at the FIRST `_` into
+#     (service_name, tool), and authorization is handed
+#     `ResourceId::new(service_name, tool)` - the UNPREFIXED half.
+#   * schema/cel.md:121-122 documents it in as many words:
+#     `mcp.tool.target` = "The target handling the tool call after
+#     multiplexing resolution", `mcp.tool.name` = "The resolved tool name
+#     sent to the upstream target".
+#
+# So `mcp.tool.name.startsWith('unifi_')` - the naive transliteration of
+# the Cedar rule - would be WRONG in both directions. It would fail to
+# match the real unifi tools on `tools/call` (the gateway strips the
+# `unifi_` prefix before authorization, leaving `unifi_tool_index` etc.
+# from the SERVER's own naming, which happens to still start with
+# `unifi_`... but `truenas-baldar_list_pools` arrives as `list_pools`),
+# and it would wrongly match any other server that ever shipped a tool
+# literally named `unifi_*`.
+#
+# The correct predicate is `mcp.tool.target`, which is the workload name -
+# i.e. exactly the thing the Cedar `unifi_*` glob was really selecting on.
+#
+# ------------------------------------------------------------------
+# WHY THREE POLICY OBJECTS
+# ------------------------------------------------------------------
+# `backend.mcp.authorization` holds ONE action and ONE rule whose
+# `matchExpressions` are ANDed. Cedar's two independent `permit`s are
+# therefore two Allow policies; the CRD merges "authorization rules
+# applied across different policies" into one rule set, and "any matching
+# allow rule allows the request".
+#
+# ------------------------------------------------------------------
+# WHAT THIS DOES *NOT* DO, STATED PLAINLY
+# ------------------------------------------------------------------
+# A denied tool does NOT produce an HTTP 403. The CRD is explicit:
+# "Unlike authorization at the HTTP level, which rejects unauthorized
+# requests with a 403 error, this policy works at the MCPBackend level.
+# List operations ... will have each item evaluated. Items that do not
+# meet the rule will be filtered. Get or call operations ... will evaluate
+# the specific item and reject requests that do not meet the rule."
+# So: unifi tools VANISH from a non-admin's tools/list, and a direct
+# tools/call returns a JSON-RPC error inside an HTTP 200. That is the same
+# shape vmcp's Cedar layer produces today, and it is the only shape the
+# product offers - HTTP-level authorization CEL runs before the MCP body
+# is parsed, so `mcp.tool.*` is not populated there.
+#
+# Prompts and resources are denied outright, because no Allow rule
+# references `mcp.prompt` / `mcp.resource` and deny-by-default applies
+# once any Allow exists. That is FAITHFUL to today: Cedar is also
+# deny-by-default and its three statements only ever permit
+# `Action::"call_tool"`. It is also currently moot - all five servers
+# were measured on 2026-08-02 returning `"prompts":[]` and
+# `"resources":[]`. Story 34.16 must revisit this if any server ever
+# grows one.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: mcp-federation-authz-nonadmin
+  namespace: mcp
+spec:
+  targetRefs:
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation-single
+  backend:
+    mcp:
+      # Cedar statement 2: everyone authenticated gets every non-unifi tool.
+      authorization:
+        action: Allow
+        policy:
+          matchExpressions:
+            - mcp.tool.target != 'unifi'
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: mcp-federation-authz-admin
+  namespace: mcp
+spec:
+  targetRefs:
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation-single
+  backend:
+    mcp:
+      # Cedar statement 1: the admin gets everything, unifi included.
+      #
+      # `jwt.<claim>` is the flattened claims map
+      # (http/jwt.rs:423-426 + its DynamicType impl), and the MCP
+      # authorization executor is built from the request
+      # (cel/types.rs:568-573 -> set_request -> `jwt: ext::<jwt::Claims>`),
+      # so verified claims ARE in scope here. Confirmed against a real
+      # Authentik access token on 2026-08-02: it carries `groups` (and
+      # `email`), so both forms are addressable.
+      #
+      # GROUP CLAIM, NOT EMAIL. The first draft matched on a personal
+      # email literal duplicated across this rule and the deny rule below.
+      # Replaced for three reasons: it is PII in a public repo, two copies
+      # of one identity can drift apart, and the token's
+      # `email_verified` is **false** - so `email` is an unverified
+      # self-asserted string and is the weaker claim of the two.
+      #
+      # `authentik Admins` is the IdP superuser group and is the admin
+      # identity for now. It is deliberately coarse: membership grants
+      # Authentik superuser, so it is a strict superset of who should hold
+      # unifi access rather than a purpose-built role. A dedicated
+      # `mcp-admins` group is the right end state and is tracked as a
+      # follow-up (rider 34.M9); the group does NOT exist yet, and naming
+      # it here would evaluate false for every principal and make unifi
+      # unreachable - fail-closed, but indistinguishable from a correct
+      # denial. Live group list at time of writing: `authentik Admins`,
+      # `bookstack-uid-full-access`, `bookstack-admins`,
+      # `openwebui-admins`.
+      #
+      # The `has()` guard is not decoration. Measured against the running
+      # gateway's own CEL evaluator (WI-034-6 sec 7.2): the bare form
+      # `'authentik Admins' in jwt.groups` raises
+      # "No such key: groups" for a token with no `groups` claim, and an
+      # expression that fails to evaluate does not match. Guarded, this
+      # rule and the deny rule below are EXACT negations across every
+      # input - present, absent, and empty-list - which is what keeps them
+      # from drifting.
+      authorization:
+        action: Allow
+        policy:
+          matchExpressions:
+            - has(jwt.groups) && 'authentik Admins' in jwt.groups
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: mcp-federation-authz-unifi-deny
+  namespace: mcp
+spec:
+  targetRefs:
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: mcp-federation-single
+  backend:
+    mcp:
+      # Cedar statement 3: the explicit forbid.
+      #
+      # Redundant against the deny-by-default that the two Allow rules
+      # already create - and kept for exactly the reason Cedar kept it.
+      # Deny beats Allow, so if a later story ever adds a broader Allow
+      # (a service-account rule, a break-glass rule), unifi stays shut for
+      # non-admins instead of quietly opening.
+      #
+      # The second expression is the De Morgan negation of the admin
+      # rule's guarded form:
+      #   !( has(jwt.groups) && 'authentik Admins' in jwt.groups )
+      #   == !has(jwt.groups) || !('authentik Admins' in jwt.groups)
+      # so the two rules are exact complements by construction, not by
+      # someone remembering to edit both. If the group name here and in
+      # the admin rule ever diverge, unifi opens for a non-admin - which
+      # is why they are written as one expression and its mechanical
+      # negation rather than as two independent conditions.
+      #
+      # `!has(jwt.groups)` is what makes this FIRE for a token carrying no
+      # `groups` claim at all, instead of erroring out into a no-match.
+      # That matters precisely here: without it, a groups-less token would
+      # be denied only by deny-by-default, and this rule's whole purpose
+      # is to keep unifi shut even if a future story adds a broader Allow.
+      authorization:
+        action: Deny
+        policy:
+          matchExpressions:
+            - mcp.tool.target == 'unifi'
+            - "!has(jwt.groups) || !('authentik Admins' in jwt.groups)"

--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/ks.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-mcp-federation
+  namespace: flux-system
+spec:
+  # STORY-034-6 (EPIC-034 Phase 0): federate the five ToolHive MCP servers
+  # behind the agentgateway data plane, in parallel with vmcp. Spike only -
+  # reverting this PR removes every object and leaves vmcp untouched.
+  dependsOn:
+    # The Gateway, its GatewayClass and the AgentgatewayBackend /
+    # AgentgatewayPolicy CRDs all come from the network tree.
+    - name: agentgateway-config
+      namespace: network
+    # The AgentgatewayBackend targets reference the mcp-*-proxy Services
+    # by name, which the MCPServer CRs in the toolhive-gateway Kustomization create.
+    - name: toolhive-gateway
+      namespace: mcp
+  interval: 1h
+  path: ./kubernetes/apps/mcp/agentgateway-mcp-federation/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  # Every resource in app/ carries an explicit `namespace: mcp`, so no
+  # targetNamespace is set. Matches the wake-gate app's shape rather than
+  # the pilot's, and keeps the rendered objects self-describing.
+  #
+  # No `decryption:` block: this story ships NO SOPS files. It mints no
+  # credential at all - the only secret material anywhere in the flow is a
+  # user's own Authentik token, which never touches the cluster's storage.
+  # (The parent cluster-apps Kustomization patches
+  # `decryption: {provider: sops}` into every child anyway -
+  # kubernetes/flux/cluster/ks.yaml:19-28 - so declaring one locally would
+  # only risk the ns-mismatch trap 34.2 hit live.)
+  wait: false

--- a/kubernetes/apps/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
   # See toolhive-gateway/app/mcpserver-n8n.yaml and mcpserver-graphiti.yaml
   # Registry Server (MCP discovery) - must be in same namespace as MCPServers
   - ./toolhive-registry/ks.yaml
+  # STORY-034-6 (EPIC-034 Phase 0): agentgateway MCP federation spike.
+  # Additive and parallel to vmcp - reverting removes it entirely.
+  - ./agentgateway-mcp-federation/ks.yaml


### PR DESCRIPTION
## Summary

EPIC-034 Story 34.6 (Phase 0 spike). Adds a second, parallel MCP endpoint on the `ai-gateway` data
plane at `ai-gateway-mcp.homelab0.org`, federating the five existing ToolHive MCP servers as static
targets. The current VirtualMCPServer endpoint (`mcp-gateway.homelab0.org`) is untouched and keeps
serving throughout, so this is additive and reverting removes it entirely.

Full evidence, citations and the Phase-2 protocol are in `WI-034-6-mcp-federation.md`.

## Read this first: the current MCP estate is largely broken

Found while capturing the `tools/list` baseline this story was supposed to diff against. The
internal vmcp logs `Successfully queried 1/5 backends` — only n8n was serving:

- `unifi`, `truenas-baldar`, `truenas-heimdall` — the ToolHive stdio proxyrunners lost their
  exec stream to the backend containers on **2026-06-28/29** (`err="EOF"`) and never recovered.
  Dead for 35 days.
- `graphiti` — returns **HTTP 421 Invalid Host header** to every non-loopback Host. Its image builds
  `FastMCP()` with no `host=` argument, so the MCP SDK auto-enables DNS-rebinding protection with
  loopback-only `allowed_hosts` at construction time; graphiti sets the real bind address afterwards,
  too late. No env var can undo it.

Three of the four were remediated in-session (pod deletion; `rollout restart` is a no-op because the
ToolHive operator strips the annotation). `unifi` and `truenas-heimdall` are healthy again.
`truenas-baldar` re-wedged twice with the same signature — a reproducible ToolHive defect, not a
one-off. Note ToolHive here is v0.8.0 against v0.41.0 upstream.

Neither issue is caused by this PR, and both would have surfaced during Story 34.16 as an apparent
agentgateway failure. Two follow-ups are recommended: the graphiti image fix (already agreed as a
separate bugfix story) and a ToolHive stdio/upgrade ticket.

## Changes

- **`mcp-federation` backend** — five static targets, named to reproduce vmcp's `{workload}_` tool
  prefix byte-for-byte. `failureMode: FailOpen` so one sick target cannot take down `tools/list`.
- **`mcp-federation-single` backend** — one-target control. A single-target MCP backend silently
  **drops** the prefix, and the controller never sets the field that would override it, so there is
  no CRD knob for it. This rule exists to demonstrate that live rather than assert it.
- **HTTPRoute** — six rules, every one an explicit path match, no `PathPrefix: /` catch-all.
- **JWT + MCP OAuth discovery** — Authentik remote JWKS validation, plus the RFC 9728 / RFC 8414
  discovery documents. The current endpoint 401s its own discovery documents and advertises an
  in-cluster ClusterIP URL no external client can resolve, so no MCP client can bootstrap against it
  today.
- **Locally-served authorization-server metadata** — Authentik has no `registration_endpoint`.
  agentgateway ships a pre-registered-client DCR responder but no way to advertise it when the
  upstream document omits the key. This serves the document with that one key added.
- **MCP tool RBAC** — the existing Cedar rule (unifi tools admin-only) re-expressed in CEL against
  `mcp.tool.target`, **not** `mcp.tool.name`. Under federation `mcp.tool.name` carries the
  *unprefixed* name, so the naive `startsWith('unifi_')` transliteration would silently protect
  nothing on the TrueNAS servers.
- **CiliumNetworkPolicy** — required, not optional. The proxyrunner pods are already selected by
  ToolHive's policy, so their ingress is default-deny and the gateway is not in the allowlist.
  Without this, every federated `tools/list` returns empty.

## Testing

Verified pre-merge:

- `kustomize build` renders 10 objects clean; `kubectl apply --dry-run=server` accepts all 10
  (this evaluates the CRDs' own CEL validation rules).
- **All four RBAC CEL expressions compiled and evaluated by the running gateway's own evaluator**
  (`POST /api/cel` via port-forward). Full truth table measured: unifi denied for non-admin and for
  a token with no email claim, allowed for admin; everything else allowed. The naive
  `mcp.tool.name` variant was measured failing on `truenas-baldar_list_pools`.
- Raw tool inventory captured live from all five servers (88 tools total) as the real diff target.
- Authentik discovery probed live: no DCR, RFC 8414 path form serves 200 with the trailing slash and
  404 without it.
- `thv proxy` verified performing OIDC discovery and correct S256 PKCE with a static client ID and
  **no dynamic registration attempted**.
- Claude Code 2.1.220 confirmed to support `--client-id` / `--callback-port`, so neither client type
  requires DCR.

Not verifiable pre-merge (GitOps — the route does not exist until Flux applies it): federated
`tools/list`, real tool calls, MCP session behaviour, and both clients end-to-end. The Phase-2
protocol is written out step by step in the WI doc.

One item needs a browser login that did not complete in time: confirming Authentik's **access token
carries an `email` claim**. If it does not, the admin allow rule fails to evaluate and unifi becomes
unreachable for everyone — fail-closed, but it must be checked before drawing any conclusion about
the RBAC. It is the first step of the Phase-2 protocol.

## Security review

security-guardian: **APPROVED**, no CRITICAL or HIGH findings, re-confirmed after applying its two
actionable notes. It independently verified auth coverage across all six route rules, the CNP scope,
that the DCR responder mints nothing and cannot bypass Authentik's server-side redirect allowlist,
and that public DNS exposure is structurally impossible for this Gateway. No secrets, no SOPS files,
no new credentials of any kind.

## Notes

- The `clientId` in the policy is the public OAuth client ID of the existing public PKCE provider,
  already committed in `virtualmcpserver.yaml`. A drift hazard against its 1Password source is
  documented inline.
- Static targets were chosen over selector discovery. Selector discovery *can* preserve the prefix
  contract via the `agentgateway.dev/mcp-target-name` annotation, but it would require writing to
  operator-owned Services and makes federation membership implicit. Accepted constraint: the MCP
  data plane is capped at one replica while session routing is stateful.
- The fallback ladder's third rung (static API keys via headers, flagged as a conscious regression
  needing sign-off) was **not** needed and is **not** being requested.

Relates to EPIC-034 Story 34.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified MCP federation endpoint connecting Graphiti, n8n, UniFi, and TrueNAS services.
  - Added a separate single-service MCP endpoint for n8n.
  - Added OAuth/JWT authentication, authorization metadata, and dynamic client registration support.
  - Added role-based tool access, including restricted access to UniFi tools.
  - Added protected-resource and authorization-server metadata endpoints.
- **Security**
  - Restricted MCP connections to authorized gateway traffic and authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->