### PR TITLE
fix(mcp): correct dependsOn namespace for the MCP federation Kustomization

### DIFF
--- a/kubernetes/apps/mcp/agentgateway-mcp-federation/ks.yaml
+++ b/kubernetes/apps/mcp/agentgateway-mcp-federation/ks.yaml
@@ -9,15 +9,40 @@ spec:
   # STORY-034-6 (EPIC-034 Phase 0): federate the five ToolHive MCP servers
   # behind the agentgateway data plane, in parallel with vmcp. Spike only -
   # reverting this PR removes every object and leaves vmcp untouched.
+  # `dependsOn[].namespace` is where the DEPENDENCY'S OWN Kustomization CR
+  # lives. It is NOT that Kustomization's `spec.targetNamespace`, and it is
+  # not inferable from the app's namespace - this repo has two conventions
+  # and both are in use below:
+  #
+  #   * 88 of the ks.yaml files set `metadata.namespace: flux-system`
+  #     explicitly. Their CR is in flux-system no matter which app tree the
+  #     file sits in. `toolhive-gateway` is one of these
+  #     (`mcp/toolhive-gateway/ks.yaml:6-7`) - its `spec.targetNamespace:
+  #     mcp` only says where its RESOURCES go.
+  #   * 15 set no namespace at all and inherit one from their tree's
+  #     kustomize transform. `agentgateway-config` is one of these, and
+  #     `kubernetes/apps/network/kustomization.yaml:4` sets
+  #     `namespace: network`, which is what puts its CR in ns network.
+  #
+  # The mcp tree has NO such transform, so files under it keep whatever
+  # `metadata.namespace` they declare. Verify against the cluster rather
+  # than guessing:
+  #   kubectl get kustomization -A | grep -E 'toolhive-gateway|agentgateway-config'
   dependsOn:
     # The Gateway, its GatewayClass and the AgentgatewayBackend /
     # AgentgatewayPolicy CRDs all come from the network tree.
+    # CR namespace: network (inherited from the network tree transform).
     - name: agentgateway-config
       namespace: network
-    # The AgentgatewayBackend targets reference the mcp-*-proxy Services
-    # by name, which the MCPServer CRs in the toolhive-gateway Kustomization create.
+    # The AgentgatewayBackend targets reference the mcp-*-proxy Services by
+    # name, which the MCPServer CRs owned by the toolhive-gateway
+    # Kustomization create in ns mcp.
+    # CR namespace: flux-system (declared in that file, NOT its
+    # targetNamespace of mcp - getting this wrong is what left this
+    # Kustomization stuck on "dependency 'mcp/toolhive-gateway' not found"
+    # and the whole federation deployed inert).
     - name: toolhive-gateway
-      namespace: mcp
+      namespace: flux-system
   interval: 1h
   path: ./kubernetes/apps/mcp/agentgateway-mcp-federation/app
   prune: true


### PR DESCRIPTION
## Summary

Post-merge defect on #1230. One functional line.

The `agentgateway-mcp-federation` Kustomization declared its `toolhive-gateway` dependency in
namespace `mcp`. That Kustomization's CR lives in `flux-system` — `mcp` is its
`spec.targetNamespace`, which only says where its *resources* go. Flux reported:

```
flux-system/agentgateway-mcp-federation   READY=False
  dependency 'mcp/toolhive-gateway' not found:
  kustomizations.kustomize.toolkit.fluxcd.io "toolhive-gateway" not found
```

and never applied anything. `kubectl get agentgatewaybackend -n mcp` returned *No resources found* —
**the federation merged green and deployed inert**, zero of its ten objects created.

## Changes

```diff
     - name: toolhive-gateway
-      namespace: mcp
+      namespace: flux-system
```

The `agentgateway-config` entry (`namespace: network`) was already correct and is unchanged. No
rendered object changes; the ten resources are byte-identical to what merged.

The rest of the diff is a comment recording why the two entries differ, because it is not
inferable and I got it wrong by reading `spec.targetNamespace`:

| convention | count | example | CR lands in |
|---|---|---|---|
| `metadata.namespace: flux-system` declared in the file | 88 | `toolhive-gateway` | `flux-system` |
| none declared; inherited from the tree's kustomize transform | 15 | `agentgateway-config` (`network/kustomization.yaml:4`) | `network` |

The `mcp` tree applies no namespace transform, so files under it keep whatever they declare.

## Testing

Both `dependsOn` entries resolved programmatically against the live cluster rather than by eye:

```
this Kustomization: flux-system/agentgateway-mcp-federation
  dependsOn network/agentgateway-config      exists in cluster: True
  dependsOn flux-system/toolhive-gateway     exists in cluster: True
ALL DEPENDENCIES RESOLVE: True
```

Also: app render unchanged (10 objects), `kubectl apply --dry-run=server` on the `ks.yaml` accepted.

Ordering re-checked: `toolhive-gateway` has `wait: true`, and `dependsOn` gates on the dependency
reaching `Ready`, so the `mcp-*-proxy` Services exist before the AgentgatewayBackends reference them.

## CI blind spot — second instance, not a one-off

**flux-local cannot catch dependency-resolution failures.** It renders each Kustomization's `path`
in isolation and diffs the output; it never builds the dependency graph. All 14 checks on #1230
passed while the Kustomization was unreconcilable. Every check in the pipeline is a *content* check.

Same class as #1223 (`decryption.secretRef` resolved `sops-age` in the wrong namespace) — both are
cross-object reference errors detectable only against a live cluster, and both shipped green.

Worth a follow-up: a static check that parses every `ks.yaml`'s `dependsOn` and asserts each
`(namespace, name)` matches some `ks.yaml`'s post-transform identity. That would have caught both.

## Security review

security-guardian: **APPROVED**. Confirmed the diff touches no rendered object and only gates *when*
reconciliation proceeds; independently verified all four factual claims in the new comment
(the 88/15 counts, `network/kustomization.yaml:4`, `toolhive-gateway/ks.yaml:6-7`, and the absent
`mcp` transform); and confirmed there is no `Kustomization` named `toolhive-gateway` in ns `mcp`, so
`flux-system` is the only correct value.

It also noted that because #1230 no-op'd, several conditional findings become live for the first
time on merge. Two were already measured (both CNP selectors match real pods); two remain open and
are first in the post-merge checklist: the `mcp-federation-as-metadata` `directResponse` showing
Accepted, and the JWKS resolving at controller translation time.

Relates to EPIC-034 Story 34.6