### PR TITLE
fix(ai): point searxng-secrets ExternalSecret at correct 1Password item

### DIFF
--- a/kubernetes/apps/ai/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/searxng/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
   data:
     - secretKey: secret-key
       remoteRef:
-        key: firecrawl
+        key: searxng
         property: SEARXNG_SECRET_KEY
     # Valkey Redis URL with authentication for rate limiting
     - secretKey: redis-url


### PR DESCRIPTION
## Summary
EPIC-034 Story 34.7 (Discovery & Data Prep) was almost entirely read-only reconnaissance for the AgentGateway consolidation epic. This PR carries the one standalone code change that came out of it: a fix for the `searxng-secrets` ExternalSecret, which has been failing to sync since 2026-01-28.

## Problem
`kubernetes/apps/ai/searxng/app/externalsecret.yaml` sourced `SEARXNG_SECRET_KEY` from the `firecrawl` 1Password item, which never had that field. The ExternalSecrets controller has been retrying and failing hourly for over six months:

```
error processing spec.data[0] (key: firecrawl), err: expected one 1Password ItemField
matching: 'SEARXNG_SECRET_KEY' in 'firecrawl', got 0
```

SearXNG's pod has been running the entire time on a stale secret value cached from before the sync broke (created 2025-12-18) — functional, but never rotatable.

## Change
A dedicated `searxng` 1Password item now holds `SEARXNG_SECRET_KEY`. This repoints `remoteRef.key` from `firecrawl` to `searxng`. The sibling `redis-url` block (sourced from `valkey-secrets`) was already correct and is untouched.

## Testing
- [x] Verified locally — live-verified pre-merge as a pre-authorized remediation action (not deferred to post-merge): patched the live ExternalSecret to match, force-synced, confirmed `Ready: True` / `SecretSynced`, confirmed both `secret-key` and `redis-url` populated with the secret value having actually changed, restarted the searxng deployment (no Reloader wired up for this app) to pick up the refreshed secret, confirmed the new pod is healthy (`/healthz` → OK)
- [x] Checked related services — `redis-url` block unaffected; no other consumers of this ExternalSecret
- [x] No regressions — one-line diff, no secret values in the diff itself

## Security Review
- [x] security-guardian reviewed — PASS. No plaintext secrets, self-contained one-line change, item-name reference isn't sensitive, matches this repo's existing ExternalSecret conventions.

## Notes
Relates to EPIC-034 Story 34.7. This fix is intentionally independent of the rest of the epic — it stays valid and worth keeping even if the epic goes NO-GO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the source used for the SearXNG secret key configuration.
  * Improved deployment reliability by ensuring the service uses its designated secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->