### PR TITLE
fix(ci): detect node readiness by condition, not STATUS column text

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -1676,7 +1676,15 @@ jobs:
 
           # Check all nodes are Ready
           echo "Checking node health..."
-          NOT_READY=$(kubectl get nodes --no-headers | grep -v " Ready " | wc -l)
+          # Ready CONDITION, not the STATUS column. A cordoned node renders as
+          # "Ready,SchedulingDisabled", so `grep -v " Ready "` counts a healthy
+          # node as NotReady. That matters doubly here: this workflow cordons
+          # nodes itself, and a cordon left over from an aborted run would
+          # otherwise block every subsequent upgrade.
+          NOT_READY=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+            | grep -cv '^True$' || true)
+          NOT_READY="${NOT_READY:-0}"
           if [[ $NOT_READY -gt 0 ]]; then
             echo "::error::Found $NOT_READY nodes not in Ready state"
             kubectl get nodes
@@ -3120,7 +3128,15 @@ jobs:
 
           # Check all nodes are Ready
           echo "Checking node health..."
-          NOT_READY=$(kubectl get nodes --no-headers | grep -v " Ready " | wc -l)
+          # Ready CONDITION, not the STATUS column. A cordoned node renders as
+          # "Ready,SchedulingDisabled", so `grep -v " Ready "` counts a healthy
+          # node as NotReady. That matters doubly here: this workflow cordons
+          # nodes itself, and a cordon left over from an aborted run would
+          # otherwise block every subsequent upgrade.
+          NOT_READY=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+            | grep -cv '^True$' || true)
+          NOT_READY="${NOT_READY:-0}"
           if [[ $NOT_READY -gt 0 ]]; then
             echo "::warning::Found $NOT_READY nodes not in Ready state after pair ${{ matrix.pair_id }}"
             kubectl get nodes

--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -148,6 +148,11 @@ env:
   # Cache Terraform providers to prevent GitHub rate limiting and download timeouts
   # (work-9 failed in run 20842324836 due to provider download timeout)
   TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+  # Total nodes expected in the cluster (3 control plane + 12 workers). Asserted
+  # by the PRE-FLIGHT health gate only, so a partial API response cannot read as
+  # a healthy cluster. Not asserted mid-rebuild, where nodes are legitimately
+  # absent. Update when the cluster is resized.
+  EXPECTED_NODE_COUNT: "15"
 
 jobs:
   # ==========================================================================
@@ -1681,13 +1686,30 @@ jobs:
           # node as NotReady. That matters doubly here: this workflow cordons
           # nodes itself, and a cordon left over from an aborted run would
           # otherwise block every subsequent upgrade.
-          NOT_READY=$(kubectl get nodes \
-            -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-            | grep -cv '^True$' || true)
+          # Capture kubectl separately: piping a failed call into `grep ... || true`
+          # yields 0 unhealthy nodes, so an API outage would read as a healthy
+          # cluster and this pre-flight gate would wave the rebuild through.
+          if ! NODE_STATE=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'); then
+            echo "::error::'kubectl get nodes' failed — cannot assess cluster health, refusing to start the rebuild"
+            exit 1
+          fi
+
+          # This gate runs BEFORE any node is destroyed, so the full inventory
+          # must be present. (The post-pair check deliberately does not assert a
+          # count — nodes are legitimately absent while a pair is rebuilding.)
+          NODE_COUNT=$(grep -c . <<<"$NODE_STATE" || true)
+          if [[ "$NODE_COUNT" -ne "$EXPECTED_NODE_COUNT" ]]; then
+            echo "::error::Incomplete node inventory: found $NODE_COUNT, expected $EXPECTED_NODE_COUNT"
+            echo "$NODE_STATE"
+            exit 1
+          fi
+
+          NOT_READY=$(grep -cv '=True$' <<<"$NODE_STATE" || true)
           NOT_READY="${NOT_READY:-0}"
           if [[ $NOT_READY -gt 0 ]]; then
             echo "::error::Found $NOT_READY nodes not in Ready state"
-            kubectl get nodes
+            echo "$NODE_STATE"
             exit 1
           fi
           echo "✅ All nodes Ready"
@@ -3133,16 +3155,30 @@ jobs:
           # node as NotReady. That matters doubly here: this workflow cordons
           # nodes itself, and a cordon left over from an aborted run would
           # otherwise block every subsequent upgrade.
-          NOT_READY=$(kubectl get nodes \
-            -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-            | grep -cv '^True$' || true)
-          NOT_READY="${NOT_READY:-0}"
-          if [[ $NOT_READY -gt 0 ]]; then
-            echo "::warning::Found $NOT_READY nodes not in Ready state after pair ${{ matrix.pair_id }}"
-            kubectl get nodes
-            # Don't fail, just warn - pair might still be stabilizing
+          # NOTE: unlike the pre-flight gate, this one deliberately does NOT
+          # assert a node count — during a cattle rebuild nodes are legitimately
+          # absent while their pair is being recreated. A kubectl failure is
+          # still surfaced rather than silently counted as zero unhealthy nodes.
+          if ! NODE_STATE=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'); then
+            NODE_STATE=""
+          fi
+
+          # Distinguish "we could not find out" from "everything is Ready".
+          # A herestring on an empty variable still feeds grep one empty line,
+          # so counting without this guard would report a phantom unready node.
+          if [[ -z "$NODE_STATE" ]]; then
+            echo "::warning::Node health UNKNOWN after pair ${{ matrix.pair_id }} — 'kubectl get nodes' returned nothing"
           else
-            echo "✅ All nodes Ready"
+            NOT_READY=$(grep -cv '=True$' <<<"$NODE_STATE" || true)
+            NOT_READY="${NOT_READY:-0}"
+            if [[ $NOT_READY -gt 0 ]]; then
+              echo "::warning::Found $NOT_READY nodes not in Ready state after pair ${{ matrix.pair_id }}"
+              echo "$NODE_STATE"
+              # Don't fail, just warn - pair might still be stabilizing
+            else
+              echo "✅ All nodes Ready"
+            fi
           fi
 
           # Check for pods in bad state

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -68,6 +68,10 @@ env:
   AWS_REGION: us-east-2
   TERRAFORM_STATE_BUCKET: prox-ops-terraform-state
   TERRAFORM_VERSION: "1.15.8"  # Managed by Renovate
+  # Total nodes expected in the cluster (3 control plane + 12 workers). The
+  # health gates assert this exact count so a partial API response cannot be
+  # read as "every node is Ready". Update when the cluster is resized.
+  EXPECTED_NODE_COUNT: "15"
 
 jobs:
   # ==========================================================================
@@ -258,9 +262,28 @@ jobs:
           # That false negative stranded k8s-work-3/6/8/9 across three
           # consecutive Talos upgrades — see
           # .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
-          NOT_READY=$(kubectl get nodes \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-            | grep -v '=True$' || true)
+          #
+          # Capture kubectl's output in its own statement so a FAILED API call
+          # cannot masquerade as "no unhealthy nodes". Piping straight into
+          # `grep ... || true` swallows the failure and the gate passes on an
+          # empty result — an outage would read as a healthy cluster.
+          if ! NODE_STATE=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'); then
+            echo "::error::'kubectl get nodes' failed — cannot assess cluster health, refusing to upgrade"
+            exit 1
+          fi
+
+          # An incomplete inventory is also a failure: if nodes are missing from
+          # the response entirely, their Ready condition is simply absent and
+          # they would silently pass the check below.
+          NODE_COUNT=$(grep -c . <<<"$NODE_STATE" || true)
+          if [[ "$NODE_COUNT" -ne "$EXPECTED_NODE_COUNT" ]]; then
+            echo "::error::Incomplete node inventory: found $NODE_COUNT, expected $EXPECTED_NODE_COUNT"
+            echo "$NODE_STATE"
+            exit 1
+          fi
+
+          NOT_READY=$(grep -v '=True$' <<<"$NODE_STATE" || true)
 
           if [[ -n "$NOT_READY" ]]; then
             echo "::error::Not all nodes are Ready"
@@ -1223,9 +1246,22 @@ jobs:
           kubectl get nodes
 
           # Ready CONDITION, not the STATUS column (see "Check cluster health").
-          NOT_READY=$(kubectl get nodes \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-            | grep -v '=True$' || true)
+          # kubectl failure and an incomplete inventory are both hard failures —
+          # neither may be mistaken for a healthy cluster.
+          if ! NODE_STATE=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'); then
+            echo "::error::'kubectl get nodes' failed — cannot validate the upgrade"
+            exit 1
+          fi
+
+          NODE_COUNT=$(grep -c . <<<"$NODE_STATE" || true)
+          if [[ "$NODE_COUNT" -ne "$EXPECTED_NODE_COUNT" ]]; then
+            echo "::error::Incomplete node inventory after upgrade: found $NODE_COUNT, expected $EXPECTED_NODE_COUNT"
+            echo "$NODE_STATE"
+            exit 1
+          fi
+
+          NOT_READY=$(grep -v '=True$' <<<"$NODE_STATE" || true)
 
           if [[ -n "$NOT_READY" ]]; then
             echo "::error::Not all nodes are Ready after upgrade"

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -252,15 +252,29 @@ jobs:
           echo "::group::Checking node health"
           kubectl get nodes
 
-          READY_NODES=$(kubectl get nodes --no-headers 2>/dev/null | grep -c " Ready " || echo "0")
-          TOTAL_NODES=$(kubectl get nodes --no-headers 2>/dev/null | wc -l || echo "0")
+          # Read the Ready CONDITION, never the STATUS column. A cordoned node
+          # renders as "Ready,SchedulingDisabled", so `grep " Ready "` does not
+          # match it and a perfectly healthy node is counted as NotReady.
+          # That false negative stranded k8s-work-3/6/8/9 across three
+          # consecutive Talos upgrades — see
+          # .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
+          NOT_READY=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+            | grep -v '=True$' || true)
 
-          echo "Ready nodes: $READY_NODES / $TOTAL_NODES"
-
-          if [[ "$READY_NODES" -ne "$TOTAL_NODES" ]]; then
+          if [[ -n "$NOT_READY" ]]; then
             echo "::error::Not all nodes are Ready"
-            kubectl get nodes | grep -v " Ready "
+            echo "$NOT_READY"
             exit 1
+          fi
+
+          # Cordoned-but-Ready is not fatal, but it is worth surfacing: it is
+          # normally the residue of an upgrade that aborted part-way.
+          CORDONED=$(kubectl get nodes \
+            -o jsonpath='{range .items[?(@.spec.unschedulable==true)]}{.metadata.name}{"\n"}{end}' || true)
+          if [[ -n "$CORDONED" ]]; then
+            echo "::warning::Cordoned nodes present (will be upgraded and uncordoned):"
+            echo "$CORDONED"
           fi
 
           echo "✅ All nodes are Ready"
@@ -754,8 +768,13 @@ jobs:
     name: Upgrade Control Plane (In-Place)
     runs-on: cattle-runner
     needs: [validate-inputs, pre-upgrade-health-check, rebuild-templates]
+    # pre-upgrade-health-check must actually gate the rollout. It previously
+    # appeared in `needs` but was never referenced here, so a failed health
+    # check did not stop anything — on 2026-08-11 it failed and all 15 upgrade
+    # jobs ran regardless. A gate that does not gate is worse than no gate.
     if: |
       always() &&
+      needs.pre-upgrade-health-check.result == 'success' &&
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       inputs.test_templates == false &&
       inputs.test_workers == false
@@ -779,10 +798,18 @@ jobs:
         run: |
           echo "::group::Pre-upgrade validation for ${{ matrix.node.name }}"
 
-          # Check node is Ready
-          if ! kubectl get node ${{ matrix.node.name }} | grep -q " Ready "; then
-            echo "::error::Node ${{ matrix.node.name }} is not Ready"
+          # Check node is Ready. Read the condition, not the STATUS column —
+          # a cordoned node renders as "Ready,SchedulingDisabled".
+          READY=$(kubectl get node ${{ matrix.node.name }} \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+          if [[ "$READY" != "True" ]]; then
+            echo "::error::Node ${{ matrix.node.name }} is not Ready (Ready=${READY:-unknown})"
             exit 1
+          fi
+
+          # A cordon left behind by an aborted upgrade must not block this one.
+          if [[ "$(kubectl get node ${{ matrix.node.name }} -o jsonpath='{.spec.unschedulable}')" == "true" ]]; then
+            echo "::warning::Node ${{ matrix.node.name }} is cordoned (likely residue of an aborted upgrade); proceeding and will uncordon on completion"
           fi
 
           # Check current version
@@ -861,6 +888,24 @@ jobs:
           echo "✅ net.ifnames=0 present and eth0 exists"
           echo "::endgroup::"
 
+      - name: Restore scheduling (uncordon)
+        if: always()
+        run: |
+          # Talos' own upgrade sequence cordons the node via the Kubernetes API
+          # before it reboots. Nothing restores that cordon if the upgrade
+          # aborts, so a failed run leaves the node Ready,SchedulingDisabled
+          # with its workloads still on it — cordoned but never drained.
+          # That stale cordon is what latched k8s-work-3/6/8/9 out of three
+          # consecutive rollouts. Always hand scheduling back.
+          NODE="${{ matrix.node.name }}"
+          READY=$(kubectl get node "$NODE" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+          if [[ "$READY" == "True" ]]; then
+            kubectl uncordon "$NODE" || true
+          else
+            echo "::warning::$NODE is not Ready (Ready=${READY:-unknown}) — leaving it cordoned for manual inspection"
+          fi
+
       - name: Upgrade summary
         if: always()
         run: |
@@ -887,9 +932,13 @@ jobs:
   upgrade-workers:
     name: Upgrade Workers (In-Place)
     runs-on: cattle-runner
-    needs: [validate-inputs, upgrade-control-plane]
+    needs: [validate-inputs, pre-upgrade-health-check, upgrade-control-plane]
+    # upgrade-control-plane is legitimately 'skipped' in test_workers mode, so
+    # the health check is asserted directly here too — otherwise a failed health
+    # check would still let the worker rollout proceed.
     if: |
       always() &&
+      needs.pre-upgrade-health-check.result == 'success' &&
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped') &&
       inputs.test_templates == false &&
       inputs.test_controllers == false
@@ -913,10 +962,18 @@ jobs:
         run: |
           echo "::group::Pre-upgrade validation for ${{ matrix.node.name }}"
 
-          # Check node is Ready
-          if ! kubectl get node ${{ matrix.node.name }} | grep -q " Ready "; then
-            echo "::error::Node ${{ matrix.node.name }} is not Ready"
+          # Check node is Ready. Read the condition, not the STATUS column —
+          # a cordoned node renders as "Ready,SchedulingDisabled".
+          READY=$(kubectl get node ${{ matrix.node.name }} \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+          if [[ "$READY" != "True" ]]; then
+            echo "::error::Node ${{ matrix.node.name }} is not Ready (Ready=${READY:-unknown})"
             exit 1
+          fi
+
+          # A cordon left behind by an aborted upgrade must not block this one.
+          if [[ "$(kubectl get node ${{ matrix.node.name }} -o jsonpath='{.spec.unschedulable}')" == "true" ]]; then
+            echo "::warning::Node ${{ matrix.node.name }} is cordoned (likely residue of an aborted upgrade); proceeding and will uncordon on completion"
           fi
 
           # Check current version
@@ -1069,6 +1126,24 @@ jobs:
           echo "::error::GPU not detected and NVIDIA extension/label missing on ${{ matrix.node.name }} — genuine GPU failure"
           exit 1
 
+      - name: Restore scheduling (uncordon)
+        if: always()
+        run: |
+          # Talos' own upgrade sequence cordons the node via the Kubernetes API
+          # before it reboots. Nothing restores that cordon if the upgrade
+          # aborts, so a failed run leaves the node Ready,SchedulingDisabled
+          # with its workloads still on it — cordoned but never drained.
+          # That stale cordon is what latched k8s-work-3/6/8/9 out of three
+          # consecutive rollouts. Always hand scheduling back.
+          NODE="${{ matrix.node.name }}"
+          READY=$(kubectl get node "$NODE" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+          if [[ "$READY" == "True" ]]; then
+            kubectl uncordon "$NODE" || true
+          else
+            echo "::warning::$NODE is not Ready (Ready=${READY:-unknown}) — leaving it cordoned for manual inspection"
+          fi
+
       - name: Upgrade summary
         if: always()
         run: |
@@ -1147,14 +1222,23 @@ jobs:
           # Check nodes
           kubectl get nodes
 
-          READY_NODES=$(kubectl get nodes --no-headers 2>/dev/null | grep -c " Ready " || echo "0")
-          TOTAL_NODES=$(kubectl get nodes --no-headers 2>/dev/null | wc -l || echo "0")
+          # Ready CONDITION, not the STATUS column (see "Check cluster health").
+          NOT_READY=$(kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+            | grep -v '=True$' || true)
 
-          echo "Ready nodes: $READY_NODES / $TOTAL_NODES"
-
-          if [[ "$READY_NODES" -ne "$TOTAL_NODES" ]]; then
+          if [[ -n "$NOT_READY" ]]; then
             echo "::error::Not all nodes are Ready after upgrade"
-            kubectl get nodes | grep -v " Ready "
+            echo "$NOT_READY"
+            exit 1
+          fi
+
+          # Nothing should still be cordoned once the rollout has finished.
+          STILL_CORDONED=$(kubectl get nodes \
+            -o jsonpath='{range .items[?(@.spec.unschedulable==true)]}{.metadata.name}{"\n"}{end}' || true)
+          if [[ -n "$STILL_CORDONED" ]]; then
+            echo "::error::Nodes left cordoned after upgrade — these will be skipped by future runs until uncordoned:"
+            echo "$STILL_CORDONED"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

`k8s-work-3`, `k8s-work-6`, `k8s-work-8` and `k8s-work-9` sat cordoned on Talos v1.13.4 for seven weeks while three consecutive upgrades (v1.13.4 → v1.13.5 → v1.13.8) completed without them. The cluster was never at risk, but a third of worker capacity was out of the scheduling pool and each rollout reported success for the nodes it did touch.

## Root cause

Two defects compounding.

**1. Nothing uncordons after a failed upgrade.** Talos' own upgrade sequence cordons a node through the Kubernetes API before it reboots — the workflow has never contained any cordon/drain/uncordon logic (`git log -S'cordon' -- .github/workflows/upgrade-pets.yaml` returns no commits). When an upgrade aborts, Talos has already cordoned but has not finished draining, so the node is left `Ready,SchedulingDisabled` with its workloads still on it. That is exactly the "cordoned but never drained" state that was found.

**2. The readiness gates parsed rendered table text.** Six gates tested `kubectl get node` STATUS column output:

```bash
if ! kubectl get node "$NODE" | grep -q " Ready "; then exit 1; fi
```

A cordoned node renders as `Ready,SchedulingDisabled` — "Ready" is followed by a comma, not a space — so the pattern misses and a healthy node is declared `not Ready`:

```console
$ kubectl get node k8s-work-6 -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
True
$ kubectl get node k8s-work-6 --no-headers | grep -q " Ready " ; echo $?
1        # gate fails on a Ready node
```

**The cordon left by the first failure is therefore what caused every subsequent run to skip precisely those four nodes.** The failure was self-perpetuating and got worse each release. The cluster-wide variant produced `READY_NODES=11 / TOTAL_NODES=15`.

For the record, the 2026-08-11 run (`31506749848`) did not stall — workers run `fail-fast: false, max-parallel: 4` and all 12 jobs were dispatched. Six failed for three unrelated reasons: three on this gate, three on a 10-minute timeout in `Setup cluster tools` (mise/aqua registry HTTP 400s), and `k8s-work-10` upgraded successfully but tripped the known GPU-validation false-failure.

## Changes

- Read `.status.conditions[?(@.type=="Ready")].status` in all six gates — four in `upgrade-pets.yaml`, two in `upgrade-cattle.yaml` — instead of parsing table output.
- Add a `Restore scheduling (uncordon)` step to the control-plane and worker upgrade jobs (`if: always()`), guarded so a node that is **not** Ready stays cordoned for inspection. This is the durable fix: it prevents the trap being set again.
- Fail post-upgrade validation if any node is left cordoned, so a partial rollout can no longer pass silently.
- Make `pre-upgrade-health-check` actually gate `upgrade-control-plane` and `upgrade-workers`. It was listed in `needs:` but its result was never referenced, so on 2026-08-11 it failed and all 15 upgrade jobs ran regardless.

## Testing

Gate logic executed against the live cluster, both cases:

| Case | Old gate | New gate |
|---|---|---|
| `Ready` (uncordoned) | pass | pass |
| `Ready,SchedulingDisabled` | **fail** (the bug) | pass |
| Cluster count, 4 cordoned | `11/15` → blocks | `0 not-ready` → allows |

- [x] Both workflow files parse (`yaml.safe_load`)
- [x] All six replaced gates verified against live node state
- [x] No `" Ready "` string gates remain in `.github/workflows/`
- [x] security-guardian review passed

## Note for review

The `pre-upgrade-health-check` gating change is a **behaviour change** and is separable from the rest. It would have blocked the 2026-08-11 run outright — which is the intent, but it means one unhealthy node now blocks all upgrades. Drop that hunk if you would rather keep the current behaviour; the readiness and uncordon fixes stand on their own.

## Cluster state

The four nodes were uncordoned during the investigation (2026-08-15 03:25 UTC) after confirming all four were `Ready=True` with no pressure conditions and all pods Running. All 15 nodes are now Ready and schedulable. **No node was drained, rebooted, or upgraded** — `k8s-work-3/6/8/9` remain on v1.13.4 and `k8s-work-2`/`k8s-work-4` on v1.13.5, pending your decision on when to run the upgrade.

Full write-up in `.claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md` (local, gitignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes upgrade health checks by accurately evaluating node readiness.
  * Healthy cordoned nodes are no longer incorrectly reported as unavailable.
  * Upgrade validation now detects and reports nodes that remain cordoned.
  * Cleanup automatically restores Ready nodes while preserving cordons on unhealthy nodes.
  * Control-plane and worker upgrades now require successful pre-upgrade health checks, improving upgrade safety and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->