### PR TITLE
fix(k8s): make single-replica workloads drainable

### DIFF
--- a/kubernetes/apps/database/cluster/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cluster/app/helmrelease.yaml
@@ -36,6 +36,16 @@ spec:
     cluster:
       instances: 1
 
+      # A single-instance cluster gets a PDB with minAvailable=1, which makes
+      # disruptionsAllowed permanently 0 — the primary can never be evicted, so
+      # its node can never be drained. Talos' upgrade sequence cordons a node and
+      # then drains it, so this silently aborted every Talos upgrade of whichever
+      # node held the primary and left it cordoned (k8s-work-3 sat on v1.13.4 for
+      # seven weeks this way). With instances: 1 the PDB protects nothing anyway
+      # — there is no replica to fail over to. Re-enable if instances ever > 1.
+      # See .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
+      enablePDB: false
+
       # Storage configuration
       storage:
         size: 20Gi

--- a/kubernetes/apps/health/glycemicgpt/app/cnpg-cluster.yaml
+++ b/kubernetes/apps/health/glycemicgpt/app/cnpg-cluster.yaml
@@ -14,6 +14,14 @@ metadata:
 spec:
   instances: 1
 
+  # With instances: 1 the operator's primary PDB (minAvailable=1) leaves
+  # disruptionsAllowed=0 forever, so the primary cannot be evicted and its node
+  # cannot be drained. Talos cordons then drains during upgrade, so this aborts
+  # the upgrade and strands the node cordoned. The PDB guards nothing at a single
+  # instance — there is no replica to fail over to. Re-enable if instances > 1.
+  # See .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
+  enablePDB: false
+
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
   imageName: ghcr.io/cloudnative-pg/postgresql:16.8
 

--- a/kubernetes/apps/kube-system/knative-serving/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/knative-serving/app/kustomization.yaml
@@ -59,6 +59,53 @@ configMapGenerator:
       - kubernetes.containerspec-addcapabilities=enabled
 
 patches:
+  # Make the upstream PDBs drainable.
+  #
+  # Knative and net-kourier ship PodDisruptionBudgets with minAvailable: 80%,
+  # which assumes a multi-replica production deployment. We run one replica of
+  # each. Kubernetes rounds a minAvailable percentage UP, so
+  # desiredHealthy = ceil(0.8 * replicas) equals the replica count at 1, 2, 3
+  # and 4 replicas — disruptionsAllowed is 0 until 5 replicas. The pod therefore
+  # can never be evicted and its node can never be drained. Note that simply
+  # scaling to 2 does NOT fix this; the PDB itself has to change.
+  #
+  # Talos' upgrade sequence cordons a node and then drains it, so whichever node
+  # held activator / webhook / kourier-gateway silently failed every Talos
+  # upgrade and was left cordoned. k8s-work-6/8/9 sat on v1.13.4 for seven weeks
+  # this way. maxUnavailable: 1 keeps the disruption budget meaningful while
+  # allowing exactly one pod to be evicted at a time.
+  # See .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
+  - target:
+      kind: PodDisruptionBudget
+      name: activator-pdb
+      namespace: knative-serving
+    patch: |-
+      - op: remove
+        path: /spec/minAvailable
+      - op: add
+        path: /spec/maxUnavailable
+        value: 1
+  - target:
+      kind: PodDisruptionBudget
+      name: webhook-pdb
+      namespace: knative-serving
+    patch: |-
+      - op: remove
+        path: /spec/minAvailable
+      - op: add
+        path: /spec/maxUnavailable
+        value: 1
+  - target:
+      kind: PodDisruptionBudget
+      name: 3scale-kourier-gateway-pdb
+      namespace: kourier-system
+    patch: |-
+      - op: remove
+        path: /spec/minAvailable
+      - op: add
+        path: /spec/maxUnavailable
+        value: 1
+
   # Patch Kourier service to use Cilium LoadBalancer with specific IP
   # IP must be within default pool range: 10.20.66.0/23
   - target:


### PR DESCRIPTION
## Summary

This is the **root cause** of the Talos upgrade stall — the trigger, not the symptom. PR #1244 fixes the mechanism that hid it; this fixes the thing that actually broke.

Five PodDisruptionBudgets report `disruptionsAllowed: 0` **permanently**. Their pods can never be evicted, so the nodes hosting them can never be drained. Talos' upgrade sequence cordons a node and then drains it through the eviction API, so every Talos upgrade of those nodes blocked on the drain, timed out, and aborted — leaving the node cordoned with its pods still resident and still on the old version.

## The evidence

The five sat on **exactly** the four nodes stranded on v1.13.4 since 2026-06-28, and on **none** of the eleven that upgraded cleanly:

| Node | Un-evictable pod | PDB | Why `disruptionsAllowed` is always 0 |
|---|---|---|---|
| work-3 | `database/postgres-1` | `minAvailable: 1`, 1 instance | `1 - 1 = 0` |
| work-3 | `health/glycemicgpt-db-1` | `minAvailable: 1`, 1 instance | same |
| work-6 | `kourier-system/3scale-kourier-gateway` | `minAvailable: 80%`, 1 replica | `ceil(0.8×1) = 1`; `1 - 1 = 0` |
| work-8 | `knative-serving/activator` | `minAvailable: 80%`, 1 replica | same |
| work-9 | `knative-serving/webhook` | `minAvailable: 80%`, 1 replica | same |

All five had been pinned to those nodes since **2026-06-13** — two weeks before the upgrade that stranded them — and had not moved since. So the failures were deterministic, not flaky: the same four nodes failed every time because they were the four that could not be drained.

Talos' cordon → drain → uncordon sequence was confirmed directly by polling a node through an upgrade:

```
04:02:22  unschedulable=false  Ready=True     pods=25   <- steady state
04:02:32  unschedulable=true   Ready=True     pods=19   <- Talos CORDONS
04:03:15  unschedulable=true   Ready=True     pods=16   <- Talos DRAINS
04:03:26  unschedulable=true   Ready=False    pods=6    <- reboot (6 = DaemonSets)
04:04:51  unschedulable=false  Ready=Unknown  pods=6    <- Talos UNCORDONS (success only)
```

## Changes

**CNPG — `enablePDB: false` on both single-instance clusters.** At `instances: 1` the operator's `minAvailable: 1` primary PDB can never permit a disruption and protects nothing: there is no replica to fail over to. This matches CloudNativePG's own guidance for single-instance clusters. Re-enable if instances ever exceed 1.

**Knative/Kourier — `minAvailable: 80%` → `maxUnavailable: 1`** via Kustomize JSON patches. Upstream ships 80%, which assumes a multi-replica deployment; we run one replica of each.

> ⚠️ Worth knowing: **scaling these to 2 replicas does NOT fix it.** Kubernetes rounds a `minAvailable` percentage *up*, so `desiredHealthy = ceil(0.8 × replicas)` equals the replica count at 1, 2, 3 **and** 4 replicas. `disruptionsAllowed` only becomes nonzero at five. The PDB itself has to change. I nearly shipped the scale-up as the fix.

`maxUnavailable: 1` is also *stricter* than the percentage form above five replicas (at 10 replicas the old config allowed 2 concurrent evictions; this allows 1), so this does not widen disruption.

## Testing

- [x] Chart renders `enablePDB: false` into the `Cluster` CR spec (`helm template cnpg/cluster --version 0.5.0`)
- [x] CRD accepts `spec.enablePDB` (boolean) — verified against the live cluster
- [x] `kubectl kustomize` build of knative-serving succeeds; the three `remove`/`add` patches apply
- [x] Build diff vs `main` is **exactly three lines**, all PDB fields — Kourier LB annotation and all 72 objects otherwise unchanged
- [x] security-guardian review passed

## Cluster state

The upgrade itself is **done**: all 15 nodes are on Talos v1.13.8, Ready and schedulable. It was unblocked by manually relocating the five pods (announced and logged), which is equivalent in effect to what this PR makes automatic. Verified post-upgrade: `net.ifnames=0` on all 15 nodes, `eth0/1/2` intact, all 10 Cilium L2 VIP leases held, `authentik.homelab0.org` returning HTTP 302 in 0.155s through the gateway, 274 pods Running.

Without this PR the next Talos bump re-strands whichever nodes hold these pods.

## Not verified pre-merge

Whether the CNPG operator actually deletes the two PDBs on reconcile, and whether Flux applies the Kustomize PDB patches cleanly to the already-existing objects. Both are post-merge observations.

Full write-up in `.claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md` (local, gitignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance Improvements**
  - Updated disruption settings for single-instance database services to allow node draining and Talos upgrades to proceed.
  - Adjusted Knative Serving components to permit one pod disruption during node maintenance.
  - These changes improve cluster maintenance flexibility; single-instance services may have reduced availability during disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Post-merge acceptance plan

All checks are **read-only**. Do not `kubectl apply` — Flux owns these objects.

**1. Flux applied the merged revision**

```bash
flux get kustomizations -A | grep -E 'knative-serving|cluster|glycemicgpt'
# each should be Ready=True with the merged commit SHA
```

**2. No PDB remains for either single-instance CNPG cluster**

```bash
kubectl get pdb -n database; kubectl get pdb -n health
# EXPECT: postgres-primary and glycemicgpt-db-primary are GONE
# (the operator deletes them when spec.enablePDB=false reconciles)
kubectl get cluster -n database postgres   -o jsonpath='{.spec.enablePDB}{"\n"}'   # false
kubectl get cluster -n health glycemicgpt-db -o jsonpath='{.spec.enablePDB}{"\n"}' # false
```

**3. Knative/Kourier PDBs patched and actually permitting disruption**

```bash
kubectl get pdb -A -o custom-columns=\
'NS:.metadata.namespace,NAME:.metadata.name,MIN:.spec.minAvailable,MAX:.spec.maxUnavailable,ALLOWED:.status.disruptionsAllowed'
# EXPECT for activator-pdb, webhook-pdb, 3scale-kourier-gateway-pdb:
#   MIN=<none>   MAX=1   ALLOWED=1   (ALLOWED settles to 1 once the selected Pod is Ready)
```

**4. The acceptance test that actually matters — every node is drainable**

```bash
kubectl get pdb -A -o json | jq -r '[.items[]|select(.status.disruptionsAllowed==0)]
  | "PDBs still blocking: \(length)\n" + (map("  " + .metadata.namespace + "/" + .metadata.name)|join("\n"))'
# EXPECT: only github-actions/github-runners-pdb may appear, and only transiently
# while runner replicas are cycling. Any of the five named in this PR still
# appearing means the change did not take effect.
```

**Rollback:** revert this commit. The operator recreates the CNPG PDBs and Flux restores
`minAvailable: 80%`; both return the cluster to its prior (un-drainable) state with no data impact.
