### PR TITLE
fix(ci): make Talos upgrades survive transient failures

### DIFF
--- a/.github/actions/setup-cluster-tools/action.yaml
+++ b/.github/actions/setup-cluster-tools/action.yaml
@@ -21,7 +21,12 @@ runs:
       run: |
         echo "MISE_PYTHON_VENV_AUTO_CREATE=0" >> $GITHUB_ENV
 
+    # continue-on-error: a transient registry failure here must not take the
+    # whole job with it. The retry step below is the real gate — it fails the
+    # job only if a required tool is genuinely absent afterwards.
     - name: Setup mise and install tools
+      id: mise-install
+      continue-on-error: true
       uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       with:
         cache: true
@@ -29,6 +34,71 @@ runs:
         # Only install tools needed for CI workflows (not full .mise.toml)
         # This prevents disk space exhaustion on cattle-runner
         install_args: "aqua:hashicorp/terraform aqua:kubernetes/kubectl aqua:siderolabs/talos aqua:fluxcd/flux2 aqua:helm/helm aqua:jqlang/jq aqua:mikefarah/yq aqua:kubernetes-sigs/kustomize"
+
+    - name: Ensure required tools are present (retry)
+      shell: bash
+      run: |
+        # The aqua/mise registries return intermittent HTTP 400s. Before this
+        # retry existed, one blip killed the whole job: on 2026-08-11 three
+        # worker upgrade jobs died at exactly the 10-minute mark inside the
+        # step above, and k8s-work-2/3/4 were silently left un-upgraded.
+        # See .claude/.ai-docs/troubleshooting/RCA-2026-08-15-talos-upgrade-stall.md
+        #
+        # This step handles NO secrets. It prints tool names and versions only;
+        # nothing here reads or echoes the talosconfig input.
+        set -uo pipefail
+
+        TOOLS="aqua:hashicorp/terraform aqua:kubernetes/kubectl aqua:siderolabs/talos aqua:fluxcd/flux2 aqua:helm/helm aqua:jqlang/jq aqua:mikefarah/yq aqua:kubernetes-sigs/kustomize"
+        REQUIRED_BINS="terraform kubectl talosctl flux helm jq yq kustomize"
+
+        # mise shims may not be on PATH if the action above bailed out early.
+        SHIM_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+        case ":$PATH:" in
+          *":$SHIM_DIR:"*) : ;;
+          *) export PATH="$SHIM_DIR:$PATH" ;;
+        esac
+
+        missing_bins() {
+          local m=""
+          for b in $REQUIRED_BINS; do
+            if ! command -v "$b" >/dev/null 2>&1; then m="$m $b"; fi
+          done
+          printf '%s' "$m"
+        }
+
+        if ! command -v mise >/dev/null 2>&1; then
+          echo "::error::mise is not on PATH - the setup action could not bootstrap it"
+          exit 1
+        fi
+
+        for attempt in 1 2 3; do
+          MISSING="$(missing_bins)"
+          if [ -z "$MISSING" ]; then
+            break
+          fi
+          echo "Attempt ${attempt}/3 - missing:${MISSING}"
+          # Bound each attempt so a hung download cannot consume the job timeout.
+          if timeout 300 mise install $TOOLS; then
+            echo "  mise install completed"
+          else
+            echo "  mise install attempt ${attempt} did not complete (rc=$?)"
+          fi
+          hash -r 2>/dev/null || true
+          if [ "$attempt" -lt 3 ]; then
+            sleep $(( attempt * 20 ))
+          fi
+        done
+
+        MISSING="$(missing_bins)"
+        if [ -n "$MISSING" ]; then
+          echo "::error::Required tools still missing after 3 attempts:${MISSING}"
+          echo "::error::mise-action outcome was '${{ steps.mise-install.outcome }}'"
+          exit 1
+        fi
+
+        # Persist the shim dir for later steps in the calling job.
+        echo "$SHIM_DIR" >> "$GITHUB_PATH"
+        echo "✅ All required tools present"
 
     - name: Verify tool versions
       shell: bash

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -809,13 +809,74 @@ jobs:
           echo "Control plane node - using base factory image (qemu-guest-agent + net.ifnames=0)"
 
           echo "Installer image: $INSTALLER_IMAGE"
-          echo "Starting in-place upgrade..."
-          talosctl upgrade \
-            --nodes ${{ matrix.node.ip }} \
-            --image "$INSTALLER_IMAGE" \
-            --preserve \
-            --wait \
-            --timeout 10m
+
+          NODE_IP="${{ matrix.node.ip }}"
+          TARGET="v${{ inputs.new_version }}"
+
+          current_version() {
+            talosctl version --nodes "$NODE_IP" --short 2>/dev/null \
+              | grep "Tag:" | awk '{print $2}'
+          }
+
+          # Retry once. Two distinct things used to strand a node permanently:
+          #
+          #   1. `talosctl upgrade` exits non-zero when the API connection drops
+          #      during the reboot -- which is NORMAL. The node is often already
+          #      on the target version, so always check the real version before
+          #      concluding anything failed.
+          #   2. A genuinely transient failure (image pull, brief API blip) got
+          #      no second chance; the node was simply left behind, and every
+          #      later run then skipped it.
+          #
+          # Control-plane nodes upgrade with max-parallel: 1, so retrying a
+          # single node never puts etcd quorum at risk.
+          UPGRADE_OK=0
+          for attempt in 1 2; do
+            echo "Upgrade attempt ${attempt}/2 for ${{ matrix.node.name }} -> ${TARGET}"
+
+            if talosctl upgrade \
+              --nodes "$NODE_IP" \
+              --image "$INSTALLER_IMAGE" \
+              --preserve \
+              --wait \
+              --timeout 10m; then
+              UPGRADE_OK=1
+              break
+            fi
+
+            echo "::warning::talosctl upgrade returned non-zero on attempt ${attempt} - verifying the node's actual version (a dropped connection during reboot is expected)"
+
+            # Let the node finish rebooting before believing any version read.
+            # GPU nodes take roughly twice as long to come back (NVIDIA driver
+            # load), so give them a longer window -- otherwise a slow-but-fine
+            # boot looks like a failure and we would re-issue the upgrade while
+            # the node is still rebooting. This expression renders empty for the
+            # control-plane matrix (no is_gpu key), which correctly selects 5m.
+            SETTLE_TRIES=30    # 30 x 10s = 5 minutes
+            if [[ "${{ matrix.node.is_gpu }}" == "true" ]]; then
+              SETTLE_TRIES=60  # 60 x 10s = 10 minutes
+            fi
+            for _ in $(seq 1 "$SETTLE_TRIES"); do
+              if [[ "$(current_version)" == "$TARGET" ]]; then break; fi
+              sleep 10
+            done
+
+            if [[ "$(current_version)" == "$TARGET" ]]; then
+              echo "✅ Node is on ${TARGET} - the upgrade landed despite the non-zero exit"
+              UPGRADE_OK=1
+              break
+            fi
+
+            if [[ "$attempt" -eq 1 ]]; then
+              echo "::warning::Node still on '$(current_version)' - retrying once"
+              sleep 30
+            fi
+          done
+
+          if [[ "$UPGRADE_OK" -ne 1 ]]; then
+            echo "::error::Upgrade of ${{ matrix.node.name }} failed after 2 attempts (still on '$(current_version)')"
+            exit 1
+          fi
 
           echo "✅ Upgrade completed"
           echo "::endgroup::"
@@ -930,6 +991,36 @@ jobs:
           echo "✅ Pre-upgrade validation passed"
           echo "::endgroup::"
 
+      - name: Wait for control plane to settle
+        run: |
+          echo "::group::Waiting for the API server to stabilise"
+          # The worker rollout previously began TWO SECONDS after the last
+          # control-plane node finished rebooting. On 2026-08-11 the first three
+          # worker jobs then died in tool setup and k8s-work-2/3/4 were left
+          # un-upgraded. Draining workers while etcd is still settling after a
+          # rolling control-plane reboot invites exactly that.
+          #
+          # Require three CONSECUTIVE healthy probes, so one lucky response
+          # mid-election does not read as stable.
+          STABLE=0
+          for i in $(seq 1 30); do
+            if kubectl get --raw /readyz >/dev/null 2>&1; then
+              STABLE=$(( STABLE + 1 ))
+            else
+              STABLE=0
+            fi
+            if [[ "$STABLE" -ge 3 ]]; then
+              echo "✅ API server healthy on 3 consecutive probes"
+              echo "::endgroup::"
+              exit 0
+            fi
+            sleep 10
+          done
+
+          echo "::error::Control plane did not stabilise within 5 minutes - refusing to start the worker rollout"
+          kubectl get --raw '/readyz?verbose' 2>&1 | tail -20 || true
+          exit 1
+
       - name: In-place upgrade using talosctl
         run: |
           echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
@@ -956,13 +1047,74 @@ jobs:
           fi
 
           echo "Installer image: $INSTALLER_IMAGE"
-          echo "Starting in-place upgrade..."
-          talosctl upgrade \
-            --nodes ${{ matrix.node.ip }} \
-            --image "$INSTALLER_IMAGE" \
-            --preserve \
-            --wait \
-            --timeout 10m
+
+          NODE_IP="${{ matrix.node.ip }}"
+          TARGET="v${{ inputs.new_version }}"
+
+          current_version() {
+            talosctl version --nodes "$NODE_IP" --short 2>/dev/null \
+              | grep "Tag:" | awk '{print $2}'
+          }
+
+          # Retry once. Two distinct things used to strand a node permanently:
+          #
+          #   1. `talosctl upgrade` exits non-zero when the API connection drops
+          #      during the reboot -- which is NORMAL. The node is often already
+          #      on the target version, so always check the real version before
+          #      concluding anything failed.
+          #   2. A genuinely transient failure (image pull, brief API blip) got
+          #      no second chance; the node was simply left behind, and every
+          #      later run then skipped it.
+          #
+          # Control-plane nodes upgrade with max-parallel: 1, so retrying a
+          # single node never puts etcd quorum at risk.
+          UPGRADE_OK=0
+          for attempt in 1 2; do
+            echo "Upgrade attempt ${attempt}/2 for ${{ matrix.node.name }} -> ${TARGET}"
+
+            if talosctl upgrade \
+              --nodes "$NODE_IP" \
+              --image "$INSTALLER_IMAGE" \
+              --preserve \
+              --wait \
+              --timeout 10m; then
+              UPGRADE_OK=1
+              break
+            fi
+
+            echo "::warning::talosctl upgrade returned non-zero on attempt ${attempt} - verifying the node's actual version (a dropped connection during reboot is expected)"
+
+            # Let the node finish rebooting before believing any version read.
+            # GPU nodes take roughly twice as long to come back (NVIDIA driver
+            # load), so give them a longer window -- otherwise a slow-but-fine
+            # boot looks like a failure and we would re-issue the upgrade while
+            # the node is still rebooting. This expression renders empty for the
+            # control-plane matrix (no is_gpu key), which correctly selects 5m.
+            SETTLE_TRIES=30    # 30 x 10s = 5 minutes
+            if [[ "${{ matrix.node.is_gpu }}" == "true" ]]; then
+              SETTLE_TRIES=60  # 60 x 10s = 10 minutes
+            fi
+            for _ in $(seq 1 "$SETTLE_TRIES"); do
+              if [[ "$(current_version)" == "$TARGET" ]]; then break; fi
+              sleep 10
+            done
+
+            if [[ "$(current_version)" == "$TARGET" ]]; then
+              echo "✅ Node is on ${TARGET} - the upgrade landed despite the non-zero exit"
+              UPGRADE_OK=1
+              break
+            fi
+
+            if [[ "$attempt" -eq 1 ]]; then
+              echo "::warning::Node still on '$(current_version)' - retrying once"
+              sleep 30
+            fi
+          done
+
+          if [[ "$UPGRADE_OK" -ne 1 ]]; then
+            echo "::error::Upgrade of ${{ matrix.node.name }} failed after 2 attempts (still on '$(current_version)')"
+            exit 1
+          fi
 
           echo "✅ Upgrade completed"
           echo "::endgroup::"

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -759,7 +759,18 @@ jobs:
       (needs.rebuild-templates.result == 'success' || needs.rebuild-templates.result == 'skipped') &&
       inputs.test_templates == false &&
       inputs.test_workers == false
-    timeout-minutes: 30
+    # Budget must exceed the worst-case retry path or GitHub cancels the job
+    # mid-retry and the diagnosis never prints. Worst case:
+    #   tool install retry   3 x 5m  = 15m
+    #   upgrade attempt 1           = 10m   (--timeout 10m)
+    #   settle poll after failure   =  5m
+    #   backoff                     = 0.5m
+    #   upgrade attempt 2           = 10m
+    #   settle poll after failure   =  5m
+    #   wait for Ready              =  5m
+    #   verify + uncordon + summary =  2m
+    #                          total ~ 52m
+    timeout-minutes: 55
     strategy:
       # CRITICAL: Control plane MUST upgrade sequentially to maintain etcd quorum
       max-parallel: 1
@@ -793,8 +804,14 @@ jobs:
           echo "::endgroup::"
 
       - name: In-place upgrade using talosctl
+        # new_version is dispatch-controlled, so it is passed through env and
+        # read as "$NEW_VERSION" rather than expanded into the script body,
+        # where a crafted value could terminate the string and inject commands.
+        # (matrix.node.* comes from a hardcoded fromJSON literal in this file.)
+        env:
+          NEW_VERSION: ${{ inputs.new_version }}
         run: |
-          echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
+          echo "::group::Upgrading ${{ matrix.node.name }} to v${NEW_VERSION}"
 
           # Controllers require the base factory image: qemu-guest-agent + net.ifnames=0
           # Single source of truth: terraform/terraform.tfvars (talos_schematic_base).
@@ -805,13 +822,13 @@ jobs:
             echo "::error::Could not read talos_schematic_base from terraform/terraform.tfvars"
             exit 1
           fi
-          INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${{ inputs.new_version }}"
+          INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${NEW_VERSION}"
           echo "Control plane node - using base factory image (qemu-guest-agent + net.ifnames=0)"
 
           echo "Installer image: $INSTALLER_IMAGE"
 
           NODE_IP="${{ matrix.node.ip }}"
-          TARGET="v${{ inputs.new_version }}"
+          TARGET="v${NEW_VERSION}"
 
           current_version() {
             talosctl version --nodes "$NODE_IP" --short 2>/dev/null \
@@ -954,7 +971,20 @@ jobs:
       (needs.upgrade-control-plane.result == 'success' || needs.upgrade-control-plane.result == 'skipped') &&
       inputs.test_templates == false &&
       inputs.test_controllers == false
-    timeout-minutes: 20
+    # Budget must exceed the worst-case retry path (see upgrade-control-plane).
+    # Workers add the settle gate and, on GPU nodes, doubled boot windows:
+    #   tool install retry   3 x 5m  = 15m
+    #   control-plane settle gate    =  5m
+    #   upgrade attempt 1            = 10m
+    #   settle poll (GPU)            = 10m
+    #   backoff                      = 0.5m
+    #   upgrade attempt 2            = 10m
+    #   settle poll (GPU)            = 10m
+    #   wait for Ready               =  5m
+    #   verify + GPU validation      = 10m
+    #   uncordon + summary           =  1m
+    #                           total ~ 77m
+    timeout-minutes: 85
     strategy:
       fail-fast: false
       # Simplified parallelism logic: aggressive=12, safe=1, default=4
@@ -1022,8 +1052,14 @@ jobs:
           exit 1
 
       - name: In-place upgrade using talosctl
+        # new_version is dispatch-controlled, so it is passed through env and
+        # read as "$NEW_VERSION" rather than expanded into the script body,
+        # where a crafted value could terminate the string and inject commands.
+        # (matrix.node.* comes from a hardcoded fromJSON literal in this file.)
+        env:
+          NEW_VERSION: ${{ inputs.new_version }}
         run: |
-          echo "::group::Upgrading ${{ matrix.node.name }} to v${{ inputs.new_version }}"
+          echo "::group::Upgrading ${{ matrix.node.name }} to v${NEW_VERSION}"
 
           # Select correct factory schematic based on node type.
           # Single source of truth: terraform/terraform.tfvars
@@ -1039,17 +1075,17 @@ jobs:
             fi
           done
           if [[ "${{ matrix.node.is_gpu }}" == "true" ]]; then
-            INSTALLER_IMAGE="factory.talos.dev/installer/${GPU_SCHEMATIC}:v${{ inputs.new_version }}"
+            INSTALLER_IMAGE="factory.talos.dev/installer/${GPU_SCHEMATIC}:v${NEW_VERSION}"
             echo "GPU node detected - using GPU factory image (qemu-guest-agent + NVIDIA + net.ifnames=0)"
           else
-            INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${{ inputs.new_version }}"
+            INSTALLER_IMAGE="factory.talos.dev/installer/${BASE_SCHEMATIC}:v${NEW_VERSION}"
             echo "Non-GPU node - using base factory image (qemu-guest-agent + net.ifnames=0)"
           fi
 
           echo "Installer image: $INSTALLER_IMAGE"
 
           NODE_IP="${{ matrix.node.ip }}"
-          TARGET="v${{ inputs.new_version }}"
+          TARGET="v${NEW_VERSION}"
 
           current_version() {
             talosctl version --nodes "$NODE_IP" --short 2>/dev/null \


### PR DESCRIPTION
## Summary

#1244 makes the health gates *correct*. This makes the rollout *resilient* — it removes the three ways a run could silently lose a node, all of which were observed in router run [`31506749848`](https://github.com/jlengelbrecht/prox-ops/actions/runs/31506749848) on 2026-08-11.

Deliberately kept separate from #1244: this touches `setup-cluster-tools`, a **shared composite action used by 3 workflows across 11 call sites** — including the failure-triage workflow. If it misbehaves it should be revertible without also reverting the gate fixes.

## 1. Tool install had no retry and no bound

Three worker jobs (`k8s-work-2`, `-3`, `-4`) died at **exactly** the 10-minute mark inside "Setup cluster tools" — all three at the same second, on all three runners. The aqua/mise registries return intermittent HTTP 400s (still reproducible today). One blip took the whole job, and those nodes were left un-upgraded with no other symptom.

The mise step is now `continue-on-error` and is followed by a step that is the real gate: it retries up to 3 times, bounds each attempt with `timeout 300`, verifies all 8 required binaries are on `PATH`, and fails the job only if one is genuinely absent afterwards.

`continue-on-error` masks nothing — the retry step has none of its own and `exit 1`s for real. Tool versions stay pinned via the same aqua refs, so a retry cannot resolve a different version.

## 2. Upgrades had no retry, and a normal reboot looked like a failure

`talosctl upgrade` exits non-zero when the API connection drops during the reboot — which is normal and documented in `CLAUDE.md`. A node that upgraded perfectly could be reported as failed.

Each node now gets **two attempts**, and after a non-zero exit the node's **actual version** is polled before drawing any conclusion:

| Scenario | Before | After |
|---|---|---|
| Clean upgrade | pass | pass |
| Exit 1, node **is** on target (dropped connection) | **fails the job** | passes |
| Transient failure (image pull, API blip) | **node stranded** | retried, succeeds |
| Genuine failure | fails | fails after 2 attempts |

GPU nodes get a **10 minute** settle window instead of 5 — NVIDIA driver load roughly doubles boot time, and a slow-but-healthy boot must not trigger a second upgrade while the node is still rebooting. The expression renders empty for the control-plane matrix, which correctly selects 5m.

Control-plane nodes keep `max-parallel: 1`, so retrying one node never puts etcd quorum at risk (2 of 3 remain up regardless).

## 3. Workers started 2 seconds after the control plane rebooted

In the 2026-08-11 run, `k8s-ctrl-3` finished at `15:34:08` and the first worker jobs started at `15:34:10`. Draining workers while etcd is still settling after a rolling control-plane reboot invites exactly the failure that followed.

Workers now wait for **three consecutive** healthy `/readyz` probes (max 5 min) before draining anything — three in a row, so one lucky response mid-election doesn't read as stable.

## Testing

- [x] Both files parse (`yaml.safe_load`)
- [x] Retry logic verified offline under `bash -eo pipefail` for all four paths: clean, connection-dropped, transient-failure-then-success, genuine-failure
- [x] Tool-check loop verified to run all 3 attempts then **fail closed**, listing the missing binary
- [x] Settle gate confirmed present on the **worker job only**, not control-plane
- [x] GPU window selection verified for both `is_gpu=true` (10m) and the empty control-plane render (5m)
- [x] security-guardian review passed, explicitly on secret exposure

## Security

Reviewed specifically for secret exposure. The new retry step runs **before** the kubeconfig/talosconfig step ever writes `$HOME/.talos/config`, never references `inputs.talosconfig`, and adds no `set -x`, no env dump, and no printing of config contents. `$GITHUB_PATH` only receives a deterministic path derived from `$HOME`/`$MISE_DATA_DIR`. `steps.mise-install.outcome` interpolates a GitHub-controlled enum, not user data.

## Not verified pre-merge

None of this executes until the next Talos version bump — the logic was verified offline and against the live cluster, but the workflow itself only runs on a version change. The first real exercise will be the next upgrade.

## Note — the biggest autonomy gap is not in this PR

`Upgrade Failure Triage (Claude)` already exists and **already fired after all three failed upgrades** (2026-06-13, 2026-06-28, 2026-08-11), producing a verdict each time. Its publish step is named *"job summary always; Discord if configured"* — and `DISCORD_WEBHOOK_URL` is not set, so every verdict went only to the Actions job summary. That is why three failures went unnoticed for seven weeks. Setting that one secret needs no code change and is the highest-value remaining fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Improved cluster tool setup by automatically retrying temporary installation failures and confirming required tools are available.
  - Added more resilient control-plane and worker node upgrades with automatic retries and version verification.
  - Worker upgrades now wait for the Kubernetes API to remain healthy before proceeding.
  - Upgrade operations fail with clearer safeguards when nodes or the API server do not stabilize within the allotted time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->