### PR TITLE
fix(ci): install the triage CLI per-run so it cannot inherit runner state

### DIFF
--- a/.github/workflows/upgrade-failure-triage.yaml
+++ b/.github/workflows/upgrade-failure-triage.yaml
@@ -95,9 +95,42 @@ jobs:
           # Pin the CLI version (supply-chain: avoid running an unvetted latest publish
           # with the OAuth token + cluster-adjacent runner in scope). Bump deliberately.
           CLAUDE_CLI_VERSION="2.1.162"
-          npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}" >/dev/null 2>&1 \
-            || npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
-          echo "claude version: $(claude --version 2>/dev/null || echo unknown)"
+
+          # Install into a PER-RUN prefix, not the global npm prefix.
+          #
+          # This runner is self-hosted, so /opt/hostedtoolcache persists between
+          # runs. A half-written copy of the package there made every
+          # `npm install -g` fail with:
+          #   ENOTEMPTY: directory not empty, rename
+          #   .../node_modules/@anthropic-ai/claude-code -> .../.claude-code-XXXX
+          # and left bin/claude as a stale symlink. Every triage run since
+          # 2026-06-04 therefore exited 126 (Permission denied) and produced no
+          # verdict -- while the job still reported success. The `|| npm install`
+          # fallback re-ran the identical failing command, so it never recovered.
+          #
+          # A fresh prefix under $RUNNER_TEMP cannot inherit that state.
+          CLAUDE_HOME="${RUNNER_TEMP:-/tmp}/claude-cli-$$"
+          rm -rf "$CLAUDE_HOME"
+          mkdir -p "$CLAUDE_HOME"
+          npm install --prefix "$CLAUDE_HOME" --no-fund --no-audit \
+            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}" >/dev/null 2>&1 \
+            || npm install --prefix "$CLAUDE_HOME" --no-fund --no-audit \
+                 "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+
+          CLAUDE_BIN="$CLAUDE_HOME/node_modules/.bin/claude"
+          TRIAGE_BROKEN=0
+          if [ ! -x "$CLAUDE_BIN" ]; then
+            echo "::error::Claude CLI did not install as an executable at $CLAUDE_BIN"
+            ls -l "$CLAUDE_HOME/node_modules/.bin" 2>/dev/null || true
+            TRIAGE_BROKEN=1
+          else
+            CLI_VERSION="$("$CLAUDE_BIN" --version 2>/dev/null || echo unknown)"
+            echo "claude version: $CLI_VERSION"
+            if [ "$CLI_VERSION" = "unknown" ]; then
+              echo "::error::Claude CLI installed but is not runnable"
+              TRIAGE_BROKEN=1
+            fi
+          fi
           # Strip any stray whitespace/newline the GitHub secret may carry; otherwise the
           # token becomes an invalid HTTP header value ("Header has invalid value") and auth
           # is rejected at the handshake. The OAuth token contains no internal whitespace.
@@ -128,8 +161,14 @@ jobs:
           CLASSIFICATION in bold. Use generic node names (ctrl-1, work-4) — no IP addresses or secrets.
           EOF
           )
-          claude -p "$PROMPT" --allowedTools "Read" --output-format json > claude-out.json 2> claude-err.txt
-          rc=$?
+          if [ "$TRIAGE_BROKEN" = "1" ]; then
+            rc=127
+            : > claude-out.json
+            echo "Claude CLI unavailable - skipping invocation" > claude-err.txt
+          else
+            "$CLAUDE_BIN" -p "$PROMPT" --allowedTools "Read" --output-format json > claude-out.json 2> claude-err.txt
+            rc=$?
+          fi
           echo "claude exit: $rc"
           # Extract the verdict markdown + usage from the JSON result
           jq -r '.result // empty' claude-out.json > triage-verdict.md 2>/dev/null
@@ -146,7 +185,19 @@ jobs:
           echo "----- token usage -----"
           echo "$USAGE" | sed 's/^/  /'
           { echo "### Claude token usage (claude exit ${rc})"; echo "$USAGE"; } >> "$GITHUB_STEP_SUMMARY"
-          exit 0   # triage is best-effort; never fail the workflow on a triage hiccup
+          rm -rf "$CLAUDE_HOME"
+
+          # Triage is best-effort and blocks nothing (no workflow depends on it,
+          # and it does not watch itself, so a red run cannot loop). But a GREEN
+          # job that produced no diagnosis is exactly how this stayed broken from
+          # 2026-06-04 to 2026-08-15: six runs, all "success", all empty. Fail
+          # loudly instead. The "Publish verdict" step is `if: always()`, so
+          # Discord still receives the diagnostic tail either way.
+          if [ "$TRIAGE_BROKEN" = "1" ] || [ ! -s claude-out.json ]; then
+            echo "::error::Triage produced no verdict (claude exit ${rc}) - the notification will contain only a diagnostic tail"
+            exit 1
+          fi
+          exit 0
 
       - name: Publish verdict (job summary always; Discord if configured)
         if: always()

--- a/.github/workflows/upgrade-failure-triage.yaml
+++ b/.github/workflows/upgrade-failure-triage.yaml
@@ -172,7 +172,14 @@ jobs:
           echo "claude exit: $rc"
           # Extract the verdict markdown + usage from the JSON result
           jq -r '.result // empty' claude-out.json > triage-verdict.md 2>/dev/null
+          # Track whether a REAL verdict was extracted. Testing claude-out.json for
+          # emptiness is not enough: an error response is valid non-empty JSON with
+          # no `.result`, which would fall through to the diagnostic fallback below
+          # and still report success -- the same green-but-empty outcome this whole
+          # change exists to eliminate.
+          VERDICT_OK=1
           if [ ! -s triage-verdict.md ]; then
+            VERDICT_OK=0
             { echo "_Claude produced no verdict (exit ${rc}). Diagnostic tail:_"; echo '```'; tail -20 claude-err.txt 2>/dev/null; echo '```'; } > triage-verdict.md
           fi
           USAGE="$(jq -r '"- input_tokens: \(.usage.input_tokens // "?")\n- output_tokens: \(.usage.output_tokens // "?")\n- cache_read_tokens: \(.usage.cache_read_input_tokens // 0)\n- cache_creation_tokens: \(.usage.cache_creation_input_tokens // 0)\n- cost_usd: \(.total_cost_usd // "?")\n- turns: \(.num_turns // "?")\n- duration_ms: \(.duration_ms // "?")"' claude-out.json 2>/dev/null)"
@@ -193,7 +200,7 @@ jobs:
           # 2026-06-04 to 2026-08-15: six runs, all "success", all empty. Fail
           # loudly instead. The "Publish verdict" step is `if: always()`, so
           # Discord still receives the diagnostic tail either way.
-          if [ "$TRIAGE_BROKEN" = "1" ] || [ ! -s claude-out.json ]; then
+          if [ "$TRIAGE_BROKEN" = "1" ] || [ "$VERDICT_OK" != "1" ]; then
             echo "::error::Triage produced no verdict (claude exit ${rc}) - the notification will contain only a diagnostic tail"
             exit 1
           fi


### PR DESCRIPTION
## Summary

**Upgrade failure triage has never produced a verdict.** All six runs since 2026-06-04 — including the three that followed the failed Talos upgrades — reported `success` while emitting nothing but a diagnostic tail.

This surfaced only because the Discord sink now works: the first delivered alert contained the failure instead of a diagnosis.

```
Claude produced no verdict (exit 126). Diagnostic tail:
/opt/hostedtoolcache/node/20.20.2/x64/bin/claude: Permission denied
```

| run | date | outcome |
|---|---|---|
| 31869381853 | 2026-08-15 | success — no verdict |
| 31531904646 | 2026-08-11 | success — no verdict |
| 28310929008 | 2026-06-28 | success — no verdict |
| 27453257523 | 2026-06-13 | success — no verdict |
| 26929078255 | 2026-06-04 | success — no verdict |
| 26928690619 | 2026-06-04 | success — no verdict |

## Root cause

The cattle-runner is **self-hosted**, so `/opt/hostedtoolcache` persists between runs — unlike a GitHub-hosted runner, where it is fresh every time. A half-written copy of the package there made every install fail:

```
npm error ENOTEMPTY: directory not empty, rename
  '.../node_modules/@anthropic-ai/claude-code' -> '.../.claude-code-ZYBB8kVU'
claude version: unknown
claude exit: 126
```

`bin/claude` was left as a stale symlink, so the CLI exited 126 and was never actually invoked. The existing `|| npm install -g ...` fallback re-ran the *identical* failing command against the same dirty directory, so it could never recover.

## Changes

**Install into a per-run prefix.** `npm install --prefix "$RUNNER_TEMP/claude-cli-$$"` instead of the global npm prefix, `rm -rf`'d before and after. A fresh directory cannot inherit corrupted state. Version stays pinned at `2.1.162`.

**Invoke by absolute path** (`$CLAUDE_HOME/node_modules/.bin/claude`) rather than relying on `PATH` — this also removes any chance of a stale `claude` earlier on `PATH` being run instead of the pinned package.

**Verify before use.** Check the binary is executable and that `--version` works; if not, skip the invocation and say so explicitly rather than producing a confusing 126.

**Stop reporting success when no diagnosis was produced.** The final `exit 0` is now `exit 1` when there is no verdict.

> A green job with an empty verdict is exactly how this stayed broken for ten weeks — the same failure mode as the health gate that never gated (#1244) and the PDBs that silently blocked every drain (#1245).

Safe to fail: triage blocks nothing, no workflow depends on it, and it does not watch itself (its `workflow_run` trigger lists only Cattle Upgrade / Pets Upgrade / Talos Version Router), so a red run cannot cascade or loop. The publish step is `if: always()`, so **the notification still goes out either way** — you simply also get a red run telling you the diagnostics are broken.

## Testing

- [x] YAML parses (`yaml.safe_load`)
- [x] All four step bodies pass `bash -n`
- [x] Confirmed no `npm install -g` remains in executable code (only in the explanatory comment)
- [x] Confirmed the publish step retains `if: always()`
- [x] Confirmed no workflow in the repo watches this one — no retrigger loop
- [x] security-guardian review passed: secrets untouched, version still pinned, `rm -rf` target cannot collapse to a dangerous path, and absolute-path invocation assessed as a hardening improvement

## Not verified pre-merge

The fix cannot be exercised until this is on `main` and triage runs again. After merge, re-run:

```bash
gh workflow run upgrade-failure-triage.yaml -f run_id=31506749848
```

Expected: `claude version:` shows `2.1.162` rather than `unknown`, and Discord receives an actual analysis of the 2026-08-11 failure instead of a permission error.

## Note

`npm install` here still runs without `--ignore-scripts`, so the pinned package's install scripts execute with the runner's permissions. That is pre-existing behaviour, unchanged by this PR, and worth a separate decision rather than bundling it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade-failure triage reliability by validating the diagnostic tool before use.
  * Triage now reports failures when the tool is unavailable or produces no output.
  * Preserved verdict publication even when triage encounters an error.
  * Added cleanup of temporary installation files after each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->