### PR TITLE
fix(ci): wait for a positive GPU count, not the presence of the key

### DIFF
--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2976,11 +2976,12 @@ jobs:
             exit 1
           fi
 
-          # Verify GPU count. Time-slicing advertises multiple virtual GPUs per
-          # physical card (e.g. 3), so accept any positive count rather than
-          # requiring exactly 1.
-          GPU_COUNT=$(kubectl get nodes ${{ matrix.node }} -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
-          echo "Allocatable nvidia.com/gpu: ${GPU_COUNT:-0}"
+          # Reuse the count the loop already validated. Re-reading it here would
+          # reintroduce the race this fix removes: a transient empty or zero
+          # response would fail the job moments after a positive count was
+          # confirmed. Time-slicing advertises multiple virtual GPUs per physical
+          # card (e.g. 3), which the loop's `-ge 1` test accepts.
+          echo "Allocatable nvidia.com/gpu: ${GPU_COUNT}"
 
           if [[ -z "$GPU_COUNT" || "$GPU_COUNT" -lt 1 ]]; then
             echo "::error::GPU advertised but allocatable count is not positive ($GPU_COUNT)"

--- a/.github/workflows/upgrade-cattle.yaml
+++ b/.github/workflows/upgrade-cattle.yaml
@@ -2941,8 +2941,15 @@ jobs:
           MAX_RETRIES=42  # 42 * 10s = 7 minutes (GPU nodes boot ~5 min)
 
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
-            if kubectl get nodes ${{ matrix.node }} -o jsonpath='{.status.allocatable}' | grep -q "nvidia.com/gpu"; then
-              echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s"
+            # Wait for a POSITIVE COUNT, not merely the presence of the key --
+            # after a reboot the node still carries `nvidia.com/gpu: "0"` until
+            # the device plugin re-registers, so matching the key alone exits
+            # this loop at 0s and downstream checks then fail on the zero.
+            # See the same fix in upgrade-pets.yaml.
+            GPU_COUNT=$(kubectl get nodes ${{ matrix.node }} \
+              -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true)
+            if [[ -n "$GPU_COUNT" && "$GPU_COUNT" =~ ^[0-9]+$ && "$GPU_COUNT" -ge 1 ]]; then
+              echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s (${GPU_COUNT} allocatable)"
               break
             fi
 

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -1290,8 +1290,22 @@ jobs:
 
           GPU_DETECTED=false
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
-            if kubectl get nodes ${{ matrix.node.name }} -o jsonpath='{.status.allocatable}' | grep -q "nvidia.com/gpu"; then
-              echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s"
+            # Wait for a POSITIVE COUNT, not merely the presence of the key.
+            # Straight after a reboot the node still carries
+            # `nvidia.com/gpu: "0"` in allocatable because the device plugin has
+            # not re-registered yet. Grepping the raw allocatable blob for the
+            # key therefore matched immediately, broke out of this loop at 0s,
+            # and the count check below then hard-failed on that zero:
+            #   ✅ GPU detected by Kubernetes after 0s
+            #   Allocatable nvidia.com/gpu: 0
+            #   ::error::GPU advertised but allocatable count is not positive (0)
+            # So the wait never actually waited, and every GPU node upgrade
+            # reported failure even though the upgrade itself succeeded
+            # (k8s-work-10 on 2026-08-11, k8s-work-4 on 2026-06-28).
+            GPU_COUNT=$(kubectl get nodes ${{ matrix.node.name }} \
+              -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true)
+            if [[ -n "$GPU_COUNT" && "$GPU_COUNT" =~ ^[0-9]+$ && "$GPU_COUNT" -ge 1 ]]; then
+              echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s (${GPU_COUNT} allocatable)"
               GPU_DETECTED=true
               break
             fi

--- a/.github/workflows/upgrade-pets.yaml
+++ b/.github/workflows/upgrade-pets.yaml
@@ -1315,14 +1315,12 @@ jobs:
           done
 
           if [[ "$GPU_DETECTED" == "true" ]]; then
-            # Time-slicing advertises multiple virtual GPUs per physical card
-            # (e.g. 3), so accept any positive count rather than requiring exactly 1.
-            GPU_COUNT=$(kubectl get nodes ${{ matrix.node.name }} -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
-            echo "Allocatable nvidia.com/gpu: ${GPU_COUNT:-0}"
-            if [[ -z "$GPU_COUNT" || "$GPU_COUNT" -lt 1 ]]; then
-              echo "::error::GPU advertised but allocatable count is not positive ($GPU_COUNT)"
-              exit 1
-            fi
+            # Reuse the count the loop already validated. Re-reading it here
+            # would reintroduce the race this fix removes: a transient empty or
+            # zero response would fail the job moments after a positive count
+            # was confirmed. Time-slicing advertises multiple virtual GPUs per
+            # physical card (e.g. 3), which the loop's `-ge 1` test accepts.
+            echo "Allocatable nvidia.com/gpu: ${GPU_COUNT}"
             echo "✅ GPU validation passed (${GPU_COUNT} schedulable GPU(s))"
             echo "::endgroup::"
             exit 0


### PR DESCRIPTION
## Summary

**Every GPU node upgrade has reported failure even when the upgrade succeeded.** This was found while verifying that the next Talos bump would run cleanly — it would not have.

```
✅ GPU detected by Kubernetes after 0s
Allocatable nvidia.com/gpu: 0
##[error]GPU advertised but allocatable count is not positive (0)
```

## Root cause

The wait loop tested for the **presence of the key** `nvidia.com/gpu` in `.status.allocatable` using `grep -q`:

```bash
if kubectl get nodes "$NODE" -o jsonpath='{.status.allocatable}' | grep -q "nvidia.com/gpu"; then
  echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s"
  GPU_DETECTED=true
  break
fi
```

Straight after a reboot that key is still present with value `0`, because the NVIDIA device plugin has not re-registered. So the loop matched on its **first iteration**, broke out claiming success at 0s, and the count check immediately below hard-failed on that same zero.

**The seven-minute wait never waited.** The comment above it — "GPU nodes take ~5 min to boot… allow up to 7 minutes" — described intent the code never implemented.

Confirmed against the real runs: `k8s-work-10` failed this way on 2026-08-11 (GPU validation step ran for **1 second**), and `k8s-work-4` the same way on 2026-06-28. Both nodes had upgraded correctly.

## Fix

Read the count directly and require a positive integer before breaking out. Applied to **both** `upgrade-pets.yaml` and `upgrade-cattle.yaml`, which shared the identical pattern:

```bash
GPU_COUNT=$(kubectl get nodes "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true)
if [[ -n "$GPU_COUNT" && "$GPU_COUNT" =~ ^[0-9]+$ && "$GPU_COUNT" -ge 1 ]]; then
  echo "✅ GPU detected by Kubernetes after $((RETRY_COUNT * 10))s (${GPU_COUNT} allocatable)"
  GPU_DETECTED=true
  break
fi
```

The `MAX_RETRIES=42` bound is unchanged, so a node whose GPU genuinely never returns still fails after seven minutes — the loop now just actually uses that budget.

## Why this matters now

Failures reach Discord as of #1248. Without this, the next Talos bump would upgrade both GPU nodes correctly and then **page you twice for false alarms** — the fastest way to teach yourself to ignore the new alerting.

## Testing

| `GPU_COUNT` | before | after |
|---|---|---|
| `3` | break, pass | break, pass |
| `0` (post-reboot) | **break, then hard-fail** | **keep waiting** |
| `""` (node unreachable) | keep waiting | keep waiting |
| `unknown` (non-numeric) | keep waiting | keep waiting |

- [x] Both files parse (`yaml.safe_load`)
- [x] The key-presence pattern no longer appears in **any** workflow (0 occurrences repo-wide)
- [x] Live check: `k8s-work-4` and `k8s-work-10` both report `3` allocatable and pass the new condition
- [x] security-guardian review passed — regex guard short-circuits before `-ge` so non-numeric input can't error under `-e`, `|| true` is inside the command substitution so a failing kubectl can't abort the step, and the retry bound is intact (no infinite-loop regression)

## Not verified pre-merge

The post-reboot path itself. The bug only manifests in the window where the device plugin has not yet re-registered, which requires an actual GPU node reboot. The logic is verified against every count value it can observe, but the real proof is the next upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU validation during upgrades by waiting for a positive, numeric GPU count.
  * Prevented validation from passing while GPU resources are still registering or remain at zero.
  * Success messages now include the detected GPU count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->