### PR TITLE
fix(ai): three 34.11 follow-up defects from live verification

### DIFF
--- a/kubernetes/apps/ai/agentgateway-pilot/app/local-model-policies.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/local-model-policies.yaml
@@ -136,6 +136,25 @@ spec:
 # every key on every section: a client (of any key) that declares a
 # model inconsistent with the rule/header it actually hit gets 403, not
 # a silently-substituted answer.
+# FOLLOW-UP (post-34.11 live verification, PM decision: alias not pin):
+# Claude Code's zero-config /v1/messages path sends its OWN configured
+# default in the body - "model":"claude-sonnet-5" - not "qwen36-27b".
+# That failed the mandatory body-consistency check above (403, matching
+# 34.11's own LEAD ITEM finding). Widening the two match expressions
+# below to accept either string does NOT weaken the property that
+# check exists to protect: which backend serves a request is still
+# fixed entirely by which section/targetRef this policy is attached to
+# (qwen36-27b-chat / qwen36-27b-messages, set at write-time, never
+# derived from the request), so accepting the alias only widens WHO is
+# authorized to use it, never WHERE the request can go. Keeping each
+# model's authz as its own hardcoded-literal section (not collapsed,
+# not derived from client input) is unchanged.
+#
+# MAINTENANCE NOTE: "claude-sonnet-5" is Claude Code's own default model
+# string, set by Anthropic and independent of this repo - it has already
+# changed across CLI releases and will again. Re-capture the live value
+# (see WI-034-11-LIVE-VERIFICATION.md's capture-server method) if the
+# zero-config path starts 403ing again after a Claude Code upgrade.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -156,7 +175,7 @@ spec:
       action: Allow
       policy:
         matchExpressions:
-          - (apiKey.models == 'any' || apiKey.models.split(',').exists(m, m == 'qwen36-27b')) && json(request.body).model == 'qwen36-27b'
+          - (apiKey.models == 'any' || apiKey.models.split(',').exists(m, m == 'qwen36-27b')) && json(request.body).model in ['qwen36-27b', 'claude-sonnet-5']
 ---
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy

--- a/kubernetes/apps/ai/agentgateway-pilot/app/policy.yaml
+++ b/kubernetes/apps/ai/agentgateway-pilot/app/policy.yaml
@@ -36,6 +36,35 @@ spec:
       secretRef:
         name: agentgateway-pilot-spike-key
 ---
+# FOLLOW-UP (post-34.11 live verification): /v1/models is how every real
+# consumer discovers models, but it inherited auth from the route-level
+# policy above, which only recognises the 34.2 throwaway spike key - both
+# production keys (34.10: agentgateway-claude-code, agentgateway-open-webui)
+# got 401 here even though they work fine on the actual chat/messages
+# routes. Section-scoped policy wins over the route-level default (same
+# precedence rule local-model-policies.yaml relies on), so this narrowly
+# swaps auth for JUST the models-stub section to secretSelector on the
+# label 34.10 already put on both production Secrets - no changes to
+# those Secrets, and the spike key keeps working everywhere else on this
+# route (route-level policy is untouched).
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agentgateway-pilot-models-stub-apikey
+  namespace: ai
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: agentgateway-pilot
+      sectionName: models-stub
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretSelector:
+        matchLabels:
+          agentgateway.dev/credential-set: agentgateway-pilot-local-models
+---
 # STORY-034-11: appended the 5 local chat-model aliases for LiteLLM
 # parity - the exact `model_name` strings from litellm/app/configmap.yaml,
 # which is also what local-model-policies.yaml's authorization CEL expects

--- a/kubernetes/apps/ai/kserve/app/dolphin-chat-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/dolphin-chat-inferenceservice.yaml
@@ -93,7 +93,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/hermes-jarvis-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/hermes-jarvis-inferenceservice.yaml
@@ -104,7 +104,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         env:
           - name: HF_TOKEN

--- a/kubernetes/apps/ai/kserve/app/qwen-coder-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-coder-inferenceservice.yaml
@@ -103,7 +103,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/qwen-omni-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-omni-inferenceservice.yaml
@@ -99,7 +99,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:


### PR DESCRIPTION
## Summary

Three defects found during EPIC-034 Story 34.11's live verification (`.claude/.ai-docs/stories/EPIC-034-TRACKING.md` row 34.11). Two commits, kept separately revertible since the vLLM flag rename is a pre-existing KServe bug unrelated to the gateway work.

## Changes

**fix(kserve): rename vLLM --disable-log-requests to --no-enable-log-requests**
- Upstream vLLM renamed the flag; the old name crashloops `qwen-coder`, `hermes-jarvis`, `dolphin-chat`, and `qwen-omni` on startup (`unrecognized arguments: --disable-log-requests`)
- `qwen36-27b` unaffected (llama-server, not vLLM)
- `dolphin-chat` was inferred from identical image+args in the handoff; confirmed here by direct grep of the manifest, same as the two directly-confirmed models

**fix(agentgateway): accept Claude Code's model alias and both production keys**
- Claude Code's zero-config `/v1/messages` path sends its own default `"model":"claude-sonnet-5"`, which 403'd against the mandatory body-consistency check added in 34.11. Widened the qwen36-27b authz CEL (both `chat` and `messages` sections, one shared policy object) to accept the alias alongside `qwen36-27b`. Backend selection stays fixed by the policy's `targetRefs` (unchanged) — this only widens who is authorized, never where traffic goes; the per-section hardcoded-literal structure is untouched.
- `/v1/models` only authenticated the old 34.2 spike key, so both production keys (`agentgateway-claude-code`, `agentgateway-open-webui`) got 401 at the model-discovery endpoint. Added a section-scoped policy for `models-stub` reusing the production-key label already set by 34.10, without touching the route-level default any other section relies on.

## Testing

Manifests validated with `kubectl kustomize` against both affected app directories (no dry-run apply — GitOps, no direct cluster mutation). security-guardian review completed pre-commit: APPROVED, no fixes required.

Live verification (cold-start times per model, Claude Code alias end-to-end, `/v1/models` with both production keys, `ai/kserve` Kustomization reaching Ready) is pending post-merge, since Flux only reconciles these manifests after merge — will report results once run.

## Notes

Relates to `.claude/.ai-docs/stories/EPIC-034-TRACKING.md` row 34.11 (LIVE-VERIFIED 2026-08-16 findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `claude-sonnet-5` model alias in local model authorization and routing.
  - Added strict API-key authentication for the models stub route.

- **Bug Fixes**
  - Updated model serving configuration to reliably disable request logging across supported AI services.

- **Documentation**
  - Documented the `claude-sonnet-5` body-model alias and related authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->