### PR TITLE
fix(network): scrape the agentgateway data plane on its metrics port

### DIFF
--- a/kubernetes/apps/network/agentgateway-config/app/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./gateway.yaml
   - ./parameters.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/network/agentgateway-config/app/podmonitor.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/podmonitor.yaml
@@ -1,0 +1,30 @@
+---
+# STORY-034-20a: the agentgateway deployer's per-Gateway Service
+# ("ai-gateway", ns network) only publishes the Gateway's own listener
+# ports (http/https) - it does not publish the proxy container's
+# declared `metrics` port (15020, verified live via
+# `kubectl get deploy -n network -l gateway.networking.k8s.io/gateway-name=ai-gateway
+# -o jsonpath='{.items[0].spec.template.spec.containers[0].ports}'`). The
+# chart's own `agentgateway-proxy` ServiceMonitor scrapes that Service by
+# `gateway.networking.k8s.io/gateway-class-name`, so it has scraped zero
+# targets since day one (PM measurement 2026-08-10). That ServiceMonitor
+# is disabled in ../../agentgateway-operator/app/helmrelease.yaml
+# (postRenderers patch) so it stops showing as dead target config.
+#
+# This PodMonitor bypasses the Service entirely and scrapes the pod port
+# directly. Selector is pinned to `gateway-name: ai-gateway` (not just
+# `gateway-class-name: agentgateway`) so a second agentgateway Gateway in
+# ns network would not silently get pulled into this target set.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ai-gateway-proxy
+  namespace: network
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: ai-gateway
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s

--- a/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway-operator/app/helmrelease.yaml
@@ -39,3 +39,30 @@ spec:
     # no extra release-label matching is needed here.
     monitoring:
       enabled: true
+  # STORY-034-20a: the chart's `agentgateway-proxy` ServiceMonitor
+  # (templates/monitoring.yaml) selects Services by
+  # `gateway.networking.k8s.io/gateway-class-name: agentgateway`, but the
+  # deployer's per-Gateway Service only publishes the Gateway's own
+  # listener ports, never a `metrics` port - so it has scraped zero
+  # targets since day one (PM measurement 2026-08-10, live-verified).
+  # `monitoring.serviceMonitor.enabled` is the only chart toggle and it
+  # would also remove the *working* control-plane ServiceMonitor
+  # (`agentgateway`, which scrapes this chart's own Service - that one
+  # does publish a `metrics` port, see templates/service.yaml), so a
+  # values toggle can't disable just the broken one. A postRenderer patch
+  # removes only the dead ServiceMonitor; ../../agentgateway-config/app/
+  # podmonitor.yaml is the real fix that scrapes the proxy pods directly.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+              name: "^agentgateway-proxy$"
+              namespace: network
+            patch: |
+              apiVersion: monitoring.coreos.com/v1
+              kind: ServiceMonitor
+              metadata:
+                name: agentgateway-proxy
+                namespace: network
+              $patch: delete


### PR DESCRIPTION
## Summary
The AI gateway's data-plane metrics have been emitted and silently discarded since the gateway was installed. The chart ships an `agentgateway-proxy` ServiceMonitor that selects the operator-generated `ai-gateway` Service and scrapes a port named `metrics` — but that Service only publishes `listener-80`/`listener-443`, so Prometheus never creates a target. All traffic, duration, and per-model token-usage series (70 metric families on the pods' declared `metrics` port 15020) go nowhere, and the chart's shipped Grafana dashboard stays empty.

## Changes
- Add a PodMonitor in the `network` namespace that scrapes the proxy pods' container port 15020 directly, selecting on `gateway.networking.k8s.io/gateway-name: ai-gateway` (narrower than the class-name label, matching the existing network-policy precedent in the MCP federation config).
- Remove only the dead `agentgateway-proxy` ServiceMonitor with a `postRenderers` kustomize `$patch: delete` on the operator HelmRelease. The chart's single `monitoring.serviceMonitor.enabled` toggle would also disable the working control-plane ServiceMonitor, so a values change is the wrong tool here.

## Testing
- flux-local test (v8.0.1 container): 173 passed, 0 failed, including both touched kustomizations.
- kubeconform with CRD schemas: agentgateway-config 3/3 valid, agentgateway-operator 4/4 valid.
- Verified against the live cluster (read-only) that the proxy pods declare `metrics: 15020`, the Service has no such port, and `podMonitorSelectorNilUsesHelmValues: false` already lets Prometheus discover PodMonitors cluster-wide.
- Drift detection operates on the post-render manifest, so the delete patch does not create a drift-restore loop.

## Notes
Known limit, out of scope here: the Anthropic-Messages translation path does not emit `gen_ai_client_token_usage`, so token accounting for that path stays gapped until the translation-path workaround lands. This change restores everything the proxy already emits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jlengelbrecht/prox-ops/pull/1251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for AI gateway proxy pods, collecting metrics directly every 15 seconds.
  * Limited monitoring to pods associated with the AI gateway.

* **Configuration**
  * Updated monitoring configuration to use pod-level collection for proxy metrics while retaining control-plane monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->