### PR TITLE
fix(ai): rename vLLM flag in non-chat InferenceService configs

### DIFF
--- a/kubernetes/apps/ai/kserve/app/flux-klein-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/flux-klein-inferenceservice.yaml
@@ -84,7 +84,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/qwen-tts-base-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-tts-base-inferenceservice.yaml
@@ -100,7 +100,7 @@ spec:
               --host=0.0.0.0 \
               --port=8080 \
               --disable-log-stats \
-              --disable-log-requests
+              --no-enable-log-requests
 
         # No args needed - all in command above
         args: []

--- a/kubernetes/apps/ai/kserve/app/qwen-tts-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-tts-inferenceservice.yaml
@@ -96,7 +96,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/stable-audio-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/stable-audio-inferenceservice.yaml
@@ -84,7 +84,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/wan-video-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/wan-video-inferenceservice.yaml
@@ -89,7 +89,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:


### PR DESCRIPTION
## Summary
Follow-up to PR #1250's flag rename for the remaining model configurations. This renames `--disable-log-requests` to `--no-enable-log-requests` in five dormant non-chat InferenceServices to prevent crashloops on cold start.

## Changes
- qwen-tts
- qwen-tts-base
- wan-video
- flux-klein
- stable-audio

These services use the same vLLM image (v0.22.0) where the flag was removed, causing the four chat models to crashloop in PR #1250's verification. This aligns the remaining models to the same fix.

## Testing
- Zero occurrences of removed flag remain under kubernetes/apps/ai/kserve/app/
- Kustomize builds successfully
- No other changes to the manifests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jlengelbrecht/prox-ops/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->