### PR TITLE
fix(kserve): rename vLLM --disable-log-requests in the non-chat models

### DIFF
--- a/kubernetes/apps/ai/kserve/app/flux-klein-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/flux-klein-inferenceservice.yaml
@@ -84,7 +84,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/qwen-tts-base-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-tts-base-inferenceservice.yaml
@@ -100,7 +100,7 @@ spec:
               --host=0.0.0.0 \
               --port=8080 \
               --disable-log-stats \
-              --disable-log-requests
+              --no-enable-log-requests
 
         # No args needed - all in command above
         args: []

--- a/kubernetes/apps/ai/kserve/app/qwen-tts-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/qwen-tts-inferenceservice.yaml
@@ -96,7 +96,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/stable-audio-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/stable-audio-inferenceservice.yaml
@@ -84,7 +84,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:

--- a/kubernetes/apps/ai/kserve/app/wan-video-inferenceservice.yaml
+++ b/kubernetes/apps/ai/kserve/app/wan-video-inferenceservice.yaml
@@ -89,7 +89,7 @@ spec:
 
           # Disable telemetry
           - --disable-log-stats
-          - --disable-log-requests
+          - --no-enable-log-requests
 
         # Environment variables
         env:


### PR DESCRIPTION
## Summary
Completes the flag rename from #1250 for the remaining five model configurations. `flux-klein`, `qwen-tts`, `qwen-tts-base`, `stable-audio`, and `wan-video` run the same `vllm-omni:v0.22.0` image as `qwen-omni`, whose crashloop on `--disable-log-requests` (removed upstream in vLLM v0.22.x) was confirmed directly. Left as they were, all five would hit the identical unrecognized-argument startup failure on their next cold start. This was flagged during #1250 review and deliberately split out to keep that fix's scope tight.

## Changes
- One-line rename per file, `--disable-log-requests` → `--no-enable-log-requests`, in the five InferenceService manifests. Four are argument list items; `qwen-tts-base` carries the flag inside its multiline command string, formatting preserved.
- `--no-enable-log-requests` is the direct argparse BooleanOptionalAction equivalent: request logging stays disabled, same behavior as intended before.

## Testing
- `grep -rn -- "--disable-log-requests" kubernetes/apps/ai/kserve/app/` returns nothing.
- kubeconform with CRD schemas: 55 resources valid, 0 invalid.
- flux-local test (v8.0.1 container): 173 passed, 0 failed.

## Notes
These models are scale-to-zero with no routes pointing at them yet, so there is no live impact until they are next woken. The equivalent rename on the four chat models was validated end-to-end after #1250 merged: each new revision cold-started to Ready.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jlengelbrecht/prox-ops/pull/1253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->