### PR TITLE
fix(kserve): stop health-gating InferenceServices until the KServe upgrade

### DIFF
--- a/kubernetes/apps/ai/kserve/ks.yaml
+++ b/kubernetes/apps/ai/kserve/ks.yaml
@@ -30,3 +30,15 @@ spec:
       kind: Service
       name: kserve-webhook-server-service
       namespace: kserve
+  # STORY-034-M10: KServe v0.13.1's InferenceService status.observedGeneration
+  # mirrors the Knative revision counter instead of the ISVC's own spec
+  # generation, so kstatus's default generation-comparison health check never
+  # converges even though the ISVC is actually Ready (e.g. gen=18/obsGen=16,
+  # or gen=8/obsGen=10 where obsGen exceeds gen). Key InferenceService health
+  # on the Ready condition instead. Revert this once 34.M5 upgrades KServe
+  # past the obsGen bug.
+  healthCheckExprs:
+    - apiVersion: serving.kserve.io/v1beta1
+      kind: InferenceService
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')

--- a/kubernetes/apps/ai/kserve/ks.yaml
+++ b/kubernetes/apps/ai/kserve/ks.yaml
@@ -16,7 +16,16 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
+  # STORY-034-M10: InferenceService health is NOT gated here. KServe v0.13.1
+  # writes ISVC status.observedGeneration from the Knative revision counter,
+  # not the ISVC's own metadata.generation, so the two never match and kstatus
+  # reads InProgress forever. Flux's healthCheckExprs cannot work around this:
+  # kustomize-controller's CEL evaluator (fluxcd/pkg/runtime, RFC 0009) checks
+  # observedGeneration != generation and returns InProgress BEFORE evaluating
+  # any user expression. Until the KServe upgrade fixes observedGeneration,
+  # wait stays false and only the explicit healthChecks below gate the
+  # release; revert to wait: true once the upgrade lands.
+  wait: false
   timeout: 10m
   healthChecks:
     # Wait for KServe controller manager to be ready
@@ -30,24 +39,3 @@ spec:
       kind: Service
       name: kserve-webhook-server-service
       namespace: kserve
-  # STORY-034-M10: KServe v0.13.1's InferenceService status.observedGeneration
-  # mirrors the Knative revision counter instead of the ISVC's own spec
-  # generation, so kstatus's default generation-comparison health check never
-  # converges even though the ISVC is actually Ready (e.g. gen=18/obsGen=16,
-  # or gen=8/obsGen=10 where obsGen exceeds gen). Key InferenceService health
-  # on the Ready condition instead. Revert this once 34.M5 upgrades KServe
-  # past the obsGen bug.
-  # No `failed` expression (it is optional per the Flux docs): Ready=False is
-  # routinely transient during rollouts (RevisionMissing, image pulls), and a
-  # failed hit would hard-fail the Kustomization immediately. Without it, a
-  # not-yet-Ready ISVC stays in-progress until the 10m timeout — the same
-  # failure semantics as the default kstatus check.
-  # has() guard: an ISVC whose status has no conditions (or no Ready entry
-  # yet) evaluates false (in-progress), not vacuously true. A brand-new ISVC
-  # with no status at all makes the expression error, which Flux treats as
-  # still-in-progress until timeout; CEL's has() cannot guard top-level
-  # fields like status, so this is the tightest guard available.
-  healthCheckExprs:
-    - apiVersion: serving.kserve.io/v1beta1
-      kind: InferenceService
-      current: has(status.conditions) && status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')

--- a/kubernetes/apps/ai/kserve/ks.yaml
+++ b/kubernetes/apps/ai/kserve/ks.yaml
@@ -37,11 +37,17 @@ spec:
   # or gen=8/obsGen=10 where obsGen exceeds gen). Key InferenceService health
   # on the Ready condition instead. Revert this once 34.M5 upgrades KServe
   # past the obsGen bug.
-  # has()/exists() guard: a fresh ISVC with no status.conditions (or no Ready
-  # entry yet) must evaluate false for both exprs (in-progress), not vacuously
-  # true as filter().all() would on an empty list.
+  # No `failed` expression (it is optional per the Flux docs): Ready=False is
+  # routinely transient during rollouts (RevisionMissing, image pulls), and a
+  # failed hit would hard-fail the Kustomization immediately. Without it, a
+  # not-yet-Ready ISVC stays in-progress until the 10m timeout — the same
+  # failure semantics as the default kstatus check.
+  # has() guard: an ISVC whose status has no conditions (or no Ready entry
+  # yet) evaluates false (in-progress), not vacuously true. A brand-new ISVC
+  # with no status at all makes the expression error, which Flux treats as
+  # still-in-progress until timeout; CEL's has() cannot guard top-level
+  # fields like status, so this is the tightest guard available.
   healthCheckExprs:
     - apiVersion: serving.kserve.io/v1beta1
       kind: InferenceService
-      failed: has(status.conditions) && status.conditions.exists(e, e.type == 'Ready' && e.status == 'False')
       current: has(status.conditions) && status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')

--- a/kubernetes/apps/ai/kserve/ks.yaml
+++ b/kubernetes/apps/ai/kserve/ks.yaml
@@ -37,8 +37,11 @@ spec:
   # or gen=8/obsGen=10 where obsGen exceeds gen). Key InferenceService health
   # on the Ready condition instead. Revert this once 34.M5 upgrades KServe
   # past the obsGen bug.
+  # has()/exists() guard: a fresh ISVC with no status.conditions (or no Ready
+  # entry yet) must evaluate false for both exprs (in-progress), not vacuously
+  # true as filter().all() would on an empty list.
   healthCheckExprs:
     - apiVersion: serving.kserve.io/v1beta1
       kind: InferenceService
-      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
-      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+      failed: has(status.conditions) && status.conditions.exists(e, e.type == 'Ready' && e.status == 'False')
+      current: has(status.conditions) && status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')


### PR DESCRIPTION
## Summary

The kserve Flux Kustomization has been stuck unhealthy: with `wait: true`, Flux runs kstatus over every applied resource, including InferenceServices, and kstatus reports InProgress whenever `status.observedGeneration != metadata.generation`. KServe v0.13.1 writes InferenceService `status.observedGeneration` from the Knative revision counter rather than the ISVC's own spec generation, so on live objects the two never converge (currently gen=18/obsGen=16 on one ISVC and gen=8/obsGen=10 on another, where obsGen even exceeds gen). The Kustomization therefore times out forever on resources that are actually Ready.

Earlier commits on this branch tried to fix this with `healthCheckExprs` keyed on the Ready condition. That turned out to be a no-op on kustomize-controller v1.7.3: the CEL status evaluator in fluxcd/pkg/runtime v0.91.0 checks the observedGeneration/generation mismatch and returns InProgress before it evaluates any user expression ([runtime/cel/status_evaluator.go](https://github.com/fluxcd/pkg/blob/runtime/v0.91.0/runtime/cel/status_evaluator.go), per RFC 0009), so the custom expression never runs on exactly the objects it was written for. Those commits are kept in history for the reasoning trail; squash-merge collapses them.

## Changes

- `kubernetes/apps/ai/kserve/ks.yaml`: set `wait: false` so InferenceServices are no longer health-gated.
- Kept the explicit `healthChecks` on the kserve-controller-manager Deployment and the kserve-webhook-server-service Service — with `wait: false` these still gate the release on the controller actually coming up.
- Removed the `healthCheckExprs` block (dead config under the built-in generation pre-check).
- A comment in the file documents the root cause and the revert plan: once the KServe upgrade fixes observedGeneration, go back to `wait: true`.

## Testing

- flux-local test (`--enable-helm --all-namespaces`): 173 passed.
- Apply and prune behavior is unchanged; only the health-wait semantics move.