### PR TITLE
fix(network): publish the AI gateway hostname to the internal resolver

### DIFF
--- a/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
@@ -101,6 +101,20 @@ spec:
   # story is forbidden from reintroducing. `coredns.io/hostname` is
   # k8s-gateway-only and invisible to unifi-dns/external-dns.
   #
+  # MERGE SAFETY (PR #1255 review): this overlay cannot clobber the Gateway's
+  # `lbipam.cilium.io/ips` pin. At operator v1.3.1 the overlay runs AFTER helm
+  # renders the Service - which already carries infrastructure.annotations via
+  # `gatewayAnnotations` (controller/pkg/helm/agentgateway/templates/
+  # service.yaml) - and overlay metadata merges additively into the existing
+  # annotation map (`maps.Copy`, never a map replace:
+  # controller/pkg/deployer/strategicpatch/strategicpatch.go:150-157, invoked
+  # post-render by gateway_parameters.go PostProcessObjects). Putting the
+  # hostname in gateway.yaml's infrastructure.annotations instead was
+  # considered and rejected: the chart also smears those annotations onto the
+  # Deployment metadata AND pod template (templates/deployment.yaml), so a
+  # DNS-only edit would roll the proxy pods; this overlay touches only the
+  # Service.
+  #
   # SPIKE HOSTNAMES (AC3): only the pilot hostname (this story's actual
   # subject, STORY-034-2) is published here. `ai-gateway-auth.homelab0.org`
   # (34.3 auth-matrix spike), `ai-gateway-spike.homelab0.org` (34.4

--- a/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
+++ b/kubernetes/apps/network/agentgateway-config/app/parameters.yaml
@@ -13,6 +13,9 @@
 # the sqlite file (SQLITE_CANTOPEN, discovered live in Phase 2: the new
 # ReplicaSet pod crash-looped while the old one kept serving traffic
 # through the rolling update, so no consumer impact during the fix).
+# STORY-034-19b: restores LAN name resolution for the agentgateway front
+# door via `service.metadata.annotations` below. See that field for the
+# root-cause writeup and the reasoning behind the mechanism chosen.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayParameters
 metadata:
@@ -40,3 +43,76 @@ spec:
               volumeMounts:
                 - name: request-log
                   mountPath: /data/agentgateway
+
+  # ROOT CAUSE (STORY-034-19b AC1, confirmed by reading the k8s-gateway
+  # CoreDNS plugin source, chart 3.7.1 / app v1.7.0, and agentgateway
+  # v1.3.1's status_syncer.go, both at
+  # ../../k8s-gateway/app/helmrelease.yaml's pinned versions):
+  #
+  # k8s-gateway's HTTPRoute lookup (kubernetes.go:lookupGateways ->
+  # fetchGatewayIPs) resolves a hostname's IP ONLY from the parent
+  # Gateway's `status.addresses` - never from the HTTPRoute or any
+  # annotation. Our own HelmRelease sets no `filters.gatewayClasses`
+  # (../../k8s-gateway/app/helmrelease.yaml), which defaults to an empty
+  # list - k8s-gateway already watches Gateways/HTTPRoutes of EVERY
+  # GatewayClass, "agentgateway" included. So the PM's original hypothesis
+  # (a watch/class-scoping bug in the k8s-gateway chart) is RULED OUT:
+  # there is no restrictive filter to widen.
+  # grafana.homelab0.org resolves because its parent Gateway
+  # (gatewayClassName: envoy) is Envoy Gateway, a mature implementation
+  # that reliably publishes `status.addresses` from its managed Service.
+  # ai-gateway's parent Gateway (gatewayClassName: agentgateway) is
+  # reconciled by the agentgateway-operator (pinned v1.3.1) instead. That
+  # control plane does carry logic to mirror a generated Service's
+  # LoadBalancer address onto `Gateway.status.addresses`
+  # (status_syncer.go's mergeGatewayAddresses, "computed from the
+  # generated Service by the gateway reconciler") - but this repo has
+  # already hit two other Gateway/Service-parity gaps in this same
+  # operator (the 2026-08-01 Gateway-named-"agentgateway" Service
+  # collision documented in ../agentgateway-operator/app/helmrelease.yaml,
+  # and STORY-034-20a's finding that the generated proxy Service never
+  # gets a `metrics` port), so `status.addresses` landing reliably here is
+  # unproven, not just unlucky timing.
+  #
+  # FIX (AC2): rather than touch k8s-gateway's watch config (nothing to
+  # scope - see above) or resurrect blanket/scoped unifi-dns publication
+  # (would reopen 34.4 finding F2, forbidden by this story), this
+  # `service` overlay teaches k8s-gateway the same hostname through a
+  # SECOND, independent, already-enabled resource type: "Service" is
+  # already in k8s-gateway's `watchedResources`
+  # (../../k8s-gateway/app/helmrelease.yaml). k8s-gateway's Service
+  # lookup (kubernetes.go:lookupServiceIndex) reads
+  # `Service.status.loadBalancer.ingress` directly - populated by Cilium
+  # LBIPAM from this same Gateway's `lbipam.cilium.io/ips: "10.20.67.27"`
+  # infrastructure annotation (gateway.yaml), the exact mechanism already
+  # proven live (the VIP is reachable today, per this story's Problem
+  # statement - only the name doesn't resolve). This is a single
+  # consistent path: still k8s-gateway, still *.homelab0.org, no new DNS
+  # system, no live-cluster dependency on the agentgateway operator's own
+  # status reconciliation.
+  #
+  # `coredns.io/hostname` (not `external-dns.alpha.kubernetes.io/hostname`)
+  # is deliberate: unifi-dns runs `sources: [gateway-httproute, service]`
+  # (../unifi-dns/app/helmrelease.yaml) and its `--gateway-name=
+  # envoy-internal` scoping only narrows the gateway-httproute source, not
+  # the service source - an `external-dns.alpha...` annotation here would
+  # make unifi-dns's UNSCOPED service source publish a UDM record for this
+  # Service, which is exactly the blanket-publication regression (F2) this
+  # story is forbidden from reintroducing. `coredns.io/hostname` is
+  # k8s-gateway-only and invisible to unifi-dns/external-dns.
+  #
+  # SPIKE HOSTNAMES (AC3): only the pilot hostname (this story's actual
+  # subject, STORY-034-2) is published here. `ai-gateway-auth.homelab0.org`
+  # (34.3 auth-matrix spike), `ai-gateway-spike.homelab0.org` (34.4
+  # wake-gate spike) and `ai-gateway-mcp.homelab0.org` (34.6 MCP
+  # federation spike) are left dark on purpose: all three are temporary
+  # kill-gate/spike surfaces (their own HTTPRoute file headers say so),
+  # each already has a working LAN test path that doesn't need a DNS
+  # record (`curl --resolve` / `/etc/hosts`, per those files' comments),
+  # and publishing them would be new general LAN reachability for
+  # surfaces this epic hasn't decided to keep - scope creep beyond what
+  # this story asked for.
+  service:
+    metadata:
+      annotations:
+        coredns.io/hostname: ai-gateway.homelab0.org


### PR DESCRIPTION
## Summary
`ai-gateway.homelab0.org` no longer resolves on the LAN: #1215 correctly scoped unifi-dns to envoy-internal HTTPRoutes (fixing the authentik CNAME flap), which also removed the blanket UDM records that had incidentally covered the AI gateway's hostnames. k8s-gateway can't pick up the slack through its HTTPRoute path — reading its plugin source shows it resolves a hostname only from the parent Gateway's `status.addresses`, and the agentgateway operator's population of that field is unproven here (this repo has already hit two other Gateway/Service parity gaps in the same operator). The VIP itself (10.20.67.27) works — only the name is dark.

## Changes
- Add `coredns.io/hostname: ai-gateway.homelab0.org` to the operator-generated Service via the `AgentgatewayParameters` `service.metadata.annotations` overlay (field verified against the live CRD schema). k8s-gateway already watches Services and answers from `status.loadBalancer.ingress`, which Cilium LBIPAM populates from the Gateway's existing infrastructure annotation — one consistent LAN resolution path, no new DNS machinery.
- Deliberately NOT `external-dns.alpha.kubernetes.io/hostname`: unifi-dns's `service` source is unscoped (#1215 only narrowed its gateway-httproute source), so the external-dns annotation would recreate the blanket-publication problem. `coredns.io/hostname` is consumed only by the LAN-only k8s-gateway; cloudflare-dns has no service source at all.
- Spike hostnames (`ai-gateway-auth`, `ai-gateway-spike`, `ai-gateway-mcp`) stay unpublished on purpose — temporary surfaces with working `--resolve` test paths.

## Testing
- flux-local test (v8.0.1 container): 173 passed, 0 failed.
- kubeconform with CRD schemas: 3/3 valid.
- Live CRD schema check (read-only): `spec.service.metadata.annotations` exists on agentgatewayparameters.
- Post-merge check planned: the name resolves via the internal resolver (10.20.67.21), the answer is the existing VIP, and `authentik.homelab0.org` still returns exactly one answer (no regression of the #1215 fix).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jlengelbrecht/prox-ops/pull/1255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->